### PR TITLE
fix: map profile to user for OIDC authentication

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -339,6 +339,37 @@ export const initAuth = (db: dbClient) => {
                   discoveryUrl: process.env.OIDC_DISCOVERY_URL,
                   scopes: ["openid", "email", "profile"],
                   pkce: true,
+                  mapProfileToUser: (profile: {
+                    name?: string;
+                    display_name?: string;
+                    preferred_username?: string;
+                    given_name?: string;
+                    family_name?: string;
+                    email?: string;
+                    email_verified?: boolean;
+                    sub?: string;
+                    picture?: string;
+                    avatar?: string;
+                  }) => {
+                    console.log("OIDC profile:", profile);
+
+                    const name =
+                      profile.name ??
+                      profile.display_name ??
+                      profile.preferred_username ??
+                      (profile.given_name && profile.family_name
+                        ? `${profile.given_name} ${profile.family_name}`.trim()
+                        : (profile.given_name ?? profile.family_name)) ??
+                      profile.sub ??
+                      "";
+
+                    return {
+                      email: profile.email,
+                      name: name,
+                      emailVerified: profile.email_verified ?? false,
+                      image: profile.picture ?? profile.avatar ?? null,
+                    };
+                  },
                 },
               ],
             }),


### PR DESCRIPTION
- After upgrading better-auth it seems OIDC authentication is throwing a `name_is_missing` error
- Added custom mapProfileToUser to guarantee a name field is provided to better-auth

Related to: https://github.com/kanbn/kan/issues/295