### PR TITLE
fix: render comments inside contenteditable (#68)

### DIFF
--- a/apps/web/src/views/card/components/Comment.tsx
+++ b/apps/web/src/views/card/components/Comment.tsx
@@ -132,7 +132,11 @@ const Comment = ({
         )}
       </div>
       {!isEditing ? (
-        <p className="mt-2 text-sm">{comment}</p>
+        <ContentEditable
+          html={comment ?? ""}
+          disabled={true}
+          className="mt-2 text-sm"
+        />
       ) : (
         <form onSubmit={handleSubmit(onSubmit)}>
           <ContentEditable


### PR DESCRIPTION
Render comments inside contenteditable with `disabled: true` to correctly format the HTML

Closes: #68 