### PR TITLE
fix: remove duplicate OIDC provider registration in getSocialProviders

### DIFF
--- a/packages/auth/src/providers.ts
+++ b/packages/auth/src/providers.ts
@@ -92,14 +92,6 @@ export const socialProvidersPlugin = () => ({
         const providers = ctx.context.socialProviders.map((p) =>
           p.id.toLowerCase(),
         );
-        // Add OIDC provider if configured
-        if (
-          process.env.OIDC_CLIENT_ID &&
-          process.env.OIDC_CLIENT_SECRET &&
-          process.env.OIDC_DISCOVERY_URL
-        ) {
-          providers.push("oidc");
-        }
         return ctx.json(providers);
       },
     ),


### PR DESCRIPTION
The getSocialProviders endpoint was manually pushing "oidc" to the  providers array when OIDC env vars are present, but Better Auth already  includes the OIDC provider in ctx.context.socialProviders when it is  configured. This resulted in ["oidc","oidc"] being returned from  /api/auth/social-providers, causing a duplicate provider registration  that led to a TypeError: Cannot read properties of null (reading 'id')  during the OIDC login callback, preventing all OIDC logins.

Fix: remove the manual providers.push("oidc") block as it is redundant.