### PR TITLE
fix(api): correct values of `Content-Disposition` attributes

### DIFF
--- a/apps/web/src/pages/api/download/attatchment.ts
+++ b/apps/web/src/pages/api/download/attatchment.ts
@@ -17,12 +17,11 @@ export default async function handler(
   }
 
   try {
-    const downloadUrl = decodeURIComponent(url);
-    const downloadFilename =
-      (typeof filename === "string" ? decodeURIComponent(filename) : null) ??
-      "attachment";
+    const downloadFilename = typeof filename === "string"
+      ? encodeURIComponent(filename)
+      : "attachment";
 
-    const upstream = await fetch(downloadUrl);
+    const upstream = await fetch(url);
 
     if (!upstream.ok) {
       return res.status(upstream.status).json({
@@ -36,7 +35,7 @@ export default async function handler(
     res.setHeader("Content-Type", contentType);
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename="${downloadFilename}"`,
+      `attachment; filename="${downloadFilename}"; filename*=UTF-8''${downloadFilename}`,
     );
 
     const buffer = await upstream.arrayBuffer();


### PR DESCRIPTION
Added the extended `filename*` attribute as described on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#syntax).

Also it seems that Next.js automatically decodes values of request query. For the extended `filename*` attribute the value should be encoded, but I am not sure about the regular one:

> The parameters filename and filename* differ only in that filename* uses the encoding defined in [RFC 5987, section 3.2](https://datatracker.ietf.org/doc/html/rfc5987#section-3.2). When both filename and filename* are present in a single header field value, filename* is preferred over filename when both are understood. It's recommended to include both for maximum compatibility, and you can convert filename* to filename by substituting non-ASCII characters with ASCII equivalents (such as converting é to e). You may want to avoid percent escape sequences in filename, because they are handled inconsistently across browsers. (Firefox and Chrome decode them, while Safari does not.)


Fixes: #259 