### PR TITLE
fix: check if `POSTGRES_URL` env variable is set before migration

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -81,5 +81,4 @@ ARG PORT=3000
 ENV PORT=${PORT}
 EXPOSE ${PORT}
 
-CMD ["sh", "-c", "cd /app && pnpm db:migrate && cd /app/apps/web && pnpm start"]
-
+CMD ["sh", "-c", "if [ -n \"$POSTGRES_URL\" ]; then cd /app && pnpm db:migrate && cd /app/apps/web; fi && pnpm start"]


### PR DESCRIPTION
Adds a check if the variable is set before running `pnpm db:migrate`. Just realized I forgot that in my previous PR