### PR TITLE
fix: allow member invites when signup is disabled

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -166,9 +166,19 @@ export const initAuth = (db: dbClient) => {
     databaseHooks: {
       user: {
         create: {
-          before() {
+          async before(user) {
             if (env("NEXT_PUBLIC_DISABLE_SIGN_UP")?.toLowerCase() === "true") {
-              return Promise.resolve(false);
+              const pendingInvitation = await memberRepo.getByEmailAndStatus(
+                db,
+                user.email,
+                "invited",
+              );
+
+              if (!pendingInvitation) {
+                return Promise.resolve(false);
+              }
+
+              return Promise.resolve(true);
             }
             return Promise.resolve(true);
           },

--- a/packages/db/src/repository/member.repo.ts
+++ b/packages/db/src/repository/member.repo.ts
@@ -41,6 +41,20 @@ export const getByPublicId = async (db: dbClient, publicId: string) => {
   });
 };
 
+export const getByEmailAndStatus = async (
+  db: dbClient,
+  email: string,
+  status: MemberStatus,
+) => {
+  return db.query.workspaceMembers.findFirst({
+    where: and(
+      eq(workspaceMembers.email, email),
+      eq(workspaceMembers.status, status),
+      isNull(workspaceMembers.deletedAt),
+    ),
+  });
+};
+
 export const acceptInvite = async (
   db: dbClient,
   args: { memberId: number; userId: string },


### PR DESCRIPTION
- Setting `NEXT_PUBLIC_DISABLE_SIGN_UP` true was preventing new members from being created
- Extended the before user create hook to allow the creation of new users if a pending invitation exists

Fixes: https://github.com/kanbn/kan/issues/96