### PR TITLE
fix: affix avatar fileName with UID to invalidate next image cache

### DIFF
--- a/apps/web/src/views/settings/components/Avatar.tsx
+++ b/apps/web/src/views/settings/components/Avatar.tsx
@@ -3,6 +3,8 @@ import { t } from "@lingui/core/macro";
 import { env } from "next-runtime-env";
 import { useState } from "react";
 
+import { generateUID } from "@kan/shared/utils";
+
 import { usePopup } from "~/providers/popup";
 import { api } from "~/utils/api";
 import { getAvatarUrl } from "~/utils/helpers";
@@ -58,7 +60,7 @@ export default function Avatar({
       }
 
       const fileExt = file.name.split(".").pop();
-      const fileName = `${userId}/avatar.${fileExt}`;
+      const fileName = `${userId}/avatar-${generateUID()}.${fileExt}`;
 
       setUploading(true);
 


### PR DESCRIPTION
Attempting to upload another avatar would not result in the image changing due to next's aggressive caching policy.

Affixing a UID to the fileName invalidates this and ensures the new avatar is returned.