### PR TITLE
fix: redirect to boards list after archive/unarchive

### DIFF
--- a/apps/web/src/views/board/components/BoardDropdown.tsx
+++ b/apps/web/src/views/board/components/BoardDropdown.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { t } from "@lingui/core/macro";
 import {
   HiEllipsisHorizontal,
@@ -29,6 +30,7 @@ export default function BoardDropdown({
   isFavorite?: boolean;
   boardName?: string;
 }) {
+  const router = useRouter();
   const { openModal } = useModal();
   const { showPopup } = usePopup();
   const { canEditBoard, canDeleteBoard, canCreateBoard, canArchiveBoard } =
@@ -47,6 +49,7 @@ export default function BoardDropdown({
             : t`The board has been unarchived.`,
           icon: "success",
         });
+        void router.push(`/boards`);
       } else if (variables.favorite !== undefined) {
         showPopup({
           header: variables.favorite


### PR DESCRIPTION
## Summary
- Archiving or unarchiving a board now redirects the user to `/boards`, matching the existing behaviour of delete and move operations
- Previously the user was left on the archived/unarchived board view with no clear navigation path

## Test plan
- [x] Open a board, archive it via the dropdown menu → should redirect to boards list
- [x] View an archived board, unarchive it via the dropdown menu → should redirect to boards list
- [x] Verify the correct workspace's boards are shown after redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)