### PR TITLE
fix: auth /social-providers endpoint ids

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node-terminal",
       "request": "launch",
       "command": "pnpm dev",
-      "cwd": "${workspaceFolder}/apps/nextjs",
+      "cwd": "${workspaceFolder}/apps/web",
       "skipFiles": ["<node_internals>/**"],
       "sourceMaps": true,
       "sourceMapPathOverrides": {

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -259,6 +259,7 @@ export function Auth({ setIsMagicLinkSent, isSignUp }: AuthProps) {
             }
             return (
               <Button
+                key={key}
                 onClick={() => handleLoginWithProvider(key as SocialProvider)}
                 isLoading={isLoginWithProviderPending === key}
                 iconLeft={<provider.icon />}

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -84,7 +84,7 @@ export const socialProvidersPlugin = () => ({
         method: "GET",
       },
       async (ctx) =>
-        ctx.json(ctx.context.socialProviders.map((p) => p.name.toLowerCase())),
+        ctx.json(ctx.context.socialProviders.map((p) => p.id.toLowerCase())),
     ),
   },
 });


### PR DESCRIPTION
The `/social-providers` endpoint should return a list of the provider ids, not their names. This was found when trying to use the microsoft endpoint and the endpoint was returning `"microsoft entraid"`, when the `AuthForm` expects it to just be `"microsoft"`. This was resulting in the `AuthForm` thinking there was a provider that was supposed to be used, but the button wasn't actually being created because the name was not matching the key.