### PR TITLE
fix: prevent long card titles from overflowing column width

### DIFF
--- a/apps/web/src/views/board/components/Card.tsx
+++ b/apps/web/src/views/board/components/Card.tsx
@@ -66,8 +66,8 @@ const Card = ({
   const hasDueDate = !!dueDate;
 
   return (
-    <div className="flex flex-col rounded-md border border-light-200 bg-light-50 px-3 py-2 text-sm text-neutral-900 dark:border-dark-200 dark:bg-dark-200 dark:text-dark-1000 dark:hover:bg-dark-300">
-      <span>{title}</span>
+    <div className="flex flex-col overflow-hidden rounded-md border border-light-200 bg-light-50 px-3 py-2 text-sm text-neutral-900 dark:border-dark-200 dark:bg-dark-200 dark:text-dark-1000 dark:hover:bg-dark-300">
+      <span className="break-words">{title}</span>
       {labels.length ||
       members.length ||
       checklists.length > 0 ||


### PR DESCRIPTION
## Summary

Long unbreakable strings (e.g. URLs) in card titles caused columns to expand beyond their fixed width, triggering horizontal scrolling and degrading the drag-and-drop experience

Added overflow-hidden to the card container and break-words to the title span so long strings wrap naturally within the card boundaries

Linked issue: https://github.com/kanbn/kan/issues/341

### Before

<img width="316" height="319" alt="Capture d’écran du 2026-02-07 22-58-56" src="https://github.com/user-attachments/assets/b93773c4-2dba-48bf-afb3-0e2906b8f723" />

### After

<img width="316" height="319" alt="Capture d’écran du 2026-02-07 22-58-41" src="https://github.com/user-attachments/assets/07871ac2-f36c-41b4-bf29-0011cd6594d7" />

## Test plan

- [ ] Create a card with a long URL as the title
- [ ] Verify the title wraps within the card without expanding the column width
- [ ] Verify no horizontal scrollbar appears on the board
- [ ] Verify drag-and-drop still works correctly with long titles
- [ ] Verify normal short titles are unaffected

---

Thank you for building and maintaining Kan. It's a beautifully crafted OSS. Happy to contribute! 🙏