### PR TITLE
fix: preserve board scroll position when navigating back from a card

### DIFF
--- a/apps/web/src/hooks/useScrollRestore.ts
+++ b/apps/web/src/hooks/useScrollRestore.ts
@@ -1,0 +1,44 @@
+import type { RefObject } from "react";
+import type { NextRouter } from "next/router";
+import { useEffect, useRef } from "react";
+
+const scrollPositions = new Map<string, number>();
+
+export function useScrollRestore(
+  boardId: string | null | undefined,
+  scrollRef: RefObject<HTMLElement | null>,
+  router: NextRouter,
+  isReady: boolean,
+) {
+  const restored = useRef(false);
+
+  useEffect(() => {
+    if (!boardId) return;
+
+    restored.current = false;
+
+    const saveScrollPosition = () => {
+      if (scrollRef.current) {
+        scrollPositions.set(boardId, scrollRef.current.scrollLeft);
+      }
+    };
+
+    router.events.on("routeChangeStart", saveScrollPosition);
+    return () => router.events.off("routeChangeStart", saveScrollPosition);
+  }, [boardId, router.events, scrollRef]);
+
+  useEffect(() => {
+    if (restored.current || !isReady || !boardId) return;
+    restored.current = true;
+
+    const saved = scrollPositions.get(boardId);
+    if (saved === undefined) return;
+
+    // StrictModeDroppable delays rendering by one requestAnimationFrame
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (scrollRef.current) scrollRef.current.scrollLeft = saved;
+      });
+    });
+  }, [isReady, scrollRef, boardId]);
+}

--- a/apps/web/src/views/board/index.tsx
+++ b/apps/web/src/views/board/index.tsx
@@ -26,6 +26,7 @@ import { StrictModeDroppable as Droppable } from "~/components/StrictModeDroppab
 import { Tooltip } from "~/components/Tooltip";
 import { EditYouTubeModal } from "~/components/YouTubeEmbed/EditYouTubeModal";
 import { useDragToScroll } from "~/hooks/useDragToScroll";
+import { useScrollRestore } from "~/hooks/useScrollRestore";
 import { usePermissions } from "~/hooks/usePermissions";
 import { useKeyboardShortcut } from "~/providers/keyboard-shortcuts";
 import { useModal } from "~/providers/modal";
@@ -140,6 +141,8 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
   }, [boardId]);
 
   const isLoading = isInitialLoading || isQueryLoading;
+
+  useScrollRestore(boardId, scrollRef, router, !isLoading && (boardData?.lists.length ?? 0) > 0);
 
   const updateListMutation = api.list.update.useMutation({
     onMutate: async (args) => {


### PR DESCRIPTION
## Description

When opening a card from a board and navigating back, the horizontal scroll position was lost. The board always reset to the beginning. This is a little bit frustrating on boards with many lists that require horizontal scrolling.

https://github.com/user-attachments/assets/e826c685-e1c7-4f3b-93ec-aa45ee16793d

I couldn't find an existing issue related to this problem, so I'm submitting this PR directly. Happy to discuss whether this is something worth fixing and open to feedback on the technical approach.

## Changes

- Added `useScrollRestore` hook that saves the board scroll position on route change and restores it when navigating back
- Integrated the hook into `BoardPage`

## How it works

- Scroll position is saved via Next.js `routeChangeStart` event (before the DOM unmounts)
- On return, position is restored after `StrictModeDroppable` finishes rendering (double `requestAnimationFrame`)
- Positions are stored per board in a module-level `Map`, so each board remembers its own position within the session

## Demo

https://github.com/user-attachments/assets/dece6eef-2d94-4cb3-b192-0ef1b856f102

## How to test

1. Open a board with enough lists to require horizontal scrolling
2. Scroll to the right
3. Click on a card to open it
4. Close the card (X button or browser back)
5. Verify the board scroll position is preserved
