### PR TITLE
feat: update all label router endpoints to return a consistent structure

### DIFF
--- a/packages/db/src/repository/label.repo.ts
+++ b/packages/db/src/repository/label.repo.ts
@@ -23,7 +23,12 @@ export const create = async (
       createdBy: labelInput.createdBy,
       boardId: labelInput.boardId,
     })
-    .returning({ id: labels.id });
+    .returning({
+      id: labels.id,
+      publicId: labels.publicId,
+      name: labels.name,
+      colourCode: labels.colourCode,
+    });
 
   if (labelInput.cardId && result) {
     await db.insert(cardsToLabels).values({
@@ -91,6 +96,7 @@ export const update = async (
     .where(eq(labels.publicId, labelInput.labelPublicId))
     .returning({
       id: labels.id,
+      publicId: labels.publicId,
       name: labels.name,
       colourCode: labels.colourCode,
     });


### PR DESCRIPTION
**Changes:**
- Added a label schema to the label router (these should probably exist somewhere else but fine for now)
- Updated the meta output to use the new label schema
- Updated the returned value of all label endpoint to match the label schema

These changes should be rolled out across all other routers.

Resolves: https://github.com/kanbn/kan/issues/102
