### PR TITLE
chore: patch migration order

### DIFF
--- a/packages/db/migrations/20250610200449_ReaddIntegrationTable.sql
+++ b/packages/db/migrations/20250610200449_ReaddIntegrationTable.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "integration" (
+	"provider" varchar(255) NOT NULL,
+	"userId" uuid NOT NULL,
+	"accessToken" varchar(255) NOT NULL,
+	"refreshToken" varchar(255),
+	"expiresAt" timestamp NOT NULL,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp,
+	CONSTRAINT "integration_pkey" PRIMARY KEY("userId","provider")
+);
+--> statement-breakpoint
+ALTER TABLE "integration" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "integration" ADD CONSTRAINT "integration_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/migrations/meta/20250608100932_snapshot.json
+++ b/packages/db/migrations/meta/20250608100932_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "d170c8e0-bf75-4c71-abd9-0ecbeeb14003",
-  "prevId": "1a07a776-0481-49f9-9098-02d530b37cf5",
+  "prevId": "058e8521-2814-46f0-a33f-1bbd86f450ce",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -93,12 +93,8 @@
           "name": "account_userId_user_id_fk",
           "tableFrom": "account",
           "tableTo": "user",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -246,12 +242,8 @@
           "name": "apiKey_userId_user_id_fk",
           "tableFrom": "apiKey",
           "tableTo": "user",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -321,12 +313,8 @@
           "name": "session_userId_user_id_fk",
           "tableFrom": "session",
           "tableTo": "user",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -336,9 +324,7 @@
         "session_token_unique": {
           "name": "session_token_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
+          "columns": ["token"]
         }
       },
       "policies": {},
@@ -524,12 +510,8 @@
           "name": "board_createdBy_user_id_fk",
           "tableFrom": "board",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -537,12 +519,8 @@
           "name": "board_deletedBy_user_id_fk",
           "tableFrom": "board",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -550,12 +528,8 @@
           "name": "board_importId_import_id_fk",
           "tableFrom": "board",
           "tableTo": "import",
-          "columnsFrom": [
-            "importId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["importId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -563,12 +537,8 @@
           "name": "board_workspaceId_workspace_id_fk",
           "tableFrom": "board",
           "tableTo": "workspace",
-          "columnsFrom": [
-            "workspaceId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspaceId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -578,9 +548,7 @@
         "board_publicId_unique": {
           "name": "board_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -714,12 +682,8 @@
           "name": "card_activity_cardId_card_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "card",
-          "columnsFrom": [
-            "cardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["cardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -727,12 +691,8 @@
           "name": "card_activity_fromListId_list_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "list",
-          "columnsFrom": [
-            "fromListId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["fromListId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -740,12 +700,8 @@
           "name": "card_activity_toListId_list_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "list",
-          "columnsFrom": [
-            "toListId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["toListId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -753,12 +709,8 @@
           "name": "card_activity_labelId_label_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "label",
-          "columnsFrom": [
-            "labelId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -766,12 +718,8 @@
           "name": "card_activity_workspaceMemberId_workspace_members_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "workspace_members",
-          "columnsFrom": [
-            "workspaceMemberId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspaceMemberId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -779,12 +727,8 @@
           "name": "card_activity_createdBy_user_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -792,12 +736,8 @@
           "name": "card_activity_commentId_card_comments_id_fk",
           "tableFrom": "card_activity",
           "tableTo": "card_comments",
-          "columnsFrom": [
-            "commentId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["commentId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -807,9 +747,7 @@
         "card_activity_publicId_unique": {
           "name": "card_activity_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -839,12 +777,8 @@
           "name": "_card_workspace_members_cardId_card_id_fk",
           "tableFrom": "_card_workspace_members",
           "tableTo": "card",
-          "columnsFrom": [
-            "cardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["cardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -852,12 +786,8 @@
           "name": "_card_workspace_members_workspaceMemberId_workspace_members_id_fk",
           "tableFrom": "_card_workspace_members",
           "tableTo": "workspace_members",
-          "columnsFrom": [
-            "workspaceMemberId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspaceMemberId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -865,10 +795,7 @@
       "compositePrimaryKeys": {
         "_card_workspace_members_cardId_workspaceMemberId_pk": {
           "name": "_card_workspace_members_cardId_workspaceMemberId_pk",
-          "columns": [
-            "cardId",
-            "workspaceMemberId"
-          ]
+          "columns": ["cardId", "workspaceMemberId"]
         }
       },
       "uniqueConstraints": {},
@@ -960,12 +887,8 @@
           "name": "card_createdBy_user_id_fk",
           "tableFrom": "card",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -973,12 +896,8 @@
           "name": "card_deletedBy_user_id_fk",
           "tableFrom": "card",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -986,12 +905,8 @@
           "name": "card_listId_list_id_fk",
           "tableFrom": "card",
           "tableTo": "list",
-          "columnsFrom": [
-            "listId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["listId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -999,12 +914,8 @@
           "name": "card_importId_import_id_fk",
           "tableFrom": "card",
           "tableTo": "import",
-          "columnsFrom": [
-            "importId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["importId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1014,9 +925,7 @@
         "card_publicId_unique": {
           "name": "card_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -1046,12 +955,8 @@
           "name": "_card_labels_cardId_card_id_fk",
           "tableFrom": "_card_labels",
           "tableTo": "card",
-          "columnsFrom": [
-            "cardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["cardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1059,12 +964,8 @@
           "name": "_card_labels_labelId_label_id_fk",
           "tableFrom": "_card_labels",
           "tableTo": "label",
-          "columnsFrom": [
-            "labelId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["labelId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1072,10 +973,7 @@
       "compositePrimaryKeys": {
         "_card_labels_cardId_labelId_pk": {
           "name": "_card_labels_cardId_labelId_pk",
-          "columns": [
-            "cardId",
-            "labelId"
-          ]
+          "columns": ["cardId", "labelId"]
         }
       },
       "uniqueConstraints": {},
@@ -1149,12 +1047,8 @@
           "name": "card_comments_cardId_card_id_fk",
           "tableFrom": "card_comments",
           "tableTo": "card",
-          "columnsFrom": [
-            "cardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["cardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1162,12 +1056,8 @@
           "name": "card_comments_createdBy_user_id_fk",
           "tableFrom": "card_comments",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1175,12 +1065,8 @@
           "name": "card_comments_deletedBy_user_id_fk",
           "tableFrom": "card_comments",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1190,9 +1076,7 @@
         "card_comments_publicId_unique": {
           "name": "card_comments_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -1254,12 +1138,8 @@
           "name": "feedback_createdBy_user_id_fk",
           "tableFrom": "feedback",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1320,12 +1200,8 @@
           "name": "import_createdBy_user_id_fk",
           "tableFrom": "import",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1335,9 +1211,7 @@
         "import_publicId_unique": {
           "name": "import_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -1422,12 +1296,8 @@
           "name": "label_createdBy_user_id_fk",
           "tableFrom": "label",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1435,12 +1305,8 @@
           "name": "label_boardId_board_id_fk",
           "tableFrom": "label",
           "tableTo": "board",
-          "columnsFrom": [
-            "boardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["boardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1448,12 +1314,8 @@
           "name": "label_importId_import_id_fk",
           "tableFrom": "label",
           "tableTo": "import",
-          "columnsFrom": [
-            "importId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["importId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1461,12 +1323,8 @@
           "name": "label_deletedBy_user_id_fk",
           "tableFrom": "label",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1476,9 +1334,7 @@
         "label_publicId_unique": {
           "name": "label_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -1563,12 +1419,8 @@
           "name": "list_createdBy_user_id_fk",
           "tableFrom": "list",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1576,12 +1428,8 @@
           "name": "list_deletedBy_user_id_fk",
           "tableFrom": "list",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1589,12 +1437,8 @@
           "name": "list_boardId_board_id_fk",
           "tableFrom": "list",
           "tableTo": "board",
-          "columnsFrom": [
-            "boardId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["boardId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1602,12 +1446,8 @@
           "name": "list_importId_import_id_fk",
           "tableFrom": "list",
           "tableTo": "import",
-          "columnsFrom": [
-            "importId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["importId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1617,9 +1457,7 @@
         "list_publicId_unique": {
           "name": "list_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -1689,9 +1527,7 @@
         "user_email_unique": {
           "name": "user_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -1751,12 +1587,8 @@
           "name": "integration_userId_user_id_fk",
           "tableFrom": "integration",
           "tableTo": "user",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1764,10 +1596,7 @@
       "compositePrimaryKeys": {
         "integration_pkey": {
           "name": "integration_pkey",
-          "columns": [
-            "userId",
-            "provider"
-          ]
+          "columns": ["userId", "provider"]
         }
       },
       "uniqueConstraints": {},
@@ -1800,9 +1629,7 @@
         "workspace_slugs_slug_unique": {
           "name": "workspace_slugs_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -1896,12 +1723,8 @@
           "name": "workspace_members_userId_user_id_fk",
           "tableFrom": "workspace_members",
           "tableTo": "user",
-          "columnsFrom": [
-            "userId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1909,12 +1732,8 @@
           "name": "workspace_members_workspaceId_workspace_id_fk",
           "tableFrom": "workspace_members",
           "tableTo": "workspace",
-          "columnsFrom": [
-            "workspaceId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["workspaceId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1922,12 +1741,8 @@
           "name": "workspace_members_deletedBy_user_id_fk",
           "tableFrom": "workspace_members",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1937,9 +1752,7 @@
         "workspace_members_publicId_unique": {
           "name": "workspace_members_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         }
       },
       "policies": {},
@@ -2026,12 +1839,8 @@
           "name": "workspace_createdBy_user_id_fk",
           "tableFrom": "workspace",
           "tableTo": "user",
-          "columnsFrom": [
-            "createdBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["createdBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -2039,12 +1848,8 @@
           "name": "workspace_deletedBy_user_id_fk",
           "tableFrom": "workspace",
           "tableTo": "user",
-          "columnsFrom": [
-            "deletedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["deletedBy"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2054,16 +1859,12 @@
         "workspace_publicId_unique": {
           "name": "workspace_publicId_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "publicId"
-          ]
+          "columns": ["publicId"]
         },
         "workspace_slug_unique": {
           "name": "workspace_slug_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
+          "columns": ["slug"]
         }
       },
       "policies": {},
@@ -2075,10 +1876,7 @@
     "public.board_visibility": {
       "name": "board_visibility",
       "schema": "public",
-      "values": [
-        "private",
-        "public"
-      ]
+      "values": ["private", "public"]
     },
     "public.card_activity_type": {
       "name": "card_activity_type",
@@ -2102,53 +1900,32 @@
     "public.source": {
       "name": "source",
       "schema": "public",
-      "values": [
-        "trello"
-      ]
+      "values": ["trello"]
     },
     "public.status": {
       "name": "status",
       "schema": "public",
-      "values": [
-        "started",
-        "success",
-        "failed"
-      ]
+      "values": ["started", "success", "failed"]
     },
     "public.role": {
       "name": "role",
       "schema": "public",
-      "values": [
-        "admin",
-        "member",
-        "guest"
-      ]
+      "values": ["admin", "member", "guest"]
     },
     "public.member_status": {
       "name": "member_status",
       "schema": "public",
-      "values": [
-        "invited",
-        "active",
-        "removed"
-      ]
+      "values": ["invited", "active", "removed"]
     },
     "public.slug_type": {
       "name": "slug_type",
       "schema": "public",
-      "values": [
-        "reserved",
-        "premium"
-      ]
+      "values": ["reserved", "premium"]
     },
     "public.workspace_plan": {
       "name": "workspace_plan",
       "schema": "public",
-      "values": [
-        "free",
-        "pro",
-        "enterprise"
-      ]
+      "values": ["free", "pro", "enterprise"]
     }
   },
   "schemas": {},

--- a/packages/db/migrations/meta/20250610200449_snapshot.json
+++ b/packages/db/migrations/meta/20250610200449_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "058e8521-2814-46f0-a33f-1bbd86f450ce",
-  "prevId": "1a07a776-0481-49f9-9098-02d530b37cf5",
+  "id": "91f9a2fa-31e2-4f3a-bdb9-852292fd7501",
+  "prevId": "058e8521-2814-46f0-a33f-1bbd86f450ce",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -92,11 +92,15 @@
         "account_userId_user_id_fk": {
           "name": "account_userId_user_id_fk",
           "tableFrom": "account",
+          "columnsFrom": [
+            "userId"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["userId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -241,11 +245,15 @@
         "apiKey_userId_user_id_fk": {
           "name": "apiKey_userId_user_id_fk",
           "tableFrom": "apiKey",
+          "columnsFrom": [
+            "userId"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["userId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
@@ -312,19 +320,25 @@
         "session_userId_user_id_fk": {
           "name": "session_userId_user_id_fk",
           "tableFrom": "session",
+          "columnsFrom": [
+            "userId"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["userId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "session_token_unique": {
           "name": "session_token_unique",
-          "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -478,9 +492,9 @@
             }
           ],
           "isUnique": false,
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "concurrently": false
         },
         "unique_slug_per_workspace": {
           "name": "unique_slug_per_workspace",
@@ -499,56 +513,74 @@
             }
           ],
           "isUnique": true,
-          "where": "\"board\".\"deletedAt\" IS NULL",
-          "concurrently": false,
+          "with": {},
           "method": "btree",
-          "with": {}
+          "where": "\"board\".\"deletedAt\" IS NULL",
+          "concurrently": false
         }
       },
       "foreignKeys": {
         "board_createdBy_user_id_fk": {
           "name": "board_createdBy_user_id_fk",
           "tableFrom": "board",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "board_deletedBy_user_id_fk": {
           "name": "board_deletedBy_user_id_fk",
           "tableFrom": "board",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "board_importId_import_id_fk": {
           "name": "board_importId_import_id_fk",
           "tableFrom": "board",
+          "columnsFrom": [
+            "importId"
+          ],
           "tableTo": "import",
-          "columnsFrom": ["importId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "board_workspaceId_workspace_id_fk": {
           "name": "board_workspaceId_workspace_id_fk",
           "tableFrom": "board",
+          "columnsFrom": [
+            "workspaceId"
+          ],
           "tableTo": "workspace",
-          "columnsFrom": ["workspaceId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "board_publicId_unique": {
           "name": "board_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -681,73 +713,103 @@
         "card_activity_cardId_card_id_fk": {
           "name": "card_activity_cardId_card_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "cardId"
+          ],
           "tableTo": "card",
-          "columnsFrom": ["cardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_activity_fromListId_list_id_fk": {
           "name": "card_activity_fromListId_list_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "fromListId"
+          ],
           "tableTo": "list",
-          "columnsFrom": ["fromListId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_activity_toListId_list_id_fk": {
           "name": "card_activity_toListId_list_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "toListId"
+          ],
           "tableTo": "list",
-          "columnsFrom": ["toListId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_activity_labelId_label_id_fk": {
           "name": "card_activity_labelId_label_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "labelId"
+          ],
           "tableTo": "label",
-          "columnsFrom": ["labelId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_activity_workspaceMemberId_workspace_members_id_fk": {
           "name": "card_activity_workspaceMemberId_workspace_members_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "workspaceMemberId"
+          ],
           "tableTo": "workspace_members",
-          "columnsFrom": ["workspaceMemberId"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "card_activity_createdBy_user_id_fk": {
           "name": "card_activity_createdBy_user_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "card_activity_commentId_card_comments_id_fk": {
           "name": "card_activity_commentId_card_comments_id_fk",
           "tableFrom": "card_activity",
+          "columnsFrom": [
+            "commentId"
+          ],
           "tableTo": "card_comments",
-          "columnsFrom": ["commentId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "card_activity_publicId_unique": {
           "name": "card_activity_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -776,26 +838,37 @@
         "_card_workspace_members_cardId_card_id_fk": {
           "name": "_card_workspace_members_cardId_card_id_fk",
           "tableFrom": "_card_workspace_members",
+          "columnsFrom": [
+            "cardId"
+          ],
           "tableTo": "card",
-          "columnsFrom": ["cardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "_card_workspace_members_workspaceMemberId_workspace_members_id_fk": {
           "name": "_card_workspace_members_workspaceMemberId_workspace_members_id_fk",
           "tableFrom": "_card_workspace_members",
+          "columnsFrom": [
+            "workspaceMemberId"
+          ],
           "tableTo": "workspace_members",
-          "columnsFrom": ["workspaceMemberId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {
         "_card_workspace_members_cardId_workspaceMemberId_pk": {
           "name": "_card_workspace_members_cardId_workspaceMemberId_pk",
-          "columns": ["cardId", "workspaceMemberId"]
+          "columns": [
+            "cardId",
+            "workspaceMemberId"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -886,46 +959,64 @@
         "card_createdBy_user_id_fk": {
           "name": "card_createdBy_user_id_fk",
           "tableFrom": "card",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "card_deletedBy_user_id_fk": {
           "name": "card_deletedBy_user_id_fk",
           "tableFrom": "card",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "card_listId_list_id_fk": {
           "name": "card_listId_list_id_fk",
           "tableFrom": "card",
+          "columnsFrom": [
+            "listId"
+          ],
           "tableTo": "list",
-          "columnsFrom": ["listId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_importId_import_id_fk": {
           "name": "card_importId_import_id_fk",
           "tableFrom": "card",
+          "columnsFrom": [
+            "importId"
+          ],
           "tableTo": "import",
-          "columnsFrom": ["importId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "card_publicId_unique": {
           "name": "card_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -954,26 +1045,37 @@
         "_card_labels_cardId_card_id_fk": {
           "name": "_card_labels_cardId_card_id_fk",
           "tableFrom": "_card_labels",
+          "columnsFrom": [
+            "cardId"
+          ],
           "tableTo": "card",
-          "columnsFrom": ["cardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "_card_labels_labelId_label_id_fk": {
           "name": "_card_labels_labelId_label_id_fk",
           "tableFrom": "_card_labels",
+          "columnsFrom": [
+            "labelId"
+          ],
           "tableTo": "label",
-          "columnsFrom": ["labelId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         }
       },
       "compositePrimaryKeys": {
         "_card_labels_cardId_labelId_pk": {
           "name": "_card_labels_cardId_labelId_pk",
-          "columns": ["cardId", "labelId"]
+          "columns": [
+            "cardId",
+            "labelId"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -1046,37 +1148,51 @@
         "card_comments_cardId_card_id_fk": {
           "name": "card_comments_cardId_card_id_fk",
           "tableFrom": "card_comments",
+          "columnsFrom": [
+            "cardId"
+          ],
           "tableTo": "card",
-          "columnsFrom": ["cardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "card_comments_createdBy_user_id_fk": {
           "name": "card_comments_createdBy_user_id_fk",
           "tableFrom": "card_comments",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "card_comments_deletedBy_user_id_fk": {
           "name": "card_comments_deletedBy_user_id_fk",
           "tableFrom": "card_comments",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "card_comments_publicId_unique": {
           "name": "card_comments_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1137,11 +1253,15 @@
         "feedback_createdBy_user_id_fk": {
           "name": "feedback_createdBy_user_id_fk",
           "tableFrom": "feedback",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
@@ -1199,19 +1319,25 @@
         "import_createdBy_user_id_fk": {
           "name": "import_createdBy_user_id_fk",
           "tableFrom": "import",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "import_publicId_unique": {
           "name": "import_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1295,46 +1421,64 @@
         "label_createdBy_user_id_fk": {
           "name": "label_createdBy_user_id_fk",
           "tableFrom": "label",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "label_boardId_board_id_fk": {
           "name": "label_boardId_board_id_fk",
           "tableFrom": "label",
+          "columnsFrom": [
+            "boardId"
+          ],
           "tableTo": "board",
-          "columnsFrom": ["boardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "label_importId_import_id_fk": {
           "name": "label_importId_import_id_fk",
           "tableFrom": "label",
+          "columnsFrom": [
+            "importId"
+          ],
           "tableTo": "import",
-          "columnsFrom": ["importId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
         },
         "label_deletedBy_user_id_fk": {
           "name": "label_deletedBy_user_id_fk",
           "tableFrom": "label",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "label_publicId_unique": {
           "name": "label_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1418,46 +1562,64 @@
         "list_createdBy_user_id_fk": {
           "name": "list_createdBy_user_id_fk",
           "tableFrom": "list",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "list_deletedBy_user_id_fk": {
           "name": "list_deletedBy_user_id_fk",
           "tableFrom": "list",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "list_boardId_board_id_fk": {
           "name": "list_boardId_board_id_fk",
           "tableFrom": "list",
+          "columnsFrom": [
+            "boardId"
+          ],
           "tableTo": "board",
-          "columnsFrom": ["boardId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "list_importId_import_id_fk": {
           "name": "list_importId_import_id_fk",
           "tableFrom": "list",
+          "columnsFrom": [
+            "importId"
+          ],
           "tableTo": "import",
-          "columnsFrom": ["importId"],
-          "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "list_publicId_unique": {
           "name": "list_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1526,8 +1688,10 @@
       "uniqueConstraints": {
         "user_email_unique": {
           "name": "user_email_unique",
-          "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1558,8 +1722,10 @@
       "uniqueConstraints": {
         "workspace_slugs_slug_unique": {
           "name": "workspace_slugs_slug_unique",
-          "nullsNotDistinct": false,
-          "columns": ["slug"]
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1652,37 +1818,51 @@
         "workspace_members_userId_user_id_fk": {
           "name": "workspace_members_userId_user_id_fk",
           "tableFrom": "workspace_members",
+          "columnsFrom": [
+            "userId"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["userId"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "workspace_members_workspaceId_workspace_id_fk": {
           "name": "workspace_members_workspaceId_workspace_id_fk",
           "tableFrom": "workspace_members",
+          "columnsFrom": [
+            "workspaceId"
+          ],
           "tableTo": "workspace",
-          "columnsFrom": ["workspaceId"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
         },
         "workspace_members_deletedBy_user_id_fk": {
           "name": "workspace_members_deletedBy_user_id_fk",
           "tableFrom": "workspace_members",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "workspace_members_publicId_unique": {
           "name": "workspace_members_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1768,33 +1948,45 @@
         "workspace_createdBy_user_id_fk": {
           "name": "workspace_createdBy_user_id_fk",
           "tableFrom": "workspace",
+          "columnsFrom": [
+            "createdBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["createdBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         },
         "workspace_deletedBy_user_id_fk": {
           "name": "workspace_deletedBy_user_id_fk",
           "tableFrom": "workspace",
+          "columnsFrom": [
+            "deletedBy"
+          ],
           "tableTo": "user",
-          "columnsFrom": ["deletedBy"],
-          "columnsTo": ["id"],
-          "onDelete": "set null",
-          "onUpdate": "no action"
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "workspace_publicId_unique": {
           "name": "workspace_publicId_unique",
-          "nullsNotDistinct": false,
-          "columns": ["publicId"]
+          "columns": [
+            "publicId"
+          ],
+          "nullsNotDistinct": false
         },
         "workspace_slug_unique": {
           "name": "workspace_slug_unique",
-          "nullsNotDistinct": false,
-          "columns": ["slug"]
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
         }
       },
       "policies": {},
@@ -1806,7 +1998,10 @@
     "public.board_visibility": {
       "name": "board_visibility",
       "schema": "public",
-      "values": ["private", "public"]
+      "values": [
+        "private",
+        "public"
+      ]
     },
     "public.card_activity_type": {
       "name": "card_activity_type",
@@ -1830,39 +2025,60 @@
     "public.source": {
       "name": "source",
       "schema": "public",
-      "values": ["trello"]
+      "values": [
+        "trello"
+      ]
     },
     "public.status": {
       "name": "status",
       "schema": "public",
-      "values": ["started", "success", "failed"]
+      "values": [
+        "started",
+        "success",
+        "failed"
+      ]
     },
     "public.role": {
       "name": "role",
       "schema": "public",
-      "values": ["admin", "member", "guest"]
+      "values": [
+        "admin",
+        "member",
+        "guest"
+      ]
     },
     "public.member_status": {
       "name": "member_status",
       "schema": "public",
-      "values": ["invited", "active", "removed"]
+      "values": [
+        "invited",
+        "active",
+        "removed"
+      ]
     },
     "public.slug_type": {
       "name": "slug_type",
       "schema": "public",
-      "values": ["reserved", "premium"]
+      "values": [
+        "reserved",
+        "premium"
+      ]
     },
     "public.workspace_plan": {
       "name": "workspace_plan",
       "schema": "public",
-      "values": ["free", "pro", "enterprise"]
+      "values": [
+        "free",
+        "pro",
+        "enterprise"
+      ]
     }
   },
   "schemas": {},
+  "views": {},
   "sequences": {},
   "roles": {},
   "policies": {},
-  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1749377372062,
       "tag": "20250608100932_AddIntegrationsTable",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1749585889984,
+      "tag": "20250610200449_ReaddIntegrationTable",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Migration order was out of sync which was preventing AddIntegrationsTable from running.

- Patched duplicate prevId in snapshot
- Created a new migration to recreate the integration table (will be ignored if already exist)