### PR TITLE
fix: disable tooltips on touch devices

### DIFF
--- a/apps/web/src/components/Tooltip.tsx
+++ b/apps/web/src/components/Tooltip.tsx
@@ -35,6 +35,7 @@ export function Tooltip({
       delay,
       interactive: false,
       theme: "tooltip",
+      touch: false,
     });
 
     return () => {


### PR DESCRIPTION
## Summary

On iOS, tooltips appear when tapping buttons. My users struggled with this. They mistook the tooltip for a tappable element and kept tapping on it expecting action.

<img width="454" height="913" alt="image" src="https://github.com/user-attachments/assets/9c55eb45-9bb3-4365-b9b1-054fe4cff920" />

**Affected buttons**: 
- Create new list
- Create new board

## Changes

Add `touch: false` to tippy.js configuration to disable tooltips on touch devices.

## Rationale

These tooltips explain standard UI patterns that users already understand. In this case the "+" button for creating new items is a universal convention in modern apps. The tooltips provide minimal value while causing confusion on touch devices. Disabling them on touch is a reasonable trade-off. Desktop hover behavior remains unchanged.
