### PR TITLE
Join Workspace Email improvements

### DIFF
--- a/packages/auth/src/plugins.ts
+++ b/packages/auth/src/plugins.ts
@@ -225,10 +225,16 @@ export function createPlugins(db: dbClient) {
             },
           );
         } else {
-          // TOOD: Respect NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY
-          await sendEmail(email, "Sign in to kan.bn", "MAGIC_LINK", {
-            magicLoginUrl: url,
-          });
+          await sendEmail(
+            email,
+            process.env.NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY === "true"
+              ? "Sign in to your account"
+              : "Sign in to Kan",
+            "MAGIC_LINK",
+            {
+              magicLoginUrl: url,
+            },
+          );
         }
       },
     }),

--- a/packages/email/src/templates/join-workspace.tsx
+++ b/packages/email/src/templates/join-workspace.tsx
@@ -42,7 +42,7 @@ export const JoinWorkspaceTemplate = ({
             color: "#232323",
           }}
         >
-          kan.bn
+          {env("NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY") !== "true" && "Kan"}
         </Heading>
         <Heading
           style={{ fontSize: "24px", fontWeight: "bold", color: "#232323" }}
@@ -90,23 +90,27 @@ export const JoinWorkspaceTemplate = ({
         >
           If you don&apos;t want to join this workspace, you can safely ignore this email.
         </Text>
-        <Hr
-          style={{
-            marginTop: "2.5rem",
-            marginBottom: "2rem",
-            borderWidth: "1px",
-          }}
-        />
-        <Text style={{ color: "#7e7e7e" }}>
-          <Link
-            href={env("NEXT_PUBLIC_BASE_URL")}
-            target="_blank"
-            style={{ color: "#7e7e7e", textDecoration: "underline" }}
-          >
-            Kan
-          </Link>
-          , the open source Trello alternative.
-        </Text>
+        {env("NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY") !== "true" && (
+          <>
+            <Hr
+              style={{
+                marginTop: "2.5rem",
+                marginBottom: "2rem",
+                borderWidth: "1px",
+              }}
+            />
+            <Text style={{ color: "#7e7e7e" }}>
+              <Link
+                href={env("NEXT_PUBLIC_BASE_URL")}
+                target="_blank"
+                style={{ color: "#7e7e7e", textDecoration: "underline" }}
+              >
+                Kan
+              </Link>
+              , the open source Trello alternative.
+            </Text>
+          </>
+        )}
       </Container>
     </Body>
   </Html>


### PR DESCRIPTION
This is the last one for me this weekend I swear.

- This fixes a join workspace email bug due to checking if the url contains type=invite, but failed on percent-encoded URLs. This will now work on both.
- Renames some strings from "kan.bn" to "Kan" for consistency
- Respects the `NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY` environment variable for this email message only.

The other templates should be reviewed for the last two list items but I will open a separate PR for that, possibly next weekend.