### PR TITLE
fix: bypass custom URL checkout for self hosted

### DIFF
--- a/apps/web/public/__ENV.js
+++ b/apps/web/public/__ENV.js
@@ -1,8 +1,1 @@
-window.__ENV = {
-  NEXT_PUBLIC_UMAMI_ID: "aaed1f55-25e2-4223-b918-e429c390be35",
-  NEXT_PUBLIC_KAN_ENV: "cloud",
-  NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
-  NEXT_PUBLIC_AVATAR_BUCKET_NAME: "avatars",
-  NEXT_PUBLIC_STORAGE_DOMAIN: "storage.kanbn.com",
-  NEXT_PUBLIC_STORAGE_URL: "https://storage.kanbn.com",
-};
+window.__ENV = {"NEXT_PUBLIC_UMAMI_ID":"aaed1f55-25e2-4223-b918-e429c390be35","NEXT_PUBLIC_KAN_ENV":"cloud","NEXT_PUBLIC_BASE_URL":"http://localhost:3000","NEXT_PUBLIC_AVATAR_BUCKET_NAME":"avatars","NEXT_PUBLIC_STORAGE_DOMAIN":"storage.kanbn.com","NEXT_PUBLIC_STORAGE_URL":"https://storage.kanbn.com"};

--- a/apps/web/src/views/settings/components/UpdateWorkspaceUrlForm.tsx
+++ b/apps/web/src/views/settings/components/UpdateWorkspaceUrlForm.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { env } from "next-runtime-env";
 import { useForm } from "react-hook-form";
 import { HiCheck, HiMiniStar } from "react-icons/hi2";
 import { z } from "zod";
@@ -92,7 +93,9 @@ const UpdateWorkspaceUrlForm = ({
   const isWorkspaceSlugAvailable = checkWorkspaceSlugAvailability.data;
 
   const onSubmit = (data: FormValues) => {
-    if (isWorkspaceSlugAvailable?.isAvailable && workspacePlan !== "pro")
+    if (!isWorkspaceSlugAvailable?.isAvailable) return;
+
+    if (workspacePlan !== "pro" && env("NEXT_PUBLIC_KAN_ENV") === "cloud")
       return openModal("UPDATE_WORKSPACE_URL", data.slug);
 
     updateWorkspaceSlug.mutate({
@@ -118,7 +121,11 @@ const UpdateWorkspaceUrlForm = ({
               ? "This workspace username has already been taken"
               : undefined)
           }
-          prefix="kan.bn/"
+          prefix={
+            env("NEXT_PUBLIC_KAN_ENV") === "cloud"
+              ? "kan.bn/"
+              : `${env("NEXT_PUBLIC_BASE_URL")}/`
+          }
           iconRight={
             isWorkspaceSlugAvailable?.isAvailable ||
             (workspacePlan === "pro" && slug === workspaceUrl) ? (

--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import { env } from "next-runtime-env";
 import { z } from "zod";
 
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
@@ -225,9 +226,18 @@ export const workspaceRouter = createTRPCRouter({
           await workspaceRepo.isWorkspaceSlugAvailable(ctx.db, input.slug);
 
         if (
+          env("NEXT_PUBLIC_KAN_ENV") === "cloud" &&
+          workspace.plan !== "pro" &&
+          input.slug !== workspace.publicId
+        ) {
+          throw new TRPCError({
+            message: `Workspace slug cannot be changed in cloud without upgrading to a paid plan`,
+            code: "CONFLICT",
+          });
+        }
+
+        if (
           reservedOrPremiumWorkspaceSlug?.type === "reserved" ||
-          (workspace.plan !== "pro" &&
-            reservedOrPremiumWorkspaceSlug?.type === "premium") ||
           !isWorkspaceSlugAvailable
         ) {
           throw new TRPCError({

--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -232,7 +232,7 @@ export const workspaceRouter = createTRPCRouter({
         ) {
           throw new TRPCError({
             message: `Workspace slug cannot be changed in cloud without upgrading to a paid plan`,
-            code: "CONFLICT",
+            code: "FORBIDDEN",
           });
         }
 


### PR DESCRIPTION
## Summary
Self-hosted instances should be able to freely change their workspace slug without be prompted to checkout. These changes allow this by checking the `NEXT_PUBLIC_KAN_ENV !== 'cloud'`.

## Test plan
- Set `NEXT_PUBLIC_KAN_ENV` to `cloud` and check checkout is prompted
- Remove `NEXT_PUBLIC_KAN_ENV` and check workspace slug can be freely changed

Resolves #15