### PR TITLE
Fix: change postgres volume name

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ networks:
   kan-network:
 
 volumes:
-  postgres_data:
+  kan_postgres_data:
 ```
 
 2. Start the containers in detached mode:


### PR DESCRIPTION
Adjust docker-compose volume name in README.md


![image](https://github.com/user-attachments/assets/d0f91593-dbfa-4666-85a9-d03e9eee91cc)
