### PR TITLE
fix: increase max workspace url length from 24 to 64 characters (clos…

### DIFF
--- a/apps/web/src/components/NewWorkspaceForm.tsx
+++ b/apps/web/src/components/NewWorkspaceForm.tsx
@@ -33,7 +33,7 @@ const schema = z.object({
     .min(3, {
       message: t`URL must be at least 3 characters long`,
     })
-    .max(24, { message: t`URL cannot exceed 24 characters` })
+    .max(64, { message: t`URL cannot exceed 64 characters` })
     .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/, {
       message: t`URL can only contain letters, numbers, and hyphens`,
     })

--- a/apps/web/src/pages/api/stripe/create_checkout_session.ts
+++ b/apps/web/src/pages/api/stripe/create_checkout_session.ts
@@ -11,7 +11,7 @@ import { withRateLimit } from "@kan/api/utils/rateLimit";
 const workspaceSlugSchema = z
   .string()
   .min(3)
-  .max(24)
+  .max(64)
   .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/);
 
 interface CheckoutSessionRequest {

--- a/apps/web/src/views/settings/components/UpdateWorkspaceUrlForm.tsx
+++ b/apps/web/src/views/settings/components/UpdateWorkspaceUrlForm.tsx
@@ -33,7 +33,7 @@ const UpdateWorkspaceUrlForm = ({
       .min(3, {
         message: t`URL must be at least 3 characters long`,
       })
-      .max(24, { message: t`URL cannot exceed 24 characters` })
+      .max(64, { message: t`URL cannot exceed 64 characters` })
       .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/, {
         message: t`URL can only contain letters, numbers, and hyphens`,
       }),

--- a/packages/api/src/routers/board.ts
+++ b/packages/api/src/routers/board.ts
@@ -218,7 +218,7 @@ export const boardRouter = createTRPCRouter({
         workspaceSlug: z
           .string()
           .min(3)
-          .max(24)
+          .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/),
         boardSlug: z
           .string()

--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -160,7 +160,7 @@ export const workspaceRouter = createTRPCRouter({
         workspaceSlug: z
           .string()
           .min(3)
-          .max(24)
+          .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/),
       }),
     )
@@ -207,7 +207,7 @@ export const workspaceRouter = createTRPCRouter({
         slug: z
           .string()
           .min(3)
-          .max(24)
+          .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/)
           .optional(),
       }),
@@ -290,7 +290,7 @@ export const workspaceRouter = createTRPCRouter({
         slug: z
           .string()
           .min(3)
-          .max(24)
+          .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/)
           .optional(),
         description: z.string().min(3).max(280).optional(),
@@ -424,7 +424,7 @@ export const workspaceRouter = createTRPCRouter({
         workspaceSlug: z
           .string()
           .min(3)
-          .max(24)
+          .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/),
       }),
     )


### PR DESCRIPTION
This pull request increases the maximum allowed length for workspace slugs (URLs) from 24 to 64 characters across both the frontend and backend validation logic. This change ensures users can create and update workspace URLs up to 64 characters long throughout the application.

**Validation updates for workspace slugs:**

* Increased the maximum length for workspace slugs from 24 to 64 characters in the API routers: `board.ts` and `workspace.ts` (`packages/api/src/routers/board.ts`, `packages/api/src/routers/workspace.ts`). [[1]](diffhunk://#diff-78d1662ab9db2946d67f68bd3a10185ff5c8a581538c6a0fbccfbd460f9e37c6L221-R221) [[2]](diffhunk://#diff-9bcf4f738ad2e3476a49e510867a85f36e1a64f542a551d3047e9ed33f21e475L163-R163) [[3]](diffhunk://#diff-9bcf4f738ad2e3476a49e510867a85f36e1a64f542a551d3047e9ed33f21e475L210-R210) [[4]](diffhunk://#diff-9bcf4f738ad2e3476a49e510867a85f36e1a64f542a551d3047e9ed33f21e475L293-R293) [[5]](diffhunk://#diff-9bcf4f738ad2e3476a49e510867a85f36e1a64f542a551d3047e9ed33f21e475L427-R427)
* Updated frontend validation schemas to allow workspace URLs up to 64 characters in `NewWorkspaceForm.tsx`, `UpdateWorkspaceUrlForm.tsx`, and the Stripe checkout session API route (`apps/web/src/components/NewWorkspaceForm.tsx`, `apps/web/src/views/settings/components/UpdateWorkspaceUrlForm.tsx`, `apps/web/src/pages/api/stripe/create_checkout_session.ts`). [[1]](diffhunk://#diff-d7d9702afaeedac7b16b65159be0e0cfeda12a2c0b0397798713aafcb05ca71cL36-R36) [[2]](diffhunk://#diff-5d797451d386dd94e5a6972759d72710dc02d5907e3aa5abf51f64f3cc4d6822L36-R36) [[3]](diffhunk://#diff-7e9331da776168627854d16670394bbca6fdc9d8a05ea7a10cb67b3c1ee20ee4L14-R14)…es #379(