### PR TITLE
feat: add two types of roadmap templates

### DIFF
--- a/apps/web/src/views/boards/components/TemplateBoards.tsx
+++ b/apps/web/src/views/boards/components/TemplateBoards.tsx
@@ -24,6 +24,18 @@ export const getTemplates = (): Template[] => [
     labels: [t`Bug`, t`Feature`, t`Enhancement`, t`Critical`, t`Documentation`],
   },
   {
+    id: "roadmap-basic",
+    name: t`Basic Roadmap`,
+    lists: [t`Requested`, t`Planned`, t`In Progress`, t`Done`],
+    labels: [t`Feature`, t`Enhancement`, t`Critical`, t`Documentation`],
+  },
+  {
+    id: "roadmap-extended",
+    name: t`Extended Roadmap`,
+    lists: [t`Requested`, t`Under Review`, t`Planned`, t`In Progress`, t`Done`, t`Rejected`],
+    labels: [t`Feature`, t`Enhancement`, t`Critical`, t`Documentation`],
+  },
+  {
     id: "content-creation",
     name: t`Content Creation`,
     lists: [


### PR DESCRIPTION
Add two different types of roadmap templates.

## 1. Basic Roadmap

Similar to the [official Kan Roadmap](https://kan.bn/kan/roadmap) but slightly modified.

- `Requested`
- `Planned`
- `In Progress`
- `Done`

## 2. Extended Roadmap
- `Requested`
- `Under Review`
- `Planned`
- `In Progress`
- `Done`
- `Rejected`