### PR TITLE
fix: handle empty commenter name in mention notification emails

### DIFF
--- a/packages/api/src/utils/notifications.ts
+++ b/packages/api/src/utils/notifications.ts
@@ -53,7 +53,7 @@ export async function sendMentionEmails({
     const commenter = await userRepo.getById(db, commenterUserId);
     if (!commenter) return;
 
-    const commenterName = commenter.name ?? commenter.email;
+    const commenterName = commenter.name?.trim() || commenter.email;
 
     // Get mentioned members with full details (filtered by workspace)
     const membersWithDetails = await memberRepo.getByPublicIdsWithUsers(


### PR DESCRIPTION
## Summary
- Fixes mention notification emails showing no commenter name when the user's `name` field is an empty string
- Changes `??` (nullish coalescing) to `||` (logical OR) with `.trim()` so empty/whitespace-only names properly fall back to the user's email address

## Problem
The `??` operator only catches `null`/`undefined`, not empty strings. If a user's `name` is `""`, the email renders as:
> **mentioned you** in a comment on the card...

<img width="860" height="489" alt="Screenshot 2026-02-16 at 4 11 37 pm" src="https://github.com/user-attachments/assets/fae0bc14-bfe7-4392-9bd3-d8c1884ca99b" />


Instead of:
> **user@email.com** mentioned you in a comment on the card...

## Fix
```diff
- const commenterName = commenter.name ?? commenter.email;
+ const commenterName = commenter.name?.trim() || commenter.email;
```

## Test plan
- [ ] Create a user account with no display name set (empty string)
- [ ] Mention another user in a comment
- [ ] Verify the email shows the commenter's email as fallback instead of blank