### PR TITLE
fix: add new created label to selected label

### DIFF
--- a/apps/web/src/components/DeleteLabelConfirmation.tsx
+++ b/apps/web/src/components/DeleteLabelConfirmation.tsx
@@ -10,11 +10,14 @@ export function DeleteLabelConfirmation({
   labelPublicId: string;
   refetch: () => void;
 }) {
-  const { closeModal } = useModal();
+  const { closeModal, closeModals } = useModal();
   const { showPopup } = usePopup();
 
   const deleteLabelMutation = api.label.delete.useMutation({
-    onSuccess: () => refetch(),
+    onSuccess: () => {
+      refetch();
+      closeModals(2);
+    },
     onError: () =>
       showPopup({
         header: "Error deleting label",
@@ -24,7 +27,6 @@ export function DeleteLabelConfirmation({
   });
 
   const handleDeleteLabel = () => {
-    closeModal();
     deleteLabelMutation.mutate({
       labelPublicId,
     });

--- a/apps/web/src/components/LabelForm.tsx
+++ b/apps/web/src/components/LabelForm.tsx
@@ -32,7 +32,7 @@ export function LabelForm({
   refetch: () => void;
   isEdit?: boolean;
 }) {
-  const { closeModal, entityId, openModal } = useModal();
+  const { closeModal, entityId, openModal, setModalState } = useModal();
 
   const label = api.label.byPublicId.useQuery(
     {
@@ -57,12 +57,13 @@ export function LabelForm({
   const isCreateAnotherEnabled = watch("isCreateAnotherEnabled");
 
   const createLabel = api.label.create.useMutation({
-    onSuccess: () => {
+    onSuccess: (newLabel) => {
       const currentColourIndex = colours.findIndex(
         (c) => c.code === watch("colour").code,
       );
       try {
         refetch();
+        setModalState("NEW_LABEL_CREATED", newLabel.publicId);
         if (!isCreateAnotherEnabled) {
           closeModal();
         } else {
@@ -220,6 +221,7 @@ export function LabelForm({
         <div className="space-x-2">
           {isEdit && (
             <Button
+              type="button"
               variant="secondary"
               onClick={() => openModal("DELETE_LABEL", entityId)}
             >

--- a/apps/web/src/providers/modal.tsx
+++ b/apps/web/src/providers/modal.tsx
@@ -18,6 +18,8 @@ type ModalContextType = {
     entityLabel?: string,
   ) => void;
   closeModal: () => void;
+  closeModals: (count: number) => void;
+  clearAllModals: () => void;
   modalContentType: string;
   entityId: string;
   entityLabel: string;
@@ -58,6 +60,17 @@ export const ModalProvider: React.FC<Props> = ({ children }) => {
     });
   };
 
+  const closeModals = (count: number) => {
+    setModalStack(prev => {
+      const newLength = Math.max(0, prev.length - count);
+      return prev.slice(0, newLength);
+    });
+  };
+
+  const clearAllModals = () => {
+    setModalStack([]);
+  };
+
   const setModalState = (modalType: string, state: any) => {
     setModalStates(prev => ({
       ...prev,
@@ -87,6 +100,8 @@ export const ModalProvider: React.FC<Props> = ({ children }) => {
         isOpen,
         openModal,
         closeModal,
+        closeModals,
+        clearAllModals,
         modalContentType,
         entityId,
         entityLabel,


### PR DESCRIPTION
FIxes #26 

Now when a new label is created through a card modal, it get selected automatically. 

Another change:
```
onSuccess: () => {
      refetch();
      closeModals(2);
    },
```
implemented this close modals if more than 2 modals have been stacked, you can check it by: create card -> edit label -> delete label modal , now when clicked on delete, the current logics returns to previous modal i.e edit label modal, which shouldnt be the case since the label is already deleted.

