### PR TITLE
fix: avatar upload display and oversized crop on HiDPI screens

### DIFF
--- a/apps/web/src/utils/helpers.ts
+++ b/apps/web/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { env } from "next-runtime-env";
+
 export const formatToArray = (
   value: string | string[] | undefined,
 ): string[] => {
@@ -48,6 +50,22 @@ export const getAvatarUrl = (imageOrKey: string | null) => {
 
   if (imageOrKey.startsWith("http://") || imageOrKey.startsWith("https://")) {
     return imageOrKey;
+  }
+
+  // Construct URL from S3 key
+  const useVirtualHosted = env("NEXT_PUBLIC_USE_VIRTUAL_HOSTED_URLS") === "true";
+  const storageDomain = env("NEXT_PUBLIC_STORAGE_DOMAIN");
+  const storageUrl = env("NEXT_PUBLIC_STORAGE_URL");
+  const bucket = env("NEXT_PUBLIC_AVATAR_BUCKET_NAME");
+
+  if (useVirtualHosted && storageDomain && bucket) {
+    // Virtual-hosted style: https://{bucket}.{domain}/{key}
+    return `https://${bucket}.${storageDomain}/${imageOrKey}`;
+  }
+
+  if (storageUrl && bucket) {
+    // Path-style: {storageUrl}/{bucket}/{key}
+    return `${storageUrl}/${bucket}/${imageOrKey}`;
   }
 
   return "";

--- a/apps/web/src/views/settings/components/Avatar.tsx
+++ b/apps/web/src/views/settings/components/Avatar.tsx
@@ -110,18 +110,17 @@ export default function Avatar({
     const cropYpx = (crop.y / 100) * image.naturalHeight;
     const cropWpx = (crop.width / 100) * image.naturalWidth;
     const cropHpx = (crop.height / 100) * image.naturalHeight;
-    canvas.width = Math.max(1, Math.floor(cropWpx));
-    canvas.height = Math.max(1, Math.floor(cropHpx));
+
+    // Cap output at 512x512 — avatars display at 64x64, so higher res is wasteful
+    // and causes "File too large" errors on HiDPI screens
+    const maxSize = 512;
+    const scale = Math.min(maxSize / cropWpx, maxSize / cropHpx, 1);
+    canvas.width = Math.max(1, Math.floor(cropWpx * scale));
+    canvas.height = Math.max(1, Math.floor(cropHpx * scale));
     const ctx = canvas.getContext("2d");
     if (!ctx) throw new Error("Canvas not supported");
 
-    // For better quality on HiDPI screens
-    const pixelRatio = window.devicePixelRatio || 1;
-    canvas.width = canvas.width * pixelRatio;
-    canvas.height = canvas.height * pixelRatio;
-    ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
     ctx.imageSmoothingQuality = "high";
-
     ctx.drawImage(
       image,
       cropXpx,
@@ -130,8 +129,8 @@ export default function Avatar({
       cropHpx,
       0,
       0,
-      canvas.width / pixelRatio,
-      canvas.height / pixelRatio,
+      canvas.width,
+      canvas.height,
     );
 
     const mime = selectedFile?.type ?? "image/jpeg";
@@ -139,6 +138,7 @@ export default function Avatar({
       canvas.toBlob(
         (b) => (b ? resolve(b) : reject(new Error("toBlob failed"))),
         mime,
+        0.85,
       );
     });
     return blob;


### PR DESCRIPTION
## Summary

Two related avatar upload bugs:

1. **`getAvatarUrl()` returns empty string for S3 keys** — uploaded avatars never display because the function only handles full URLs, not S3 keys. This implements the URL construction logic that the existing tests in `helpers.test.ts` already describe, supporting both path-style (MinIO/LocalStack) and virtual-hosted (Tigris/AWS S3) URLs.

2. **Avatar crop produces oversized blobs on HiDPI screens** — the crop canvas was scaled by `devicePixelRatio` (2x on Retina = 4x pixel count), and `toBlob()` was called without a quality parameter. A 782KB source image would produce a >2MB blob, exceeding `S3_AVATAR_UPLOAD_LIMIT`. Now caps output at 512x512px (more than enough for avatars displayed at 64x64) and uses `quality=0.85`.

## Changes

- `apps/web/src/utils/helpers.ts` — implement S3 key → URL construction in `getAvatarUrl()`, using `NEXT_PUBLIC_STORAGE_URL`, `NEXT_PUBLIC_AVATAR_BUCKET_NAME`, and optionally `NEXT_PUBLIC_USE_VIRTUAL_HOSTED_URLS` + `NEXT_PUBLIC_STORAGE_DOMAIN`
- `apps/web/src/views/settings/components/Avatar.tsx` — replace `devicePixelRatio` scaling with 512x512 cap, add `quality=0.85` to `canvas.toBlob()`

## Test plan

- [x] All 8 existing `getAvatarUrl` tests pass (they were previously failing against the stub implementation)
- [x] Path-style URL construction verified with self-hosted MinIO (`storage.imagineering.cc`)
- [x] Avatar upload tested on Retina MacBook — blob stays well under 2MB limit

Closes #440, closes #441