### PR TITLE
fix(api): include name and slug in workspace byId response

### DIFF
--- a/packages/db/src/repository/workspace.repo.ts
+++ b/packages/db/src/repository/workspace.repo.ts
@@ -142,6 +142,8 @@ export const getByPublicIdWithMembers = (
     columns: {
       id: true,
       publicId: true,
+      name: true,
+      slug: true,
       showEmailsToMembers: true,
     },
     with: {


### PR DESCRIPTION
## Summary

The `GET /workspaces/{workspacePublicId}` endpoint was missing the workspace's `name` and `slug` fields in the response.

## Changes

Added `name: true` and `slug: true` to the column selection in `getByPublicIdWithMembers`.

## Test plan

- Call `GET /api/v1/workspaces/{id}` and verify `name` and `slug` are now included in the response

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)