### PR TITLE
fix: delay clearing modal content until fade-out on public board

### DIFF
--- a/apps/web/src/components/CheckboxDropdown.tsx
+++ b/apps/web/src/components/CheckboxDropdown.tsx
@@ -55,51 +55,59 @@ export default function CheckboxDropdown({
 
   const renderMenuItems = (items: Item[], groupKey: string | null) => (
     <>
-      {items.map((item) => (
-        <Menu.Item key={item.key}>
-          <div
-            className="group flex items-center rounded-[5px] p-2 hover:bg-light-200 dark:hover:bg-dark-300"
-            onClick={(e) => {
-              e.preventDefault();
-              handleSelect(groupKey, { key: item.key, value: item.value });
-            }}
-          >
-            <input
-              id={item.key}
-              name={item.key}
-              type="checkbox"
-              className="h-[14px] w-[14px] rounded bg-transparent"
-              onClick={(event) => event.stopPropagation()}
-              onChange={() =>
-                handleSelect(groupKey, { key: item.key, value: item.value })
-              }
-              checked={item.selected}
-            />
-            {item.leftIcon && (
-              <span className="ml-3 flex items-center">{item.leftIcon}</span>
-            )}
-            <label
-              htmlFor={item.key}
-              className="ml-3 text-[12px] text-dark-900"
+      {items.length > 0 ? (
+        items.map((item) => (
+          <Menu.Item key={item.key}>
+            <div
+              className="group flex items-center rounded-[5px] p-2 hover:bg-light-200 dark:hover:bg-dark-300"
+              onClick={(e) => {
+                e.preventDefault();
+                handleSelect(groupKey, { key: item.key, value: item.value });
+              }}
             >
-              {item.value}
-            </label>
-            {handleEdit && (
-              <button
-                type="button"
-                className="invisible ml-auto group-hover:visible"
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  handleEdit(item.key);
-                }}
+              <input
+                id={item.key}
+                name={item.key}
+                type="checkbox"
+                className="h-[14px] w-[14px] rounded bg-transparent"
+                onClick={(event) => event.stopPropagation()}
+                onChange={() =>
+                  handleSelect(groupKey, { key: item.key, value: item.value })
+                }
+                checked={item.selected}
+              />
+              {item.leftIcon && (
+                <span className="ml-3 flex items-center">{item.leftIcon}</span>
+              )}
+              <label
+                htmlFor={item.key}
+                className="ml-3 text-[12px] text-dark-900"
               >
-                <HiEllipsisHorizontal size={20} className="text-dark-900" />
-              </button>
-            )}
+                {item.value}
+              </label>
+              {handleEdit && (
+                <button
+                  type="button"
+                  className="invisible ml-auto group-hover:visible"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    handleEdit(item.key);
+                  }}
+                >
+                  <HiEllipsisHorizontal size={20} className="text-dark-900" />
+                </button>
+              )}
+            </div>
+          </Menu.Item>
+        ))
+      ) : (
+        !handleCreate && (
+          <div className="flex items-center p-2 text-[12px] text-dark-900">
+            No items
           </div>
-        </Menu.Item>
-      ))}
+        )
+      )}
       {handleCreate && (
         <button
           type="button"

--- a/apps/web/src/views/public/board/CardModal.tsx
+++ b/apps/web/src/views/public/board/CardModal.tsx
@@ -69,17 +69,20 @@ export function CardModal({
                 onClick={async (e) => {
                   e.preventDefault();
                   closeModal();
-                  try {
-                    await router.replace(
-                      `/${workspaceSlug}/${boardSlug}`,
-                      undefined,
-                      {
-                        shallow: true,
-                      },
-                    );
-                  } catch (error) {
-                    console.error(error);
-                  }
+
+                  setTimeout(async () => {
+                    try {
+                      await router.replace(
+                        `/${workspaceSlug}/${boardSlug}`,
+                        undefined,
+                        {
+                          shallow: true,
+                        },
+                      );
+                    } catch (error) {
+                      console.error(error);
+                    }
+                  }, 200);
                 }}
               >
                 <HiXMark

--- a/apps/web/src/views/public/board/CardModal.tsx
+++ b/apps/web/src/views/public/board/CardModal.tsx
@@ -82,7 +82,7 @@ export function CardModal({
                     } catch (error) {
                       console.error(error);
                     }
-                  }, 200);
+                  }, 400);
                 }}
               >
                 <HiXMark


### PR DESCRIPTION
This fix exsure that closing the modal on the public board page does not clears the conten before the modal fade out animation finishes
Also enhanced the filters dropdown to handle empty items.