### PR TITLE
fix: make links clickable in comments

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -463,13 +463,6 @@ export default function Editor({
         StarterKit.configure({
           heading: disableHeadings ? false : undefined,
         }),
-        Markdown,
-        Placeholder.configure({
-          placeholder: readOnly
-            ? ""
-            : placeholder ??
-              t`Add description... (type '/' to open commands or '@' to mention)`,
-        }),
         Link.configure({
           openOnClick: true,
           HTMLAttributes: {
@@ -479,6 +472,14 @@ export default function Editor({
           },
           validate: (href) => /^https?:\/\//.test(href),
           autolink: true,
+          linkOnPaste: true,
+        }),
+        Markdown,
+        Placeholder.configure({
+          placeholder: readOnly
+            ? ""
+            : placeholder ??
+              t`Add description... (type '/' to open commands or '@' to mention)`,
         }),
         SlashCommands.configure({
           commandItems: getCommandItems(disableHeadings),


### PR DESCRIPTION
## Summary
- Move Link extension before Markdown in TipTap extensions array to ensure URL detection happens before markdown processing
- Explicitly enable `linkOnPaste: true` for paste detection

## Root Cause
The `tiptap-markdown` extension's paste handler was processing pasted content before the Link extension could detect URLs, causing pasted links to remain as plain text instead of being converted to clickable `<a>` tags.

## Test plan
- [ ] Paste a URL (e.g. `https://example.com`) in a comment and verify it becomes clickable
- [ ] Type a URL in a comment and verify it becomes clickable
- [ ] Verify links still work in card descriptions

Fixes #376

🤖 Generated with [Claude Code](https://claude.ai/code)