### PR TITLE
fix: disable create list and label button when input is empty

### DIFF
--- a/apps/web/src/components/LabelForm.tsx
+++ b/apps/web/src/components/LabelForm.tsx
@@ -229,6 +229,9 @@ export function LabelForm({
           <Button
             type="submit"
             isLoading={updateLabel.isPending || createLabel.isPending}
+            disabled={
+              !watch("name")
+            }
           >
             {isEdit ? t`Update label` : t`Create label`}
           </Button>

--- a/apps/web/src/views/board/components/NewListForm.tsx
+++ b/apps/web/src/views/board/components/NewListForm.tsx
@@ -145,7 +145,12 @@ export function NewListForm({
         />
 
         <div>
-          <Button type="submit">{t`Create list`}</Button>
+          <Button
+            type="submit"
+            disabled={createList.isPending || !watch("name")}
+          >
+            {t`Create list`}
+          </Button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
Currenty when creating a new list with empty name throws error and same goes with creating new label.
The buttons will be disabled until there's some input.