### PR TITLE
fix(api): add missing openapi meta to checklist.update

### DIFF
--- a/packages/api/src/routers/checklist.ts
+++ b/packages/api/src/routers/checklist.ts
@@ -81,6 +81,16 @@ export const checklistRouter = createTRPCRouter({
       return newChecklist;
     }),
   update: protectedProcedure
+    .meta({
+      openapi: {
+        summary: "Update a checklist",
+        method: "PUT",
+        path: "/checklists/{checklistPublicId}",
+        description: "Updates a checklist by its public ID",
+        tags: ["Cards"],
+        protect: true,
+      },
+    })
     .input(
       z.object({
         checklistPublicId: z.string().length(12),


### PR DESCRIPTION
## Summary
- The `checklist.update` procedure was missing its `.meta({ openapi: ... })` declaration, causing it to inherit the default `GET /protected` placeholder from `protectedProcedure`
- This made the checklist update endpoint unreachable via the REST API (`trpc-to-openapi` registered it at the wrong method/path)
- Added proper OpenAPI meta: `PUT /checklists/{checklistPublicId}`, consistent with the existing `DELETE /checklists/{checklistPublicId}` pattern

## Test plan
- [ ] Verify `PUT /api/v1/checklists/{id}` returns 200 (previously returned 404)
- [ ] Verify checklist rename still works in the web UI (uses tRPC batch, unaffected)
- [ ] Verify OpenAPI docs at `/api/v1/openapi.json` include the new route

🤖 Generated with [Claude Code](https://claude.com/claude-code)