### PR TITLE
Add Discord CDN avatars to allowed image sources

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -50,6 +50,11 @@ const config = {
           protocol: "https",
           hostname: "*.googleusercontent.com",
         },
+        {
+          protocol: 'https',
+          hostname: 'cdn.discordapp.com',
+          pathname: '/avatars/**',
+        },
       ];
 
       // Extract root domain from S3_ENDPOINT and add wildcard pattern


### PR DESCRIPTION
Currently if you sign in through discord profile pictures wont work (`"url" parameter is not allowed`), this fixes it.