### PR TITLE
fix: remove phantom spacing in auth form (closes #334)

### DIFF
--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -361,8 +361,8 @@ export function Auth({ setIsMagicLinkSent, isSignUp }: AuthProps) {
           })}
         </div>
       )}
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {!isCredentialsEnabled && socialProviders?.length === 0 && (
+      {!(isCredentialsEnabled || isMagicLinkAvailable) &&
+        socialProviders?.length === 0 && (
           <div className="flex w-full items-center gap-4">
             <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
             <span className="text-center text-sm text-light-900 dark:text-dark-900">
@@ -371,65 +371,62 @@ export function Auth({ setIsMagicLinkSent, isSignUp }: AuthProps) {
             <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
           </div>
         )}
-        {!isCredentialsEnabled && socialProviders?.length !== 0 && (
-          <div className="mb-[1.5rem] flex w-full items-center gap-4">
-            <div className="h-[1px] w-full bg-light-600 dark:bg-dark-600" />
-            <span className="text-sm text-light-900 dark:text-dark-900">
-              {t`or`}
-            </span>
-            <div className="h-[1px] w-full bg-light-600 dark:bg-dark-600" />
-          </div>
-        )}
-        <div className="space-y-2">
-          {isSignUp && isCredentialsEnabled && (
-            <div>
-              <Input
-                {...register("name", { required: true })}
-                placeholder={t`Enter your name`}
-              />
-              {errors.name && (
-                <p className="mt-2 text-xs text-red-400">
-                  {t`Please enter a valid name`}
-                </p>
-              )}
+      {(isCredentialsEnabled || isMagicLinkAvailable) && (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {socialProviders?.length !== 0 && (
+            <div className="mb-[1.5rem] flex w-full items-center gap-4">
+              <div className="h-[1px] w-full bg-light-600 dark:bg-dark-600" />
+              <span className="text-sm text-light-900 dark:text-dark-900">
+                {t`or`}
+              </span>
+              <div className="h-[1px] w-full bg-light-600 dark:bg-dark-600" />
             </div>
           )}
-          {(isCredentialsEnabled || isMagicLinkAvailable) && (
-            <>
+          <div className="space-y-2">
+            {isSignUp && isCredentialsEnabled && (
               <div>
                 <Input
-                  {...register("email", { required: true })}
-                  placeholder={t`Enter your email address`}
+                  {...register("name", { required: true })}
+                  placeholder={t`Enter your name`}
                 />
-                {errors.email && (
+                {errors.name && (
                   <p className="mt-2 text-xs text-red-400">
-                    {t`Please enter a valid email address`}
+                    {t`Please enter a valid name`}
                   </p>
                 )}
               </div>
-
-              {isCredentialsEnabled && (
-                <div>
-                  <Input
-                    type="password"
-                    {...register("password", { required: true })}
-                    placeholder={t`Enter your password`}
-                  />
-                  {errors.password && (
-                    <p className="mt-2 text-xs text-red-400">
-                      {errors.password.message ??
-                        t`Please enter a valid password`}
-                    </p>
-                  )}
-                </div>
+            )}
+            <div>
+              <Input
+                {...register("email", { required: true })}
+                placeholder={t`Enter your email address`}
+              />
+              {errors.email && (
+                <p className="mt-2 text-xs text-red-400">
+                  {t`Please enter a valid email address`}
+                </p>
               )}
-            </>
-          )}
-          {loginError && (
-            <p className="mt-2 text-xs text-red-400">{loginError}</p>
-          )}
-        </div>
-        {(isCredentialsEnabled || isMagicLinkAvailable) && (
+            </div>
+
+            {isCredentialsEnabled && (
+              <div>
+                <Input
+                  type="password"
+                  {...register("password", { required: true })}
+                  placeholder={t`Enter your password`}
+                />
+                {errors.password && (
+                  <p className="mt-2 text-xs text-red-400">
+                    {errors.password.message ??
+                      t`Please enter a valid password`}
+                  </p>
+                )}
+              </div>
+            )}
+            {loginError && (
+              <p className="mt-2 text-xs text-red-400">{loginError}</p>
+            )}
+          </div>
           <div className="mt-[1.5rem] flex items-center gap-4">
             <Button
               isLoading={isLoginWithEmailPending}
@@ -441,8 +438,11 @@ export function Auth({ setIsMagicLinkSent, isSignUp }: AuthProps) {
               {isMagicLinkMode ? t`magic link` : t`email`}
             </Button>
           </div>
-        )}
-      </form>
+        </form>
+      )}
+      {!(isCredentialsEnabled || isMagicLinkAvailable) && loginError && (
+        <p className="mt-2 text-xs text-red-400">{loginError}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Improves the logic and will no longer show the "---- OR ----" if no magic link/email auth.

This closes #334

With "Email/Magic Link" and multiple socials:
```
- NEXT_PUBLIC_ALLOW_CREDENTIALS=true
- NEXT_PUBLIC_DISABLE_SIGN_UP=false
- NEXT_PUBLIC_DISABLE_EMAIL=false
```
<img width="580" height="640" alt="firefox_FdAzIoikfc1vfERP" src="https://github.com/user-attachments/assets/474901e9-2dca-499b-8312-40f1bb6f2299" />

----

With the following conditions:
```
- NEXT_PUBLIC_ALLOW_CREDENTIALS=false
- NEXT_PUBLIC_DISABLE_SIGN_UP=false
- NEXT_PUBLIC_DISABLE_EMAIL=false
```
<img width="571" height="595" alt="firefox_5LuKfYEdSCJRxHn7" src="https://github.com/user-attachments/assets/a876607b-0360-4d4c-8f3f-8a78a08a5066" />

----

With the following conditions:
```
- NEXT_PUBLIC_ALLOW_CREDENTIALS=false
- NEXT_PUBLIC_DISABLE_SIGN_UP=true
- NEXT_PUBLIC_DISABLE_EMAIL=false
```
<img width="512" height="515" alt="firefox_SSJJgyNRsu0X3aeA" src="https://github.com/user-attachments/assets/5dea93e7-c4ae-4441-92c4-3f919269dc01" />

----

With the following conditions:
```
- NEXT_PUBLIC_ALLOW_CREDENTIALS=false
- NEXT_PUBLIC_DISABLE_SIGN_UP=true
- NEXT_PUBLIC_DISABLE_EMAIL=true
```
<img width="652" height="443" alt="firefox_2fQ8RJqW2Y0kyx96" src="https://github.com/user-attachments/assets/22aae32a-d693-4926-9c3b-a73b6e3598fb" />

