### PR TITLE
chore: add migrate step to local dev setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ pnpm install
 ```
 
 3. Copy `.env.example` to `.env` and configure your environment variables
-4. Start the development server
+4. Migrate database
+
+```bash
+pnpm db:migrate
+```
+
+5. Start the development server
 
 ```bash
 pnpm dev


### PR DESCRIPTION
I was following the steps and unfortunately I wasn't able to run by 100% following the README instructions. The db:migrate step was missing