### PR TITLE
feat: add card ticket types

### DIFF
--- a/apps/web/src/components/CardTypeBadge.tsx
+++ b/apps/web/src/components/CardTypeBadge.tsx
@@ -1,0 +1,94 @@
+import type { IconType } from "react-icons";
+import { t } from "@lingui/core/macro";
+import {
+  HiOutlineBeaker,
+  HiOutlineBolt,
+  HiOutlineBugAnt,
+  HiOutlineChartBarSquare,
+  HiOutlineChatBubbleLeftRight,
+  HiOutlineCodeBracket,
+  HiOutlineLightBulb,
+} from "react-icons/hi2";
+import { twMerge } from "tailwind-merge";
+
+import type { CardType } from "@kan/shared/constants";
+
+const cardTypeStyles: Record<CardType, string> = {
+  spike:
+    "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-300 dark:ring-amber-500/30",
+  research:
+    "bg-sky-50 text-sky-700 ring-sky-200 dark:bg-sky-500/10 dark:text-sky-300 dark:ring-sky-500/30",
+  coding:
+    "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:ring-emerald-500/30",
+  analyze:
+    "bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/30",
+  bug: "bg-red-50 text-red-700 ring-red-200 dark:bg-red-500/10 dark:text-red-300 dark:ring-red-500/30",
+  feedback:
+    "bg-cyan-50 text-cyan-700 ring-cyan-200 dark:bg-cyan-500/10 dark:text-cyan-300 dark:ring-cyan-500/30",
+  suggestion:
+    "bg-lime-50 text-lime-700 ring-lime-200 dark:bg-lime-500/10 dark:text-lime-300 dark:ring-lime-500/30",
+};
+
+const cardTypeIcons: Record<CardType, IconType> = {
+  spike: HiOutlineBolt,
+  research: HiOutlineBeaker,
+  coding: HiOutlineCodeBracket,
+  analyze: HiOutlineChartBarSquare,
+  bug: HiOutlineBugAnt,
+  feedback: HiOutlineChatBubbleLeftRight,
+  suggestion: HiOutlineLightBulb,
+};
+
+export const getCardTypeLabel = (type: CardType) => {
+  const labels: Record<CardType, string> = {
+    spike: t`Spike`,
+    research: t`Research`,
+    coding: t`Coding`,
+    analyze: t`Analyze`,
+    bug: t`Bug`,
+    feedback: t`Feedback`,
+    suggestion: t`Suggestion`,
+  };
+
+  return labels[type];
+};
+
+export const CardTypeIcon = ({
+  type,
+  className,
+}: {
+  type: CardType;
+  className?: string;
+}) => {
+  const Icon = cardTypeIcons[type];
+
+  return <Icon className={twMerge("h-3.5 w-3.5", className)} />;
+};
+
+const CardTypeBadge = ({
+  type,
+  showLabel = true,
+  size = "md",
+  className,
+}: {
+  type: CardType;
+  showLabel?: boolean;
+  size?: "sm" | "md";
+  className?: string;
+}) => (
+  <span
+    className={twMerge(
+      "inline-flex w-fit items-center rounded-full font-medium ring-1 ring-inset",
+      size === "sm"
+        ? "gap-x-1 px-1.5 py-0.5 text-[10px]"
+        : "gap-x-1.5 px-2 py-1 text-[11px]",
+      cardTypeStyles[type],
+      className,
+    )}
+  >
+    <CardTypeIcon type={type} className={size === "sm" ? "h-3 w-3" : ""} />
+    {showLabel && <span>{getCardTypeLabel(type)}</span>}
+  </span>
+);
+
+export default CardTypeBadge;

--- a/apps/web/src/components/CardTypeSelector.tsx
+++ b/apps/web/src/components/CardTypeSelector.tsx
@@ -1,0 +1,134 @@
+import { Menu, Transition } from "@headlessui/react";
+import { t } from "@lingui/core/macro";
+import { Fragment } from "react";
+
+import type { CardType } from "@kan/shared/constants";
+import { cardTypes, defaultCardType } from "@kan/shared/constants";
+
+import CardTypeBadge, {
+  CardTypeIcon,
+  getCardTypeLabel,
+} from "~/components/CardTypeBadge";
+import { usePopup } from "~/providers/popup";
+import { api } from "~/utils/api";
+import { invalidateCard } from "~/utils/cardInvalidation";
+
+interface CardTypeSelectorProps {
+  cardPublicId?: string;
+  type: CardType | null | undefined;
+  onChange?: (type: CardType) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
+const CardTypeSelector = ({
+  cardPublicId,
+  type,
+  onChange,
+  isLoading = false,
+  disabled = false,
+}: CardTypeSelectorProps) => {
+  const selectedType = type ?? defaultCardType;
+  const utils = api.useUtils();
+  const { showPopup } = usePopup();
+
+  const updateType = api.card.update.useMutation({
+    onMutate: async (update) => {
+      if (!cardPublicId) return {};
+
+      await utils.card.byId.cancel({ cardPublicId });
+      const previousCard = utils.card.byId.getData({ cardPublicId });
+
+      utils.card.byId.setData({ cardPublicId }, (oldCard) => {
+        if (!oldCard || update.type === undefined) return oldCard;
+
+        return {
+          ...oldCard,
+          type: update.type,
+        };
+      });
+
+      return { previousCard };
+    },
+    onError: (_error, _update, context) => {
+      if (cardPublicId) {
+        utils.card.byId.setData({ cardPublicId }, context?.previousCard);
+      }
+
+      showPopup({
+        header: t`Unable to update type`,
+        message: t`Please try again later, or contact customer support.`,
+        icon: "error",
+      });
+    },
+    onSettled: async () => {
+      if (cardPublicId) {
+        await invalidateCard(utils, cardPublicId);
+      }
+      await utils.board.byId.invalidate();
+      await utils.board.bySlug.invalidate();
+    },
+  });
+
+  const handleSelect = (nextType: CardType) => {
+    if (disabled || nextType === selectedType) return;
+
+    if (onChange) {
+      onChange(nextType);
+      return;
+    }
+
+    if (cardPublicId) {
+      updateType.mutate({ cardPublicId, type: nextType });
+    }
+  };
+
+  return (
+    <Menu as="div" className="relative flex w-full items-center text-left">
+      <Menu.Button
+        disabled={isLoading || disabled}
+        className={`flex h-full w-full items-center rounded-[5px] border-[1px] border-light-50 py-1 pl-2 text-left text-xs text-neutral-900 focus-visible:outline-none dark:border-dark-50 dark:text-dark-1000 ${disabled ? "cursor-not-allowed opacity-60" : "hover:border-light-300 hover:bg-light-200 dark:hover:border-dark-200 dark:hover:bg-dark-100"}`}
+      >
+        {isLoading ? (
+          <span className="h-5 w-24 animate-pulse rounded bg-light-300 dark:bg-dark-300" />
+        ) : (
+          <CardTypeBadge type={selectedType} size="sm" />
+        )}
+      </Menu.Button>
+
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Menu.Items className="absolute left-0 top-[32px] z-50 w-52 origin-top-left rounded-md border-[1px] border-light-200 bg-light-50 p-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:border-dark-500 dark:bg-dark-200">
+          {cardTypes.map((cardType) => (
+            <Menu.Item key={cardType}>
+              {({ active }) => (
+                <button
+                  type="button"
+                  onClick={() => handleSelect(cardType)}
+                  className={`flex w-full items-center rounded-[5px] p-2 text-left text-[12px] text-dark-900 ${active ? "bg-light-200 dark:bg-dark-300" : ""}`}
+                >
+                  <span className="mr-3">
+                    <CardTypeIcon type={cardType} />
+                  </span>
+                  <span>{getCardTypeLabel(cardType)}</span>
+                  {cardType === selectedType && (
+                    <span className="ml-auto h-1.5 w-1.5 rounded-full bg-light-1000 dark:bg-dark-1000" />
+                  )}
+                </button>
+              )}
+            </Menu.Item>
+          ))}
+        </Menu.Items>
+      </Transition>
+    </Menu>
+  );
+};
+
+export default CardTypeSelector;

--- a/apps/web/src/components/NewWorkspaceForm.tsx
+++ b/apps/web/src/components/NewWorkspaceForm.tsx
@@ -98,6 +98,7 @@ export function NewWorkspaceForm() {
           plan: values.plan,
           role: "admin",
           weekStartDay: 1,
+          cardPrefix: values.cardPrefix,
         });
 
         closeModal();

--- a/apps/web/src/locales/de/messages.json
+++ b/apps/web/src/locales/de/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (bearbeitet)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", oder siehe unsere"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} wurde zu deinen Favoriten hinzugefügt."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} wurde aus deinen Favoriten entfernt."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} Labels"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} nicht gefunden"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Board importieren (1)} other {Boards importieren ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Projekt importieren (1)} other {Projekte importieren ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/Monat"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "0 $"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "10 $/Monat"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "8 $/Monat"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 Benutzer"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "10 MB Datei-Uploads"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "14 Tage kostenlose Testversion · Jederzeit Plan wechseln oder kündigen"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Seite nicht gefunden | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Eine leistungsstarke, flexible Kanban-App, die dir hilft, Arbeit zu organisieren, Fortschritte zu verfolgen und Ergebnisse zu liefern – alles an einem Ort."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Konto"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Konto gelöscht"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Account-Manager"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Aktionen"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Aktiv"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Aktivität"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Aktivitätsprotokoll"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Aktivitätsprotokolle"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Label hinzufügen / bearbeiten"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Karte hinzufügen"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Element hinzufügen..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Checkliste hinzufügen"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Kommentar hinzufügen... (‚/' für Befehle oder ‚@' zum Erwähnen eingeben)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Beschreibung hinzufügen... (‚/' für Befehle oder ‚@' zum Erwähnen eingeben)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Details hinzufügen..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Label hinzufügen"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Mitglied hinzufügen"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Zu Favoriten hinzufügen"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Webhook hinzufügen"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "hat {0} Labels hinzugefügt: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "hat eine Checkliste hinzugefügt"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "hat ein Checklisten-Element hinzugefügt"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "hat ein Label zur Karte hinzugefügt"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "hat ein Mitglied zur Karte hinzugefügt"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "hat einen Anhang hinzugefügt"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "hat einen Anhang hinzugefügt <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "hat Checkliste <0>{0}</0> hinzugefügt"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "hat Checklisten-Element <0>{0}</0> hinzugefügt"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "hat Label <0>{0}</0> hinzugefügt"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Zu Favoriten hinzugefügt"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Das Hinzufügen eines neuen Mitglieds kostet zusätzlich {price} ({billingType}) pro Platz."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Passen Sie den quadratischen Zuschnitt an Ihren Avatar an."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Administrator"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Administrator-Rollen"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Erweiterte Administrator-Steuerung"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Erweiterte Administrator-Rollen"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Erweiterte Sicherheit, Compliance und dedizierter Support für große Organisationen."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Alle Free-Features +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Alle individuellen Berechtigungsüberschreibungen der Mitglieder wurden auf ihre Rollenstandards zurückgesetzt."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Alle Pro-Features +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Alle Systeme betriebsbereit"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Alle Teams-Features +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Haben Sie bereits ein Konto? <0><1>Anmelden</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Beim Verbinden Ihres GitHub-Kontos ist ein Fehler aufgetreten."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Beim Trennen Ihres GitHub-Kontos ist ein Fehler aufgetreten."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Beim Trennen Ihres Trello-Kontos ist ein Fehler aufgetreten."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Jährlich"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Jeder mit diesem Link kann Ihrem Workspace beitreten"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "API-Schlüssel erstellt"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "API-Schlüsselname"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "API-Schlüsselname darf 30 Zeichen nicht überschreiten"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "API-Schlüsselname ist erforderlich"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "API-Schlüssel"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "API-Referenz"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Bewerber"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Genehmigung"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Board archivieren"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Archiviert"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Möchten Sie {entityLabel} wirklich entfernen?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Möchten Sie den Webhook \"{webhookName}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Möchten Sie den Workspace {0} wirklich löschen?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Möchten Sie {0} wirklich löschen?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Möchten Sie diese Karte wirklich löschen?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Möchten Sie diese Checkliste wirklich löschen?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Möchten Sie diesen Kommentar wirklich löschen?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Möchten Sie dieses Label wirklich löschen?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Möchten Sie Ihr Konto wirklich löschen?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "hat <0>{0}</0> der Karte zugewiesen"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Zugewiesene Personen"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Anhang hochgeladen"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Wartet auf Kunden"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Zurück"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Basis-Kanban"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Basis-Roadmap"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Ideal für Einzelpersonen und Solo-Kreative, die gerade anfangen"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Ideal für große Organisationen mit erweiterten Anforderungen"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Ideal für kleine und wachsende Teams, die zusammenarbeiten müssen"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Ideal für kleine Teams, die gemeinsam arbeiten und schneller vorankommen möchten."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Ideal für Teams, die grenzenlos skalieren möchten"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "jährlich abgerechnet"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "monatlich abgerechnet"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Abrechnung"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Abrechnungsportal"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Blogbeitrag"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Board"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Board-Analyse"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Board archiviert"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Board-Name darf 100 Zeichen nicht überschreiten"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Board-Name ist erforderlich"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Board nicht gefunden"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Board-Vorlagen"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Board wiederhergestellt"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "Board-URL darf nur Buchstaben, Zahlen und Bindestriche enthalten"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "Board-URL darf 60 Zeichen nicht überschreiten"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "Board-URL in Zwischenablage kopiert"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "Board-URL muss mindestens 3 Zeichen lang sein"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Board-Sichtbarkeit"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Board-Sichtbarkeit aktualisiert"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Boards"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Boards, die du archivierst, werden hier angezeigt."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Brainstorming"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Bug"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Bug-Report"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Kann Kommentare hinzufügen"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Kann Boards erstellen"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Kann Karten erstellen"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Kann Listen erstellen"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Kann Boards löschen"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Kann Karten löschen"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Kann Kommentare löschen"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Kann Listen löschen"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Kann Workspace löschen"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Kann Boards bearbeiten"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Kann Karten bearbeiten"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Kann Kommentare bearbeiten"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Kann Listen bearbeiten"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Kann Mitgliederrollen und Berechtigungen bearbeiten"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Kann Workspace bearbeiten"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Kann Mitglieder einladen"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Kann Workspace-Einstellungen verwalten"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Kann Mitglieder entfernen"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Kann Boards ansehen"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Kann Karten ansehen"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Kann Kommentare ansehen"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Kann Listen ansehen"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Kann Mitglieder ansehen"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Kann Workspace ansehen"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Abbrechen"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Karte"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Karte dupliziert"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Karte nicht gefunden"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Kartentitel"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "Karten-URL in Zwischenablage kopiert"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Passwort ändern"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Schriftgröße der Anwendung ändern."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Ändern Sie Ihre Spracheinstellungen."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "hat das Fälligkeitsdatum auf <0>{formattedDate}</0> geändert"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Schauen Sie sich einige unserer bevorzugten Open-Source-Projekte an."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Überprüfen Sie Ihren Posteingang"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Checklistenname"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklisten"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Tarif wählen"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Löschen Sie alle benutzerdefinierten Mitgliederberechtigungen, sodass alle Mitglieder nur Berechtigungen von ihren Rollenstandardwerten erben."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Benutzerdefinierte Berechtigungen löschen"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Filter löschen"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Klicken Sie auf den Link, den wir an {magicLinkRecipient} gesendet haben, um sich anzumelden."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Schließen"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Code-Review"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Arbeiten Sie nahtlos mit Ihrem Team zusammen."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Zusammenarbeit"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Demnächst verfügbar"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Kommentare"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Unternehmen"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Abschließen"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Vollständige Kontrolle und Eigentümerschaft:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "hat einen Checklistenpunkt abgeschlossen"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "hat Checklistenpunkt <0>{0}</0> abgeschlossen"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Konfigurierbare Benutzerrollen und Berechtigungen"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Konfigurieren Sie Webhooks, um Benachrichtigungen zu erhalten, wenn Karten erstellt, aktualisiert, verschoben oder gelöscht werden."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Konfigurieren Sie, welche Aktionen für jede Workspace-Rolle erlaubt sind. Diese Berechtigungen gelten für alle Mitglieder mit dieser Rolle."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Bestätigen Sie Ihre E-Mail-Einstellungen:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Bestätigen Sie Ihr neues Passwort"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Verbinden"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "GitHub verbinden"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Trello verbinden"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Verbinden Sie Ihre bevorzugten Tools, um Ihren Workflow zu optimieren."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Verbinden Sie Ihr GitHub-Konto, um Projekte zu importieren."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Verbinden Sie Ihr Trello-Konto, um Boards zu importieren."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Kontakt"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Vertrieb kontaktieren"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Kontaktieren Sie uns"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Content-Erstellung"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Weiter"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Weiter mit "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Weiter mit {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Legen Sie fest, wer Ihre Boards ansehen und bearbeiten kann."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "In Link umwandeln"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Board-Link kopieren"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Karten-Link kopieren"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Checklisten kopieren"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Labels kopieren"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Link zur Karte kopieren"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Mitglieder kopieren"
   },
   "7mrkyO": {
-    "translation": "Ticket-ID kopieren",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Ticket-ID kopieren"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Kernfunktionen"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "{0} erstellen"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Weitere erstellen"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "API-Schlüssel erstellen"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Karte erstellen"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Checkliste erstellen"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Einladungslink erstellen"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Label erstellen"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Liste erstellen"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Neue {0} erstellen"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Neuen Schlüssel erstellen"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Neues Label erstellen"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Neue Liste erstellen"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Vorlage erstellen"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Webhook erstellen"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Workspace erstellen"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Erstellt"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "hat die Karte erstellt"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Kritisch"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Avatar zuschneiden"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Aktuelles Passwort ist erforderlich"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Benutzerdefinierte Board-Vorlagen"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Individuelles Branding"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Benutzerdefinierte Domain"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Benutzerdefinierte Berechtigungen"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "Benutzerdefiniertes SLA"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Benutzerdefinierte URLs erfordern ein Upgrade auf einen Pro-Plan",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Benutzerdefinierter Benutzername"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Benutzerdefinierte Benutzernamen erfordern ein Upgrade auf einen Pro-Tarif"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "Benutzerdefinierte Workspace-URL"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Benutzerdefinierter Workspace-Benutzername"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Kundensupport"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Dunkel"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Einladungslink deaktivieren"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Dedizierter Account-Manager"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Standard-Benutzername"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Löschen"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Account löschen"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Board löschen"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Karte löschen"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Kommentar löschen"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Liste löschen"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Vorlage löschen"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Webhook löschen"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Workspace löschen"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "hat eine Checkliste gelöscht"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "hat ein Checklisten-Element gelöscht"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "hat Checkliste <0>{0}</0> gelöscht"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "hat Checklisten-Element <0>{0}</0> gelöscht"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Design"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "GitHub trennen"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Trello trennen"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Diskutieren und arbeiten Sie an Karten zusammen."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Anzeigename"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Anzeigename darf 280 Zeichen nicht überschreiten"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Anzeigename muss mindestens 3 Zeichen lang sein"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Anzeigename aktualisiert"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Bieten Sie einen kostenlosen Plan an?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Möchten Sie das Abonnement kündigen?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "Docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Dokumentation"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Noch kein Konto? <0><1>Registrieren</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Fertig"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Download fehlgeschlagen"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Fälligkeitsdatum"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Fällig nächsten Monat"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Fällig nächste Woche"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Heute fällig"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Morgen fällig"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplizieren"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Karte duplizieren"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Wird dupliziert…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Bearbeiten"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Board-URL bearbeiten"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Kommentar bearbeiten"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Label bearbeiten"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Berechtigungen bearbeiten"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Webhook bearbeiten"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Workspace-URL bearbeiten"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "YouTube-Video bearbeiten"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Bearbeitung"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "E-Mail"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "E-Mail"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "E-Mail-Benachrichtigungen"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "E-Mail-Benachrichtigungen für Erwähnungen"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "E-Mail-Sichtbarkeit"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Ende der Liste"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Technik"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Verbesserung"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Benutzerdefinierten Titel eingeben"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Neues Secret eingeben, um zu aktualisieren"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Geben Sie Ihr aktuelles Passwort ein"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Geben Sie Ihr aktuelles Passwort ein und wählen Sie ein neues sicheres Passwort."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Geben Sie Ihre E-Mail-Adresse ein"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Geben Sie Ihren Namen ein"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Geben Sie Ihr neues Passwort ein"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Geben Sie Ihr Passwort ein"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Fehler"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Fehler beim Ändern des Passworts"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Fehler beim Verbinden von GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Fehler beim Erstellen des Einladungslinks"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Fehler beim Deaktivieren des Einladungslinks"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Fehler beim Löschen des Kontos"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Fehler beim Löschen des Labels"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Fehler beim Löschen des Arbeitsbereichs"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Fehler beim Trennen von GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Fehler beim Trennen von Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Fehler beim Einladen des Mitglieds"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Fehler beim Aktualisieren des Anzeigenamens"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Fehler beim Aktualisieren der Workspace-Beschreibung"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Fehler beim Aktualisieren des Workspace-Namens"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Fehler beim Aktualisieren der Workspace-URL"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Fehler beim Upgrade des Abonnements"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Fehler beim Upgrade auf Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Fehler beim Hochladen des Profilbilds"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Ereignisse"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Alles aus dem kostenlosen Plan, plus:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Alles, was Sie brauchen, für immer kostenlos. Unbegrenzte Boards, unbegrenzte Listen, unbegrenzte Karten. Jederzeit upgraden."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Ausführung"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Erweiterte Roadmap"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Einladung konnte nicht angenommen werden. Bitte versuchen Sie es später erneut oder kontaktieren Sie den Kundensupport."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Einladungslink konnte nicht kopiert werden"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Board konnte nicht erstellt werden"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Webhook konnte nicht erstellt werden"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Webhook konnte nicht gelöscht werden"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Videoinformationen konnten nicht abgerufen werden"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Anmeldung mit {0} fehlgeschlagen. Bitte versuchen Sie es erneut."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Webhook konnte nicht getestet werden"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Webhook konnte nicht aktualisiert werden"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Anhang konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "FAQs"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Feature"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Feature-Anfrage"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Features"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Feedback"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Feedback gesendet"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Datei-Uploads"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filter"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Finden Sie Antworten auf häufig gestellte Fragen zu Kan. Können Sie nicht finden, wonach Sie suchen? <0>Kontaktieren Sie uns</0> gerne."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Schriftgröße"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Für langfristige Nachhaltigkeit erkennen wir an, dass alle guten Open-Source-Projekte eine Einnahmequelle benötigen. Unsere stammt aus dem kostenpflichtigen Cloud-Angebot für Workspaces mit mehreren Benutzern und für benutzerdefinierte Workspace-Slugs. Es besteht keine Verpflichtung zur Nutzung, und Sie können die Software kostenlos auf Ihrer eigenen Infrastruktur selbst hosten."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Kostenlos"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Kostenlos für alle"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Kostenloser Plan"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Kostenlos, für immer"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Vollständiger API-Zugriff"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Vollzeit"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Spaß"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Allgemein"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Loslegen"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Jetzt starten"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Legen Sie los, indem Sie ein neues {0} erstellen"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Legen Sie los, indem Sie eine neue Liste erstellen"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Starten Sie noch heute kostenlos"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Starten Sie kostenlos ohne Nutzungsbeschränkungen. Für die Zusammenarbeit upgraden Sie auf einen Plan, der zur Größe Ihres Teams passt."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "In der Cloud starten"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Erste Schritte"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub verbunden"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub getrennt"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Zur Startseite"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Zur App"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Zu den Boards"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Zur Startseite"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Zu den Mitgliedern"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Zu den Einstellungen"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Zu Vorlagen gehen"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Gut geeignet für Einsteiger, die nur die wichtigsten Funktionen benötigen."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Gast"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Hohe Priorität"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Eingestellt"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "HMAC-Secret zur Signaturverifizierung"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Hosten Sie Kan auf Ihrer eigenen Infrastruktur. Ideal für Organisationen, die vollständige Kontrolle über ihre Daten benötigen."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Wie erhalte ich eine benutzerdefinierte URL?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Wie importiere ich meine Trello-Boards?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Wie lade ich Teammitglieder ein?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Wie hoste ich selbst?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Wie wird das Projekt finanziert?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Ich bestätige, dass alle meine Kontodaten dauerhaft gelöscht werden und möchte fortfahren."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Ich bestätige, dass alle Workspace-Daten dauerhaft gelöscht werden und möchte fortfahren."
   },
   "VOwhhz": {
-    "translation": "ID kopiert",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID kopiert"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Ideen"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Ideen zur Verbesserung dieser Seite..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importieren"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Import abgeschlossen"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Import fehlgeschlagen"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importieren Sie Ihre Trello-Boards und legen Sie direkt los."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Wichtig"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importieren von Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Das Importieren Ihrer Trello-Boards in Kan ist einfach. Sie können unserer Schritt-für-Schritt-Anleitung <0>hier</0> folgen."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Imports"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "in"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "In Bearbeitung"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inaktiv"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Einzelpersonen"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integrationen"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Intelligente Suche"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Interviewing"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Ungültige E-Mail-Adresse"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Ungültige Einladung"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Einladen"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Einladungslink kopiert"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Einladungslink in Zwischenablage kopiert"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Einladungslinks"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Einladungslinks erfordern ein Team- oder Pro-Abonnement. Bitte upgraden Sie Ihren Workspace."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Mitglied einladen"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Das Einladen von Mitgliedern erfordert einen Team-Plan. Sie werden zur Upgrade-Seite Ihres Workspaces weitergeleitet."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Workspace beitreten"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Workspace beitreten | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban ist besser im Team. Perfekt für kleine und wachsende Teams, die zusammenarbeiten möchten."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban neu gedacht"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Beachten Sie, dass diese Aktion nicht rückgängig gemacht werden kann."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Tastaturkürzel"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Labels"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Labels & Filter"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Labels & Filter"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Sprache"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Groß"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Launch-Angebot"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Launch-Angebot: Unbegrenzte Mitglieder mit Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Launch-Angebot: Unbegrenzte Plätze für nur 29 $/Monat mit Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Mehr erfahren"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Lernen"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Rechtliches"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Lizenz"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Hell"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Eingeschränkter API-Zugriff"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Link kopiert"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Liste"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Listenname"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Listen"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Weitere Aktivitäten laden"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Berechtigungen werden geladen ..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Wird geladen ..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Anmelden | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Abmelden"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Langfristig"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Weltweit von Teams geliebt"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Niedrige Priorität"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "Magic-Link"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Vorlage erstellen"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Mitglieder verwalten"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "hat ein Checklistenelement als unvollständig markiert"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "hat Checklistenelement <0>{0}</0> als unvollständig markiert"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Mittel"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Mittlere Priorität"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Mitglied"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Mitglieder"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Mitglieder | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Erwähnungen"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Montag"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Monatlich"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "Monatliche Abrechnung"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "In andere Liste verschieben"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "In Liste verschieben"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "hat die Karte von <0>{0}</0> nach <1>{1}</1> verschoben"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "hat die Karte in eine andere Liste verschoben"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Mein Webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Name"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navigation"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Benötigen Sie Hilfe?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Neu"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Neue {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Neuer API-Schlüssel"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Neue Karte"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Neue Checkliste"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Neuer Import"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Neues Label"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Neue Liste"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Neues Passwort ist erforderlich"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "Neues Passwort muss sich vom aktuellen Passwort unterscheiden"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Neue Vorlage"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Neues Ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Neuer Webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Neuer Workspace"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Nächste Schritte"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Keine {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Keine archivierten Boards"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Derzeit sind keine Authentifizierungsmethoden verfügbar"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Keine Boards gefunden"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Keine Kreditkarte erforderlich"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Keine Daten"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Für diesen Anhang ist keine Download-URL verfügbar."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Keine Tastenkombinationen registriert."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Keine Listen"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Es wurden noch keine Listen erstellt"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Keine Projekte gefunden"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Keine Ergebnisse für \"{debouncedQuery}\" gefunden."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Für diesen Workspace wurden noch keine Rollen gefunden."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Keine Webhooks konfiguriert. Fügen Sie einen Webhook hinzu, um Benachrichtigungen zu erhalten."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Angebot"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-Premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "On-Premise-Bereitstellungsoption"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Sobald Sie Ihr Konto löschen, gibt es kein Zurück mehr. Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Sobald Sie Ihren Workspace löschen, gibt es kein Zurück mehr. Diese Aktion kann nicht rückgängig gemacht werden."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Befehlsmenü öffnen"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Tastenkombinationen öffnen"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open Source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Open-Source-Freunde"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "oder"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organisieren und finden Sie Karten schnell mit leistungsstarken Filterwerkzeugen."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "OSS Friends"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Überfällig"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Überschreibungen gelöscht"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Behalten Sie die Kontrolle über Ihre Daten"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Seite nicht gefunden"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Teilzeit"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Passwort geändert"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Passwort ist für die Anmeldung erforderlich."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Passwort ist für die Registrierung erforderlich."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "Passwort muss mindestens 8 Zeichen lang sein"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Passwörter stimmen nicht überein"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Pausiert"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Zahlungshäufigkeit"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Ausstehend"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "pro Benutzer/Monat"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Preisgestaltung pro Arbeitsplatz"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Perfekt für kleine und wachsende Teams, die zusammenarbeiten möchten."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Berechtigung"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Berechtigungen"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Berechtigungen zurückgesetzt"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Berechtigungen aktualisiert"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Persönliches Projekt"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Wählen Sie einen Tarif, um loszulegen. Alle kostenpflichtigen Tarife beinhalten eine 14-tägige kostenlose Testphase."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Geplant"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planung"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Plattform"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Bitte bestätigen Sie Ihr neues Passwort"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Bitte geben Sie eine gültige E-Mail-Adresse ein"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Bitte geben Sie einen gültigen Namen ein"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Bitte geben Sie ein gültiges Passwort ein"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Bitte geben Sie eine gültige URL ein"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Bitte geben Sie eine gültige YouTube-URL ein"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Bitte wählen Sie eine Datei zum Hochladen aus."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Bitte versuchen Sie es später erneut oder kontaktieren Sie den Kundensupport."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Bitte versuchen Sie es später erneut."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Bitte versuchen Sie es erneut."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Position in Liste (0 = erste, leer lassen für Ende)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Preise"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Priorisierter E-Mail-Support"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Datenschutzerklärung"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privat"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Pro-Plan"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Pro-Plan ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Profilbild aktualisiert"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Profilbild"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Öffentlich"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Veröffentlichung"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Frage"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Fragen?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Quick Win"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Recruiting"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Abgelehnt"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Remote"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Entfernen"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Aus Favoriten entfernen"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Mitglied entfernen"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "hat {0} Labels entfernt: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "hat ein Label von der Karte entfernt"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "hat ein Mitglied von der Karte entfernt"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "hat einen Anhang entfernt"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "hat einen Anhang entfernt <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Aus Favoriten entfernt"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "hat Label entfernt <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "hat das Fälligkeitsdatum entfernt"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "hat eine Checkliste umbenannt"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "hat Checkliste umbenannt <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "hat Checklistenelement umbenannt in <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Angefordert"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Recherche"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Auf Rollenstandards zurücksetzen"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Auflösung"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Ressourcen"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Review"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Roadmap"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Rolle"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Rolle aktualisiert"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Rollen & Berechtigungen"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Auf eigener Infrastruktur betreiben"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Samstag"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Speichern"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Änderungen speichern"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Sparen Sie Zeit mit wiederverwendbaren Board-Vorlagen."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Screening"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Boards und Karten durchsuchen..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Secret (optional)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Secret darf 512 Zeichen nicht überschreiten"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Sicherheit"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Sehen Sie, was unsere Nutzer über Kan sagen"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Liste auswählen"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Alle auswählen"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Wählen Sie mindestens ein Ereignis aus"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Quelle auswählen"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Self-Hosting"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Self-Hosting mit Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "hat sich die Karte selbst zugewiesen"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Feedback senden"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Test senden"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Senior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Fälligkeitsdatum festlegen"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "hat das Fälligkeitsdatum festgelegt"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Richten Sie Ihren Workspace ein"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Einstellungen"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Einstellungen | Konto"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Einstellungen | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Einstellungen | Abrechnung"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Einstellungen | Integrationen"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Einstellungen | Berechtigungen"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Einstellungen | Webhooks"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Einstellungen | Workspace"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Tastenkombinationen"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Anmelden"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Anmelden"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Abmelden"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Registrieren"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Registrieren | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Registrierung deaktiviert"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "Die Registrierung ist derzeit deaktiviert. Bitte versuchen Sie es später erneut."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Registrieren mit "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Einfache Preisgestaltung"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Einfaches, visuelles Aufgabenmanagement, das einfach funktioniert. Verschieben Sie Karten per Drag-and-drop, arbeiten Sie mit Ihrem Team zusammen und erledigen Sie mehr."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Klein"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Social Media"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Softwareentwicklung"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Auf Github mit Stern markieren"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "14-tägige kostenlose Testversion starten"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Kostenlos starten. Upgraden Sie, wenn Ihr Team wächst. Keine versteckten Gebühren, keine Verträge."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Status"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Abonnement erforderlich"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Erfolg"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Sonntag"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Optimieren Sie Ihren Workspace für nur 29 $/Monat. Das erhalten Sie:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Support"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Unterstützen Sie die Entwicklung des Projekts"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "System"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Team"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Team-Plan"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Teams"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Vorlage"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Vorlage erstellt"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Vorlage erfolgreich erstellt"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Der Vorlagenname darf 100 Zeichen nicht überschreiten"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Vorlagenname ist erforderlich"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Vorlagen"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Nutzungsbedingungen"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Test"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Test fehlgeschlagen"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test gesendet"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test-Webhook erfolgreich gesendet!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Erfahrungsberichte"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Vielen Dank für Ihr Feedback!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "Das Board wurde archiviert."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "Das Board wurde wiederhergestellt."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "Die Karte wurde dupliziert."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "Das eingegebene aktuelle Passwort ist falsch."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "Der Hauptunterschied zwischen Kan und Trello besteht darin, dass Kan Open Source ist und es jedem ermöglicht, unseren Code einzusehen, zu ändern und dazu beizutragen. Unser Cloud-Angebot bietet außerdem keine Einschränkungen bei den Funktionen für die individuelle Nutzung, während Trello grundlegende Funktionen wie die Anzahl der Boards, die Sie erstellen können, hinter einer Paywall sperrt."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "Die Berechtigungen des Mitglieds wurden aktualisiert."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "Die Rolle des Mitglieds wurde aktualisiert."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "Die Open-Source-<0/>Alternative zu Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "Die gesuchte Seite existiert nicht oder wurde verschoben."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "Die Sichtbarkeit Ihres Boards wurde auf {0} gesetzt."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Design"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Sie können nicht mehr auf diesen Workspace zugreifen."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Diese Aktion kann nicht rückgängig gemacht werden."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Dieser API-Schlüssel wird nur einmal angezeigt. Bitte speichern Sie ihn an einem sicheren Ort."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Dieses Board ist privat oder existiert nicht"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Diese Board-URL ist bereits vergeben"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Dieser Einladungslink ist ungültig oder abgelaufen."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "Die Berechtigungen dieses Mitglieds wurden auf die Standardwerte seiner Rolle zurückgesetzt."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Diese URL ist bereits vergeben"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Diese URL ist reserviert"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Dies führt zur dauerhaften Löschung aller mit diesem Workspace verbundenen Daten."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Dies führt zur dauerhaften Löschung aller mit Ihrem Konto verbundenen Daten."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Diese Workspace-URL ist bereits vergeben"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Diese Workspace-URL ist reserviert"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Dieser Workspace-Benutzername ist bereits vergeben"
   },
   "pEb95p": {
-    "translation": "Ticket-ID in die Zwischenablage kopiert",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "Ticket-ID in die Zwischenablage kopiert"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Titel"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Titel (optional)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "Zu erledigen"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Menü umschalten"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Token ist erforderlich"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Verfolgen Sie alle Kartenänderungen mit detailliertem Aktivitätsverlauf."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello getrennt"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Trello-Importe"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Triage"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Vertraut von schnellen Teams<0/>auf der ganzen Welt"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Checklistenelement konnte nicht hinzugefügt werden"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Kommentar konnte nicht hinzugefügt werden"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Label konnte nicht hinzugefügt werden"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Überschreibungen konnten nicht gelöscht werden"
   },
   "5MPY04": {
-    "translation": "ID konnte nicht kopiert werden",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "ID konnte nicht kopiert werden"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Link konnte nicht kopiert werden"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Karte konnte nicht erstellt werden"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Checkliste konnte nicht erstellt werden"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Liste konnte nicht erstellt werden"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Vorlage konnte nicht erstellt werden"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Webhook konnte nicht erstellt werden"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Workspace konnte nicht erstellt werden"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Anhang konnte nicht gelöscht werden"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Karte konnte nicht gelöscht werden"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Checkliste konnte nicht gelöscht werden"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Checklistenelement konnte nicht gelöscht werden"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Kommentar konnte nicht gelöscht werden"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Webhook konnte nicht gelöscht werden"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Karte konnte nicht dupliziert werden"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Karte konnte nicht verschoben werden"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Mitglied konnte nicht entfernt werden"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Checklisten-Element konnte nicht neu sortiert werden"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Berechtigungen konnten nicht zurückgesetzt werden"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Feedback konnte nicht gesendet werden"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Checkout kann nicht gestartet werden"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Webhook konnte nicht getestet werden"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Board konnte nicht aktualisiert werden"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Board-URL konnte nicht aktualisiert werden"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Board-Sichtbarkeit konnte nicht aktualisiert werden"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Karte konnte nicht aktualisiert werden"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Checkliste konnte nicht aktualisiert werden"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Checklisten-Element konnte nicht aktualisiert werden"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Kommentar konnte nicht aktualisiert werden"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Fälligkeitsdatum konnte nicht aktualisiert werden"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Labels konnten nicht aktualisiert werden"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Liste konnte nicht aktualisiert werden"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Mitglieder konnten nicht aktualisiert werden"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Berechtigungen konnten nicht aktualisiert werden"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Rolle konnte nicht aktualisiert werden"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Webhook konnte nicht aktualisiert werden"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Board wiederherstellen"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "hat <0>{0}</0> von der Karte entfernt"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "hat sich selbst von der Karte entfernt"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "In Prüfung"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Unbegrenztes Aktivitätsprotokoll"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Unbegrenzte Boards"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Unbegrenzte Boards, unbegrenzte Listen, unbegrenzte Karten. Keine Kreditkarte erforderlich."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Unbegrenzte Karten"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Unbegrenzte Kommentare"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Unbegrenzte Datei-Uploads"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Unbegrenzte Listen"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Unbegrenzte Mitglieder"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Unbegrenzte Mitglieder und ein individueller Workspace-Benutzername für Teams, die wachsen möchten."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Unbegrenzte Plätze und erweiterte Funktionen für wachsende Teams."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Abmelden"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Aktualisieren"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Label aktualisieren"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "hat ein Checklisten-Element aktualisiert"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "hat die Beschreibung aktualisiert"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "hat das Fälligkeitsdatum aktualisiert"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "hat den Titel aktualisiert"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "hat den Titel zu <0>{0}</0> aktualisiert"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Auf Pro upgraden"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Auf Pro upgraden (29 $/Monat)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Upload fehlgeschlagen"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Dringend"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "URL darf nur Buchstaben, Zahlen und Bindestriche enthalten"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "URL darf 2048 Zeichen nicht überschreiten"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "URL darf maximal 64 Zeichen lang sein"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "URL muss mindestens 3 Zeichen lang sein"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Vorlage verwenden"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Wird verwendet, um Webhook-Payloads zur Verifizierung zu signieren. Leer lassen, um das bestehende Secret beizubehalten."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Benutzer"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "Benutzer ist bereits Mitglied dieses Workspaces"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Video"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "API-Schlüssel anzeigen und verwalten."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Rechnungen und Abonnement anzeigen und verwalten."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Dokumentation anzeigen"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Nur ansehen"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Roadmap anzeigen."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Workspace anzeigen"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Sichtbarkeit"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Wir verwenden die <0>AGPL-3.0-Lizenz</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Wir konnten Ihre Einstellungen nicht aktualisieren. Bitte versuchen Sie es erneut."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Wir fangen gerade erst an. "
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook erstellt"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook erfolgreich erstellt"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook gelöscht"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook erfolgreich gelöscht"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Webhook-Name darf 255 Zeichen nicht überschreiten"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Webhook-Name ist erforderlich"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Webhook-Test fehlgeschlagen"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook aktualisiert"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook erfolgreich aktualisiert"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "Webhook-URL ist erforderlich"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooks"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Wochenbeginn"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Willkommen zurück"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Welche Lizenz verwenden Sie?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Was ist der Unterschied zwischen Kan und Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Als Trello 2011 auf den Markt kam, begeisterte es alle mit seiner sorgfältig gestalteten Einfachheit, aber im Laufe der Jahre verlor es seinen Zauber und entwickelte sich zu etwas, das eher \"Jira Lite\" ähnelt. Dieses Projekt ist unser Versuch, den ursprünglichen Zauber der Einfachheit von Trello in Open Source wiederzubeleben."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Warum ein Open-Source-Trello erstellen?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Workspace"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Workspace erfolgreich erstellt. Sie können später in den Einstellungen upgraden.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Workspace gelöscht"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Workspace-Beschreibung"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "Workspace-Beschreibung darf 280 Zeichen nicht überschreiten"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "Workspace-Beschreibung muss mindestens 3 Zeichen lang sein"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Workspace-Beschreibung aktualisiert"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Workspace-Mitglieder"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Workspace-Name"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Workspace-Name darf 64 Zeichen nicht überschreiten"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Workspace-Name ist erforderlich"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Der Workspace-Name muss mindestens 3 Zeichen lang sein"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Workspace-Name aktualisiert"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Workspace-Berechtigungen"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Workspace-Slug aktualisiert"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "Workspace-URL"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Workspace-Benutzername"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Schreiben"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Jährlich"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Ja, wir bieten einen dauerhaft kostenlosen Plan für die individuelle Nutzung an. Keine Einschränkungen, keine Paywalls, keine Limits."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Sie sind dabei, Ihr Passwort zu ändern."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Sie können diese später jederzeit in den Einstellungen ändern."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Sie können eine benutzerdefinierte Workspace-URL wie <0>kan.bn/kan</0> erhalten, indem Sie in Ihre <1>Workspace-Einstellungen</1> gehen und ein Pro-Workspace-Abonnement erwerben. Alle Abonnements helfen bei der Finanzierung der Projektentwicklung!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Sie können Teammitglieder einladen, indem Sie auf die Schaltfläche \"Einladen\" in der oberen rechten Ecke der <0>Mitgliederseite</0> klicken und deren E-Mail-Adresse eingeben. Sie erhalten eine E-Mail mit einem Link, um dem Workspace beizutreten."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Sie können selbst hosten, indem Sie den Anweisungen in unserem <0>Repo</0> folgen."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Sie haben keine Berechtigung"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Sie wurden erfolgreich angemeldet."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Sie haben sich erfolgreich registriert."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Sie wurden abgemeldet!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Sie haben unbegrenzte Plätze mit Ihrem Pro-Plan. Es fallen keine zusätzlichen Kosten für neue Mitglieder an!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Sie müssen Administrator sein, um Workspace-Berechtigungen zu verwalten."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Sie wurden eingeladen, einem Workspace auf kan.bn beizutreten."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Sie wurden eingeladen, einem Workspace beizutreten."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Ihr Konto wurde gelöscht."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Ihr Avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Ihre Boards wurden importiert."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Ihr Anzeigename wurde aktualisiert."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Ihre Datei wurde erfolgreich hochgeladen."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Ihr GitHub-Konto wurde verbunden."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Ihr GitHub-Konto wurde getrennt."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Ihr GitHub-Konto ist verbunden."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Ihr Passwort wurde geändert."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Ihr Profilbild wurde aktualisiert."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Ihre Projekte wurden importiert."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Ihr Trello-Konto wurde getrennt."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Ihr Trello-Konto ist verbunden."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Ihrem Abmelde-Link fehlt ein Token. Bitte öffnen Sie die neueste E-Mail und versuchen Sie es erneut."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Ihr Workspace"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Ihre Workspace-Beschreibung"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "Ihre Workspace-Beschreibung wurde aktualisiert."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Ihr Workspace wurde gelöscht."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Ihr Workspace-Name wurde aktualisiert."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "Ihr Workspace-Slug wurde aktualisiert."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "ihr-workspace"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "YouTube-URL"
   }
 }

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -59,7 +59,7 @@
       ],
       [
         "src/views/card/index.tsx",
-        317
+        331
       ]
     ],
     "translation": "{0} | {1}"
@@ -107,7 +107,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        462
+        486
       ]
     ],
     "translation": "{0} labels"
@@ -123,7 +123,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        557
+        563
       ]
     ],
     "translation": "{0} not found"
@@ -367,11 +367,11 @@
     "origin": [
       [
         "src/views/card/index.tsx",
-        468
+        484
       ],
       [
         "src/views/public/board/CardModal.tsx",
-        205
+        212
       ]
     ],
     "translation": "Activity"
@@ -558,7 +558,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        102
+        106
       ]
     ],
     "translation": "added {0} labels: <0>{labelList}</0>"
@@ -570,7 +570,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        132
+        137
       ]
     ],
     "translation": "added a checklist"
@@ -582,7 +582,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        135
+        140
       ]
     ],
     "translation": "added a checklist item"
@@ -594,7 +594,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        128
+        133
       ]
     ],
     "translation": "added a label to the card"
@@ -606,7 +606,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        130
+        135
       ]
     ],
     "translation": "added a member to the card"
@@ -618,7 +618,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        140
+        145
       ]
     ],
     "translation": "added an attachment"
@@ -634,7 +634,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        278
+        292
       ]
     ],
     "translation": "added an attachment <0>{0}</0>"
@@ -650,7 +650,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        208
+        222
       ]
     ],
     "translation": "added checklist <0>{0}</0>"
@@ -666,7 +666,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        232
+        246
       ]
     ],
     "translation": "added checklist item <0>{0}</0>"
@@ -682,7 +682,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        192
+        206
       ]
     ],
     "translation": "added label <0>{0}</0>"
@@ -937,6 +937,18 @@
       ]
     ],
     "translation": "An unexpected error occurred. Please try again later."
+  },
+  "dtxpK2": {
+    "translation": "Analyze",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
@@ -1233,7 +1245,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        172
+        186
       ]
     ],
     "translation": "assigned <0>{0}</0> to the card"
@@ -1457,15 +1469,15 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        530
+        536
       ],
       [
         "src/views/card/index.tsx",
-        317
+        331
       ],
       [
         "src/views/public/board/index.tsx",
-        125
+        132
       ]
     ],
     "translation": "Board"
@@ -1525,7 +1537,7 @@
     "origin": [
       [
         "src/views/public/board/index.tsx",
-        181
+        188
       ]
     ],
     "translation": "Board not found"
@@ -1589,7 +1601,7 @@
       ],
       [
         "src/views/public/board/index.tsx",
-        79
+        86
       ]
     ],
     "translation": "Board URL copied to clipboard"
@@ -1679,6 +1691,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
       [
         "src/views/boards/components/TemplateBoards.tsx",
         24
@@ -2165,7 +2181,7 @@
     "origin": [
       [
         "src/views/card/index.tsx",
-        317
+        331
       ]
     ],
     "translation": "Card"
@@ -2189,11 +2205,11 @@
     "origin": [
       [
         "src/views/card/index.tsx",
-        376
+        392
       ],
       [
         "src/views/card/index.tsx",
-        413
+        429
       ]
     ],
     "translation": "Card not found"
@@ -2205,7 +2221,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        328
+        346
       ]
     ],
     "translation": "Card title"
@@ -2217,7 +2233,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        308
+        314
       ],
       [
         "src/views/card/components/Dropdown.tsx",
@@ -2225,7 +2241,7 @@
       ],
       [
         "src/views/public/board/CardModal.tsx",
-        38
+        39
       ]
     ],
     "translation": "Card URL copied to clipboard"
@@ -2289,14 +2305,30 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        303
+        317
       ],
       [
         "src/views/card/components/ActivityList.tsx",
-        317
+        331
       ]
     ],
     "translation": "changed the due date to <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "changed the type to <0>{0}</0>",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
@@ -2413,7 +2445,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        227
+        247
       ]
     ],
     "translation": "Clear filters"
@@ -2445,7 +2477,7 @@
     "origin": [
       [
         "src/views/card/index.tsx",
-        367
+        383
       ],
       [
         "src/views/members/components/EditMemberPermissionsModal.tsx",
@@ -2469,6 +2501,18 @@
       ]
     ],
     "translation": "Code Review"
+  },
+  "i2BTio": {
+    "translation": "Coding",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
@@ -2569,7 +2613,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        137
+        142
       ]
     ],
     "translation": "completed a checklist item"
@@ -2585,7 +2629,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        249
+        263
       ]
     ],
     "translation": "completed checklist item <0>{0}</0>"
@@ -2923,7 +2967,6 @@
     "translation": "Copy members"
   },
   "7mrkyO": {
-    "translation": "Copy ticket ID",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
@@ -2932,7 +2975,8 @@
         "src/views/card/components/Dropdown.tsx",
         87
       ]
-    ]
+    ],
+    "translation": "Copy ticket ID"
   },
   "9PaIxv": {
     "message": "Core features",
@@ -2973,7 +3017,7 @@
       ],
       [
         "src/views/board/components/NewCardForm.tsx",
-        527
+        551
       ],
       [
         "src/views/board/components/NewListForm.tsx",
@@ -3001,7 +3045,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        537
+        561
       ]
     ],
     "translation": "Create card"
@@ -3093,7 +3137,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        424
+        448
       ],
       [
         "src/views/card/components/LabelSelector.tsx",
@@ -3109,11 +3153,11 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        92
+        94
       ],
       [
         "src/views/board/index.tsx",
-        671
+        677
       ]
     ],
     "translation": "Create new list"
@@ -3177,7 +3221,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        124
+        128
       ]
     ],
     "translation": "created the card"
@@ -3586,7 +3630,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        134
+        139
       ]
     ],
     "translation": "deleted a checklist"
@@ -3598,7 +3642,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        139
+        144
       ]
     ],
     "translation": "deleted a checklist item"
@@ -3614,7 +3658,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        224
+        238
       ]
     ],
     "translation": "deleted checklist <0>{0}</0>"
@@ -3630,7 +3674,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        267
+        281
       ]
     ],
     "translation": "deleted checklist item <0>{0}</0>"
@@ -3886,15 +3930,15 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        171
+        190
       ],
       [
         "src/views/board/components/NewCardForm.tsx",
-        479
+        503
       ],
       [
         "src/views/card/index.tsx",
-        153
+        163
       ]
     ],
     "translation": "Due date"
@@ -3906,7 +3950,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        132
+        145
       ]
     ],
     "translation": "Due next month"
@@ -3918,7 +3962,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        127
+        140
       ]
     ],
     "translation": "Due next week"
@@ -3930,7 +3974,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        117
+        130
       ]
     ],
     "translation": "Due today"
@@ -3942,7 +3986,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        122
+        135
       ]
     ],
     "translation": "Due tomorrow"
@@ -4850,6 +4894,10 @@
     "comments": [],
     "origin": [
       [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
         "src/components/FeedbackModal.tsx",
         59
       ],
@@ -4891,7 +4939,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        221
+        241
       ]
     ],
     "translation": "Filter"
@@ -5131,7 +5179,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        656
+        662
       ]
     ],
     "translation": "Get started by creating a new list"
@@ -5517,7 +5565,6 @@
     "translation": "I acknowledge that all of the workspace data will be permanently deleted and want to proceed."
   },
   "VOwhhz": {
-    "translation": "ID copied",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
@@ -5526,7 +5573,8 @@
         "src/views/card/components/Dropdown.tsx",
         64
       ]
-    ]
+    ],
+    "translation": "ID copied"
   },
   "iwr7AP": {
     "message": "Ideas",
@@ -5979,15 +6027,15 @@
       ],
       [
         "src/views/board/components/Filters.tsx",
-        155
+        168
       ],
       [
         "src/views/board/components/NewCardForm.tsx",
-        428
+        452
       ],
       [
         "src/views/card/index.tsx",
-        133
+        143
       ]
     ],
     "translation": "Labels"
@@ -6163,7 +6211,7 @@
       ],
       [
         "src/views/board/index.tsx",
-        306
+        312
       ],
       [
         "src/views/card/components/Dropdown.tsx",
@@ -6171,11 +6219,11 @@
       ],
       [
         "src/views/public/board/CardModal.tsx",
-        36
+        37
       ],
       [
         "src/views/public/board/index.tsx",
-        77
+        84
       ]
     ],
     "translation": "Link copied"
@@ -6191,7 +6239,7 @@
       ],
       [
         "src/views/card/index.tsx",
-        124
+        134
       ]
     ],
     "translation": "List"
@@ -6215,7 +6263,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        163
+        176
       ]
     ],
     "translation": "Lists"
@@ -6227,7 +6275,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        579
+        597
       ]
     ],
     "translation": "Load more activities"
@@ -6251,7 +6299,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        579
+        597
       ]
     ],
     "translation": "Loading..."
@@ -6363,7 +6411,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        138
+        143
       ]
     ],
     "translation": "marked a checklist item as incomplete"
@@ -6379,7 +6427,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        258
+        272
       ]
     ],
     "translation": "marked checklist item <0>{0}</0> as incomplete"
@@ -6427,11 +6475,11 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        55
+        57
       ],
       [
         "src/views/card/components/ActivityList.tsx",
-        88
+        92
       ],
       [
         "src/views/members/index.tsx",
@@ -6451,15 +6499,15 @@
       ],
       [
         "src/views/board/components/Filters.tsx",
-        147
+        160
       ],
       [
         "src/views/board/components/NewCardForm.tsx",
-        386
+        410
       ],
       [
         "src/views/card/index.tsx",
-        143
+        153
       ],
       [
         "src/views/members/index.tsx",
@@ -6582,7 +6630,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        160
+        174
       ]
     ],
     "translation": "moved the card from <0>{0}</0> to<1>{1}</1>"
@@ -6594,7 +6642,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        127
+        132
       ]
     ],
     "translation": "moved the card to another list"
@@ -6714,7 +6762,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        311
+        329
       ]
     ],
     "translation": "New card"
@@ -6766,7 +6814,7 @@
       ],
       [
         "src/views/board/index.tsx",
-        620
+        626
       ]
     ],
     "translation": "New list"
@@ -6938,7 +6986,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        137
+        150
       ]
     ],
     "translation": "No dates"
@@ -6974,7 +7022,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        652
+        658
       ]
     ],
     "translation": "No lists"
@@ -6986,7 +7034,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        657
+        663
       ]
     ],
     "translation": "No lists have been created yet"
@@ -7210,7 +7258,7 @@
     "origin": [
       [
         "src/views/board/components/Filters.tsx",
-        112
+        125
       ]
     ],
     "translation": "Overdue"
@@ -7621,6 +7669,10 @@
     "comments": [],
     "origin": [
       [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
         "src/components/DeleteLabelConfirmation.tsx",
         26
       ],
@@ -7638,7 +7690,7 @@
       ],
       [
         "src/views/board/components/NewCardForm.tsx",
-        193
+        209
       ],
       [
         "src/views/board/components/NewListForm.tsx",
@@ -7662,11 +7714,11 @@
       ],
       [
         "src/views/board/index.tsx",
-        218
+        224
       ],
       [
         "src/views/board/index.tsx",
-        274
+        280
       ],
       [
         "src/views/boards/components/ImportBoardsForm.tsx",
@@ -7742,11 +7794,11 @@
       ],
       [
         "src/views/card/index.tsx",
-        232
+        246
       ],
       [
         "src/views/card/index.tsx",
-        245
+        259
       ],
       [
         "src/views/members/components/DeleteMemberConfirmation.tsx",
@@ -7854,7 +7906,7 @@
       ],
       [
         "src/views/board/index.tsx",
-        315
+        321
       ],
       [
         "src/views/card/components/Dropdown.tsx",
@@ -7866,11 +7918,11 @@
       ],
       [
         "src/views/public/board/CardModal.tsx",
-        45
+        46
       ],
       [
         "src/views/public/board/index.tsx",
-        86
+        93
       ]
     ],
     "translation": "Please try again."
@@ -8181,7 +8233,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        116
+        120
       ]
     ],
     "translation": "removed {0} labels: <0>{labelList}</0>"
@@ -8193,7 +8245,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        129
+        134
       ]
     ],
     "translation": "removed a label from the card"
@@ -8205,7 +8257,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        131
+        136
       ]
     ],
     "translation": "removed a member from the card"
@@ -8217,7 +8269,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        141
+        146
       ]
     ],
     "translation": "removed an attachment"
@@ -8233,7 +8285,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        288
+        302
       ]
     ],
     "translation": "removed an attachment <0>{0}</0>"
@@ -8261,7 +8313,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        200
+        214
       ]
     ],
     "translation": "removed label <0>{0}</0>"
@@ -8273,11 +8325,11 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        144
+        149
       ],
       [
         "src/views/card/components/ActivityList.tsx",
-        324
+        338
       ]
     ],
     "translation": "removed the due date"
@@ -8289,7 +8341,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        133
+        138
       ]
     ],
     "translation": "renamed a checklist"
@@ -8305,7 +8357,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        216
+        230
       ]
     ],
     "translation": "renamed checklist <0>{0}</0>"
@@ -8321,7 +8373,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        240
+        254
       ]
     ],
     "translation": "renamed checklist item to <0>{0}</0>"
@@ -8347,6 +8399,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
       [
         "src/views/boards/components/TemplateBoards.tsx",
         89
@@ -8697,7 +8753,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        169
+        183
       ]
     ],
     "translation": "self-assigned the card"
@@ -8765,10 +8821,22 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        142
+        147
       ]
     ],
     "translation": "set the due date"
+  },
+  "d75lEw": {
+    "translation": "Set type",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
@@ -9086,6 +9154,18 @@
     ],
     "translation": "Solo"
   },
+  "LbPk58": {
+    "translation": "Spike",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
+  },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
@@ -9177,6 +9257,18 @@
       ]
     ],
     "translation": "Success"
+  },
+  "YledUl": {
+    "translation": "Suggestion",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
@@ -9297,11 +9389,11 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        530
+        536
       ],
       [
         "src/views/board/index.tsx",
-        566
+        572
       ]
     ],
     "translation": "Template"
@@ -9665,7 +9757,7 @@
     "origin": [
       [
         "src/views/public/board/index.tsx",
-        184
+        191
       ]
     ],
     "translation": "This board is private or does not exist"
@@ -9803,7 +9895,6 @@
     "translation": "This workspace username has already been taken"
   },
   "pEb95p": {
-    "translation": "Ticket ID copied to clipboard",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
@@ -9812,7 +9903,8 @@
         "src/views/card/components/Dropdown.tsx",
         66
       ]
-    ]
+    ],
+    "translation": "Ticket ID copied to clipboard"
   },
   "MHrjPM": {
     "message": "Title",
@@ -9954,6 +10046,30 @@
     ],
     "translation": "Trusted by fast-moving teams<0/>around the world"
   },
+  "+zy2Nq": {
+    "translation": "Type",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "Types",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
+  },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
@@ -9985,7 +10101,7 @@
     "origin": [
       [
         "src/views/card/index.tsx",
-        244
+        258
       ]
     ],
     "translation": "Unable to add label"
@@ -10003,7 +10119,6 @@
     "translation": "Unable to clear overrides"
   },
   "5MPY04": {
-    "translation": "Unable to copy ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
@@ -10012,7 +10127,8 @@
         "src/views/card/components/Dropdown.tsx",
         71
       ]
-    ]
+    ],
+    "translation": "Unable to copy ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
@@ -10021,7 +10137,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        313
+        319
       ],
       [
         "src/views/card/components/Dropdown.tsx",
@@ -10029,11 +10145,11 @@
       ],
       [
         "src/views/public/board/CardModal.tsx",
-        43
+        44
       ],
       [
         "src/views/public/board/index.tsx",
-        84
+        91
       ]
     ],
     "translation": "Unable to copy link"
@@ -10045,7 +10161,7 @@
     "origin": [
       [
         "src/views/board/components/NewCardForm.tsx",
-        190
+        206
       ]
     ],
     "translation": "Unable to create card"
@@ -10333,11 +10449,11 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        273
+        279
       ],
       [
         "src/views/card/index.tsx",
-        231
+        245
       ]
     ],
     "translation": "Unable to update card"
@@ -10409,7 +10525,7 @@
     "origin": [
       [
         "src/views/board/index.tsx",
-        217
+        223
       ],
       [
         "src/views/card/components/ListSelector.tsx",
@@ -10458,6 +10574,18 @@
     ],
     "translation": "Unable to update role"
   },
+  "HX2b+Q": {
+    "translation": "Unable to update type",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
+  },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
@@ -10493,7 +10621,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        183
+        197
       ]
     ],
     "translation": "unassigned <0>{0}</0> from the card"
@@ -10505,7 +10633,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        180
+        194
       ]
     ],
     "translation": "unassigned themselves from the card"
@@ -10753,7 +10881,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        136
+        141
       ]
     ],
     "translation": "updated a checklist item"
@@ -10765,7 +10893,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        126
+        130
       ]
     ],
     "translation": "updated the description"
@@ -10777,7 +10905,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        143
+        148
       ]
     ],
     "translation": "updated the due date"
@@ -10789,7 +10917,7 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        125
+        129
       ]
     ],
     "translation": "updated the title"
@@ -10805,10 +10933,22 @@
     "origin": [
       [
         "src/views/card/components/ActivityList.tsx",
-        152
+        157
       ]
     ],
     "translation": "updated the title to <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "updated the type",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
@@ -11049,7 +11189,7 @@
     "origin": [
       [
         "src/views/public/board/index.tsx",
-        153
+        160
       ]
     ],
     "translation": "View only"
@@ -11073,7 +11213,7 @@
     "origin": [
       [
         "src/views/public/board/index.tsx",
-        187
+        194
       ]
     ],
     "translation": "View workspace"
@@ -11349,7 +11489,7 @@
       ],
       [
         "src/views/board/index.tsx",
-        530
+        536
       ],
       [
         "src/views/boards/index.tsx",
@@ -11361,7 +11501,7 @@
       ],
       [
         "src/views/public/board/index.tsx",
-        125
+        132
       ],
       [
         "src/views/public/boards/index.tsx",
@@ -11718,11 +11858,11 @@
       ],
       [
         "src/views/board/index.tsx",
-        604
+        610
       ],
       [
         "src/views/board/index.tsx",
-        662
+        668
       ],
       [
         "src/views/boards/components/BoardsList.tsx",

--- a/apps/web/src/locales/es/messages.json
+++ b/apps/web/src/locales/es/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (editado)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", o consulta nuestro"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} se ha añadido a tus favoritos."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} se ha eliminado de tus favoritos."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} etiquetas"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} no encontrado"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Importar tablero (1)} other {Importar tableros ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Importar proyecto (1)} other {Importar proyectos ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/mes"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "$0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "$10/mes"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "$8/mes"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 usuario"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "Subidas de archivos de 10 mb"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "Prueba gratuita de 14 días · Cambia de plan o cancela en cualquier momento"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Página no encontrada | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Una aplicación kanban potente y flexible que te ayuda a organizar el trabajo, hacer seguimiento del progreso y obtener resultados, todo en un solo lugar."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Cuenta"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Cuenta eliminada"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Gestor de cuenta"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Acciones"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Activo"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Actividad"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Registro de actividad"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Registros de actividad"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Añadir / editar etiqueta"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Añadir una tarjeta"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Añadir un elemento..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Añadir lista de verificación"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Añadir comentario... (escribe '/' para abrir comandos o '@' para mencionar)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Añadir descripción... (escribe '/' para abrir comandos o '@' para mencionar)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Añadir detalles..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Añadir etiqueta"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Añadir miembro"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Añadir a favoritos"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Agregar webhook"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "añadió {0} etiquetas: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "añadió una lista de verificación"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "añadió un elemento de lista de verificación"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "añadió una etiqueta a la tarjeta"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "añadió un miembro a la tarjeta"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "añadió un archivo adjunto"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "añadió un archivo adjunto <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "añadió la lista de verificación <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "añadió el elemento de lista de verificación <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "añadió la etiqueta <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Añadido a favoritos"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Añadir un nuevo miembro costará {price} adicionales ({billingType}) por puesto."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Ajusta el recorte cuadrado para que se adapte a tu avatar."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Administrador"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Roles de administrador"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Controles avanzados de administrador"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Roles avanzados de administrador"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Seguridad avanzada, cumplimiento normativo y soporte dedicado para grandes organizaciones."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Todas las funciones gratuitas +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Todas las anulaciones de permisos de miembros se han restablecido a los valores predeterminados de su rol."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Todas las funciones Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Todos los sistemas operativos"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Todas las funciones de Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "¿Ya tienes una cuenta? <0><1>Inicia sesión</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Ocurrió un error al conectar tu cuenta de GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Ocurrió un error al desconectar tu cuenta de GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Se produjo un error al desconectar tu cuenta de Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Se produjo un error inesperado. Por favor, inténtalo de nuevo más tarde."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Anual"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Cualquiera con este enlace puede unirse a tu espacio de trabajo"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Clave de API creada"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Nombre de la clave de API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "El nombre de la clave de API no puede superar los 30 caracteres"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "El nombre de la clave de API es obligatorio"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Claves de API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Referencia de API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Solicitantes"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Aprobación"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Archivar tablero"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Archivado"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "¿Estás seguro de que quieres eliminar {entityLabel}?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "¿Está seguro de que desea eliminar el webhook \"{webhookName}\"? Esta acción no se puede deshacer."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "¿Estás seguro de que quieres eliminar el espacio de trabajo {0}?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "¿Estás seguro de que quieres eliminar este {0}?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "¿Estás seguro de que quieres eliminar esta tarjeta?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "¿Estás seguro de que quieres eliminar esta lista de verificación?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "¿Estás seguro de que quieres eliminar este comentario?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "¿Estás seguro de que quieres eliminar esta etiqueta?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "¿Estás seguro de que quieres eliminar tu cuenta?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "asignó <0>{0}</0> a la tarjeta"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Asignados"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Archivo adjunto subido"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Esperando al cliente"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Atrás"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Pendientes"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Kanban básico"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Hoja de ruta básica"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Ideal para individuos y creadores en solitario que están empezando"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Ideal para grandes organizaciones con necesidades avanzadas"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Ideal para equipos pequeños y en crecimiento que necesitan colaboración"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Ideal para equipos pequeños que desean colaborar y avanzar más rápido juntos."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Ideal para equipos que quieren escalar sin límites"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "facturado anualmente"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "facturado mensualmente"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Facturación"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Portal de facturación"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Artículo de blog"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Tablero"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Analíticas del tablero"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tablero archivado"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "El nombre del tablero no puede exceder los 100 caracteres"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "El nombre del tablero es obligatorio"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Tablero no encontrado"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Plantillas de tablero"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tablero desarchivado"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "La URL del tablero solo puede contener letras, números y guiones"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "La URL del tablero no puede exceder 60 caracteres"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "URL del tablero copiada al portapapeles"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "La URL del tablero debe tener al menos 3 caracteres"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Visibilidad del tablero"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Visibilidad del tablero actualizada"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Tableros"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Los tableros que archives aparecerán aquí."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Lluvia de ideas"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Error"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Reporte de error"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Puede añadir comentarios"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Puede crear tableros"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Puede crear tarjetas"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Puede crear listas"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Puede eliminar tableros"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Puede eliminar tarjetas"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Puede eliminar comentarios"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Puede eliminar listas"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Puede eliminar espacio de trabajo"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Puede editar tableros"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Puede editar tarjetas"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Puede editar comentarios"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Puede editar listas"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Puede editar roles y permisos de miembros"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Puede editar espacio de trabajo"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Puede invitar miembros"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Puede gestionar la configuración del espacio de trabajo"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Puede eliminar miembros"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Puede ver tableros"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Puede ver tarjetas"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Puede ver comentarios"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Puede ver listas"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Puede ver miembros"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Puede ver el espacio de trabajo"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Cancelar"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Tarjeta"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Tarjeta duplicada"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Tarjeta no encontrada"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Título de la tarjeta"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "URL de la tarjeta copiada al portapapeles"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Cambiar contraseña"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Cambia el tamaño de fuente de la aplicación."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Cambia tus preferencias de idioma."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "cambió la fecha de vencimiento a <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Echa un vistazo a algunos de nuestros proyectos de código abierto favoritos."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Revisa tu bandeja de entrada"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nombre de la lista de verificación"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Listas de verificación"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Elige un plan"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Elimina cualquier permiso personalizado de miembros para que todos los miembros solo hereden permisos de sus roles predeterminados."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Eliminar permisos personalizados"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Limpiar filtros"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Haz clic en el enlace que hemos enviado a {magicLinkRecipient} para iniciar sesión."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Cerrar"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Revisión de código"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Colabora sin problemas con tu equipo."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Colaboración"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Próximamente"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Comentarios"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Empresa"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Completar"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Control y propiedad completos:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "completó un elemento de la lista de verificación"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "completó el elemento de la lista de verificación <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Roles de usuario y permisos configurables"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Configure webhooks para recibir notificaciones cuando se creen, actualicen, muevan o eliminen tarjetas."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Configura qué acciones están permitidas para cada rol del espacio de trabajo. Estos permisos se aplican a todos los miembros con ese rol."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Confirma tus preferencias de correo electrónico:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Confirma tu nueva contraseña"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Conectar"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Conectar GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Conectar Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Conecta tus herramientas favoritas para optimizar tu flujo de trabajo."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Conecta tu cuenta de GitHub para importar proyectos."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Conecta tu cuenta de Trello para importar tableros."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Contacto"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Contactar con ventas"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Contáctanos"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Creación de contenido"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Continuar"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Continuar con "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Continuar con {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Controla quién puede ver y editar tus tableros."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Convertir en enlace"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Copiar enlace del tablero"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Copiar enlace de la tarjeta"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Copiar listas de verificación"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Copiar etiquetas"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Copiar enlace a la tarjeta"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Copiar miembros"
   },
   "7mrkyO": {
-    "translation": "Copiar ID del ticket",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Copiar ID del ticket"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Funciones principales"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Crear {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Crear otro"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Crear clave API"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Crear tarjeta"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Crear lista de verificación"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Crear enlace de invitación"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Crear etiqueta"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Crear lista"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Crear nuevo {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Crear nueva clave"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Crear nueva etiqueta"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Crear nueva lista"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Crear plantilla"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Crear webhook"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Crear espacio de trabajo"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Creado"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "creó la tarjeta"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Crítico"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Recorta tu avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Se requiere la contraseña actual"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Plantillas de tablero personalizadas"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Marca personalizada"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Dominio personalizado"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Permisos personalizados"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "SLA personalizado"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Las URLs personalizadas requieren actualizar a un plan Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Nombre de usuario personalizado"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Los nombres de usuario personalizados requieren actualizar a un plan Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "URL del espacio de trabajo personalizada"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Nombre de usuario del espacio de trabajo personalizado"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Atención al cliente"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Oscuro"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Desactivar enlace de invitación"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Gestor de cuenta dedicado"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Nombre de usuario predeterminado"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Eliminar"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Eliminar cuenta"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Eliminar tablero"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Eliminar tarjeta"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Eliminar comentario"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Eliminar lista"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Eliminar plantilla"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Eliminar webhook"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Eliminar espacio de trabajo"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "eliminó una lista de verificación"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "eliminó un elemento de la lista de verificación"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "eliminó la lista de verificación <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "eliminó el elemento de la lista de verificación <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Diseño"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Desconectar GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Desconectar Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Discute y colabora en tarjetas."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Nombre para mostrar"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "El nombre para mostrar no puede exceder 280 caracteres"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "El nombre para mostrar debe tener al menos 3 caracteres"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Nombre para mostrar actualizado"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "¿Ofrecéis un plan gratuito?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "¿Quieres cancelar la suscripción?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Documentación"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "¿No tienes una cuenta? <0><1>Regístrate</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Hecho"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Error en la descarga"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Fecha de vencimiento"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Vence el próximo mes"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Vence la próxima semana"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Vence hoy"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Vence mañana"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplicar"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Duplicar tarjeta"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplicando…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Editar"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Editar URL del tablero"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Editar comentario"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Editar etiqueta"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Editar permisos"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Editar webhook"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Editar URL del espacio de trabajo"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Editar video de YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Editando"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "email"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "Email"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Notificaciones por email"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Notificaciones por email para menciones"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Visibilidad del email"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Fin de la lista"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Ingeniería"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Mejora"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Introduce un título personalizado"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Ingrese el nuevo secreto para actualizar"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Introduce tu contraseña actual"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Introduce tu contraseña actual y elige una nueva contraseña segura."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Introduce tu dirección de email"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Introduce tu nombre"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Introduce tu nueva contraseña"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Introduce tu contraseña"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Error"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Error al cambiar la contraseña"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Error al conectar GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Error al crear el enlace de invitación"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Error al desactivar el enlace de invitación"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Error al eliminar la cuenta"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Error al eliminar la etiqueta"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Error al eliminar el espacio de trabajo"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Error al desconectar GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Error al desconectar Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Error al invitar al miembro"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Error al actualizar el nombre para mostrar"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Error al actualizar la descripción del espacio de trabajo"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Error al actualizar el nombre del espacio de trabajo"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Error al actualizar la URL del espacio de trabajo"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Error al actualizar la suscripción"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Error al actualizar a Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Error al subir la imagen de perfil"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Eventos"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Todo lo del plan gratuito, más:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Todo lo que necesitas, gratis para siempre. Tableros ilimitados, listas ilimitadas, tarjetas ilimitadas. Actualiza cuando quieras."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Ejecución"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Hoja de ruta extendida"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "No se pudo aceptar la invitación. Por favor, inténtalo de nuevo más tarde o contacta con atención al cliente."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "No se pudo copiar el enlace de invitación"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "No se pudo crear el tablero"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Error al crear el webhook"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Error al eliminar el webhook"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "No se pudo obtener la información del vídeo"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "No se pudo iniciar sesión con {0}. Por favor, inténtalo de nuevo."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Error al probar el webhook"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Error al actualizar el webhook"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "No se pudo subir el archivo adjunto. Por favor, inténtalo de nuevo."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "Preguntas frecuentes"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "Preguntas frecuentes"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Función"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Solicitud de función"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Funciones"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Comentarios"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Comentarios enviados"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Subida de archivos"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filtrar"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Encuentra respuestas a preguntas frecuentes sobre Kan. ¿No encuentras lo que buscas? No dudes en <0>contactarnos</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Tamaño de fuente"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Para la sostenibilidad a largo plazo, reconocemos que todos los buenos proyectos de código abierto necesitan una fuente de ingresos. La nuestra proviene de la oferta de pago en la nube para espacios de trabajo con múltiples usuarios y para slugs de espacio de trabajo personalizados. No hay obligación de usarla, y puedes alojar el software en tu propia infraestructura de forma gratuita."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Gratis"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Gratis para todos"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Plan gratuito"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Gratis, para siempre"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Acceso completo a la API"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Tiempo completo"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Diversión"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "General"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Comenzar"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Comenzar"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Comienza creando un nuevo {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Comienza creando una nueva lista"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Comienza gratis hoy"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Comienza gratis, sin límites de uso. Para colaboración, actualiza a un plan que se ajuste al tamaño de tu equipo."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Comenzar en la nube"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Primeros pasos"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub conectado"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub desconectado"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Ir al inicio"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Ir a la aplicación"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Ir a tableros"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Ir a la página principal"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Ir a miembros"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Ir a configuración"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Ir a plantillas"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Ideal para personas que comienzan y solo necesitan lo esencial."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Invitado"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Prioridad alta"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Contratado"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Secreto HMAC para verificación de firma"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Aloja Kan en tu propia infraestructura. Ideal para organizaciones que necesitan control completo sobre sus datos."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "¿Cómo obtengo una URL personalizada?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "¿Cómo importo mis tableros de Trello?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "¿Cómo invito a miembros del equipo?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "¿Cómo hago el auto-alojamiento?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "¿Cómo se financia el proyecto?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Reconozco que todos los datos de mi cuenta se eliminarán permanentemente y quiero continuar."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Reconozco que todos los datos del espacio de trabajo se eliminarán permanentemente y quiero continuar."
   },
   "VOwhhz": {
-    "translation": "ID copiado",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID copiado"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Ideas"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Ideas para mejorar esta página..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importar"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Importación completada"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Importación fallida"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importa tus tableros de Trello y empieza a trabajar de inmediato."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Importante"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importando desde Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Importar tus tableros de Trello a Kan es fácil. Puedes seguir nuestra guía paso a paso <0>aquí</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Importaciones"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "en"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "En progreso"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inactivo"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Individuales"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integraciones"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Búsqueda inteligente"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Entrevistando"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Dirección de correo electrónico no válida"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Invitación no válida"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Invitar"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Enlace de invitación copiado"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Enlace de invitación copiado al portapapeles"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Enlaces de invitación"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Los enlaces de invitación requieren una suscripción Team o Pro. Por favor, actualiza tu espacio de trabajo."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Invitar miembro"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Invitar miembros requiere un plan Team. Serás redirigido para actualizar tu espacio de trabajo."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Unirse al espacio de trabajo"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Unirse al espacio de trabajo | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban es mejor en equipo. Perfecto para equipos pequeños y en crecimiento que buscan colaborar."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban reinventado"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Ten en cuenta que esta acción es irreversible."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Atajos de teclado"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Etiquetas"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Etiquetas y filtros"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Etiquetas y filtros"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Idioma"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Grande"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Oferta de lanzamiento"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Oferta de lanzamiento: obtén miembros ilimitados con Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Oferta de lanzamiento: asientos ilimitados por solo $29/mes con Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Más información"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Aprendizaje"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Legal"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licencia"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Claro"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Acceso limitado a la API"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Enlace copiado"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Lista"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Nombre de la lista"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Listas"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Cargar más actividades"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Cargando permisos..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Cargando..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Iniciar sesión | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Cerrar sesión"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Largo plazo"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Amado por equipos en todo el mundo"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Prioridad baja"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "enlace mágico"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Crear plantilla"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Gestionar miembros"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "marcó un elemento de la lista de verificación como incompleto"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "marcó el elemento de la lista de verificación <0>{0}</0> como incompleto"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Mediano"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Prioridad media"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Miembro"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Miembros"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Miembros | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Menciones"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Lunes"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Mensual"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "facturación mensual"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Mover a otra lista"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Mover a lista"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "movió la tarjeta de <0>{0}</0> a <1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "movió la tarjeta a otra lista"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Mi webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Nombre"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navegación"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "¿Necesitas ayuda?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Nuevo"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Nuevo {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nueva clave API"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Nueva tarjeta"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nueva lista de verificación"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nueva importación"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nueva etiqueta"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nueva lista"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Se requiere una nueva contraseña"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "La nueva contraseña debe ser diferente de la contraseña actual"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Nueva plantilla"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Nuevo ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Nuevo webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Nuevo espacio de trabajo"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Próximos pasos"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "No hay {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "No hay tableros archivados"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "No hay métodos de autenticación disponibles actualmente"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "No se encontraron tableros"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "No se requiere tarjeta de crédito"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Sin fechas"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "No hay URL de descarga disponible para este adjunto."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "No hay atajos de teclado registrados."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Sin listas"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Aún no se han creado listas"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "No se encontraron proyectos"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "No se encontraron resultados para \"{debouncedQuery}\"."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Aún no se encontraron roles para este espacio de trabajo."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "No hay webhooks configurados. Agregue un webhook para recibir notificaciones."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Oferta"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Opción de despliegue on-premise"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Una vez que elimines tu cuenta, no hay vuelta atrás. Esta acción no se puede deshacer."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Una vez que elimines tu espacio de trabajo, no hay vuelta atrás. Esta acción no se puede deshacer."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Abrir menú de comandos"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Abrir atajos de teclado"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Código abierto"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Amigos de código abierto"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "o"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organiza y encuentra tarjetas rápidamente con potentes herramientas de filtrado."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "Amigos OSS"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Atrasado"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Anulaciones eliminadas"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Tus datos te pertenecen"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Página no encontrada"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Tiempo parcial"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Contraseña cambiada"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Se requiere contraseña para iniciar sesión."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Se requiere contraseña para registrarse."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "La contraseña debe tener al menos 8 caracteres"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Las contraseñas no coinciden"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Pausado"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Frecuencia de pago"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Pendiente"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "por usuario/mes"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Precio por usuario"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Perfecto para equipos pequeños y en crecimiento que buscan colaborar."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Permiso"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Permisos"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Permisos restablecidos"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Permisos actualizados"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Proyecto personal"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Elige un plan para comenzar. Todos los planes de pago incluyen una prueba gratuita de 14 días."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Planificado"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planificación"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Plataforma"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Por favor, confirma tu nueva contraseña"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Por favor, introduce una dirección de correo electrónico válida"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Por favor, introduce un nombre válido"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Por favor, introduce una contraseña válida"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Por favor, ingrese una URL válida"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Por favor, introduce una URL de YouTube válida"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Por favor, selecciona un archivo para subir."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Por favor, inténtalo de nuevo más tarde o contacta con atención al cliente."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Por favor, inténtalo de nuevo más tarde."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Por favor, inténtalo de nuevo."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Posición en la lista (0 = primero, dejar vacío para el final)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Precios"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Soporte prioritario por correo electrónico"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Política de privacidad"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privado"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Plan Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Plan Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Imagen de perfil actualizada"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Foto de perfil"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Público"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Publicación"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Pregunta"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "¿Preguntas?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Victoria rápida"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Reclutamiento"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Rechazado"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Remoto"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Eliminar"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Eliminar de favoritos"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Eliminar miembro"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "eliminó {0} etiquetas: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "eliminó una etiqueta de la tarjeta"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "eliminó un miembro de la tarjeta"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "eliminó un adjunto"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "eliminó un adjunto <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Eliminado de favoritos"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "eliminó la etiqueta <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "eliminó la fecha de vencimiento"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "renombró una lista de verificación"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "renombró la lista de verificación <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "renombró el elemento de la lista de verificación a <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Solicitado"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Investigación"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Restablecer a valores predeterminados del rol"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Resolución"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Recursos"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Revisar"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Hoja de ruta"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Rol"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Rol actualizado"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Roles y permisos"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Ejecutar en tu propia infraestructura"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Sábado"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Guardar"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Guardar cambios"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Ahorra tiempo con plantillas de tableros reutilizables."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Selección"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Buscar tableros y tarjetas..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Secreto (opcional)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "El secreto no puede exceder los 512 caracteres"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Seguridad"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Mira lo que nuestros usuarios dicen sobre Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Seleccionar una lista"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Seleccionar todo"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Seleccione al menos un evento"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Seleccionar origen"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Autoalojamiento"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Autoalojar con Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "se autoasignó la tarjeta"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Enviar comentarios"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Enviar prueba"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Senior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Establecer fecha de vencimiento"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "estableció la fecha de vencimiento"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Configura tu espacio de trabajo"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Configuración"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Configuración | Cuenta"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Configuración | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Configuración | Facturación"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Configuración | Integraciones"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Configuración | Permisos"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Configuración | Webhooks"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Configuración | Espacio de trabajo"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Atajos"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Iniciar sesión"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Iniciar sesión"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Cerrar sesión"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Registrarse"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Registrarse | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Registro deshabilitado"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "El registro está actualmente deshabilitado. Por favor, inténtalo de nuevo más tarde."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Registrarse con "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Precios simples"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Gestión de tareas simple y visual que simplemente funciona. Arrastra y suelta tarjetas, colabora con tu equipo y haz más cosas."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Pequeño"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Redes sociales"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Desarrollo de software"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Individual"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Destacar en Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Iniciar prueba gratuita de 14 días"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Comienza gratis. Actualiza a medida que tu equipo crece. Sin tarifas ocultas, sin contratos."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Estado"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Suscripción requerida"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Éxito"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Domingo"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Potencia tu espacio de trabajo por solo $29/mes. Esto es lo que obtendrás:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Soporte"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Apoya el desarrollo del proyecto"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Sistema"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Equipo"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Plan de equipo"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Equipos"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Plantilla"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Plantilla creada"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Plantilla creada correctamente"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "El nombre de la plantilla no puede superar los 100 caracteres"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "El nombre de la plantilla es obligatorio"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Plantillas"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Términos de servicio"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Prueba"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Prueba fallida"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Prueba enviada"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "¡Webhook de prueba enviado correctamente!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Testimonios"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "¡Gracias por tus comentarios!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "El tablero ha sido archivado."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "El tablero ha sido desarchivado."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "La tarjeta ha sido duplicada."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "La contraseña actual que ingresaste es incorrecta."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "La principal diferencia entre Kan y Trello es que Kan es de código abierto, lo que permite a cualquiera ver, modificar y contribuir a nuestro código. Nuestra oferta en la nube tampoco ofrece restricciones en las funciones para uso individual, mientras que Trello bloquea funciones básicas como el número de tableros que puedes crear detrás de un muro de pago."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "Los permisos del miembro se han actualizado."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "El rol del miembro se ha actualizado."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "La alternativa de código abierto <0/> a Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "La página que buscas no existe o ha sido movida."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "La visibilidad de tu tablero se ha establecido en {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Tema"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "No podrán acceder a este espacio de trabajo."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Esta acción no se puede deshacer."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Esta clave API solo se mostrará una vez. Guárdala en un lugar seguro."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Este tablero es privado o no existe"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Esta URL de tablero ya está en uso"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Este enlace de invitación no es válido o ha caducado."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "Los permisos de este miembro se han restablecido a los valores predeterminados de su rol."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Esta URL ya está en uso"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Esta URL está reservada"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Esto resultará en la eliminación permanente de todos los datos asociados con este espacio de trabajo."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Esto resultará en la eliminación permanente de todos los datos asociados con tu cuenta."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Esta URL de espacio de trabajo ya está en uso"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Esta URL de espacio de trabajo está reservada"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Este nombre de usuario de espacio de trabajo ya está en uso"
   },
   "pEb95p": {
-    "translation": "ID del ticket copiado al portapapeles",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID del ticket copiado al portapapeles"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Título"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Título (opcional)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "Por hacer"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Alternar menú"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Se requiere el token"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Rastrea todos los cambios de tarjetas con un historial de actividad detallado."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello desconectado"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Importaciones de Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Clasificación"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Confiado por equipos ágiles<0/>de todo el mundo"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "No se pudo agregar el elemento de la lista de verificación"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "No se pudo agregar el comentario"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "No se pudo agregar la etiqueta"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "No se pudieron borrar las anulaciones"
   },
   "5MPY04": {
-    "translation": "No se pudo copiar el ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "No se pudo copiar el ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "No se pudo copiar el enlace"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "No se pudo crear la tarjeta"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "No se pudo crear la lista de verificación"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "No se pudo crear la lista"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "No se pudo crear la plantilla"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "No se pudo crear el webhook"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "No se pudo crear el espacio de trabajo"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "No se pudo eliminar el archivo adjunto"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "No se pudo eliminar la tarjeta"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "No se pudo eliminar la lista de verificación"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "No se pudo eliminar el elemento de la lista de verificación"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "No se pudo eliminar el comentario"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "No se pudo eliminar el webhook"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "No se puede duplicar la tarjeta"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "No se puede mover la tarjeta"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "No se pudo eliminar el miembro"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "No se pudo reordenar el elemento de la lista de verificación"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "No se pudieron restablecer los permisos"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "No se pudo enviar el comentario"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "No se pudo iniciar el proceso de pago"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "No se pudo probar el webhook"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "No se pudo actualizar el tablero"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "No se pudo actualizar la URL del tablero"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "No se pudo actualizar la visibilidad del tablero"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "No se pudo actualizar la tarjeta"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "No se pudo actualizar la lista de verificación"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "No se pudo actualizar el elemento de la lista de verificación"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "No se pudo actualizar el comentario"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "No se pudo actualizar la fecha de vencimiento"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "No se pudieron actualizar las etiquetas"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "No se pudo actualizar la lista"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "No se pudieron actualizar los miembros"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "No se pudieron actualizar los permisos"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "No se pudo actualizar el rol"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "No se pudo actualizar el webhook"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Desarchivar tablero"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "desasignó a <0>{0}</0> de la tarjeta"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "se desasignó a sí mismo de la tarjeta"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "En revisión"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Registro de actividad ilimitado"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Tableros ilimitados"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Tableros ilimitados, listas ilimitadas, tarjetas ilimitadas. No se requiere tarjeta de crédito."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Tarjetas ilimitadas"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Comentarios ilimitados"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Subidas de archivos ilimitadas"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Listas ilimitadas"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Miembros ilimitados"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Miembros ilimitados y un nombre de usuario personalizado para el espacio de trabajo para equipos listos para escalar."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Plazas ilimitadas y funciones avanzadas para equipos en crecimiento."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Cancelar suscripción"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Actualizar"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Actualizar etiqueta"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "actualizó un elemento de la lista de verificación"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "actualizó la descripción"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "actualizó la fecha de vencimiento"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "actualizó el título"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "actualizó el título a <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Actualizar a Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Actualizar a Pro ($29/mes)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Error al subir"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Urgente"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "La URL solo puede contener letras, números y guiones"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "La URL no puede exceder 2048 caracteres"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "La URL no puede superar los 64 caracteres"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "La URL debe tener al menos 3 caracteres"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Usar plantilla"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Se utiliza para firmar las cargas útiles del webhook para verificación. Dejar en blanco para mantener el secreto existente."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Usuario"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "El usuario ya es miembro de este espacio de trabajo"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Vídeo"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Ver y gestionar tus claves de API."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Ver y gestionar tu facturación y suscripción."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Ver documentación"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Solo lectura"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Ver nuestra hoja de ruta."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Ver espacio de trabajo"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Visibilidad"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Estamos usando la <0>licencia AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "No pudimos actualizar tus preferencias. Por favor, inténtalo de nuevo."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Apenas estamos empezando."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook creado"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook creado correctamente"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook eliminado"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook eliminado correctamente"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "El nombre del webhook no puede exceder 255 caracteres"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "El nombre del webhook es obligatorio"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "La prueba del webhook falló"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook actualizado"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook actualizado correctamente"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "La URL del webhook es obligatoria"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooks"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Día de inicio de semana"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Bienvenido de nuevo"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "¿Qué licencia estás usando?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "¿Cuál es la diferencia entre Kan y Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Cuando Trello se lanzó en 2011, sorprendió a todos con su simplicidad cuidadosamente diseñada, pero con los años perdió su magia y se convirtió en algo más parecido a \"Jira Lite\". Este proyecto es nuestro intento de recuperar la magia original de la simplicidad de Trello, en código abierto."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "¿Por qué hacer un Trello de código abierto?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Espacio de trabajo"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Espacio de trabajo creado correctamente. Puedes actualizar más tarde en la configuración.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Espacio de trabajo eliminado"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Descripción del espacio de trabajo"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "La descripción del espacio de trabajo no puede superar los 280 caracteres"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "La descripción del espacio de trabajo debe tener al menos 3 caracteres"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Descripción del espacio de trabajo actualizada"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Miembros del espacio de trabajo"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Nombre del espacio de trabajo"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "El nombre del espacio de trabajo no puede superar los 64 caracteres"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "El nombre del espacio de trabajo es obligatorio"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "El nombre del espacio de trabajo debe tener al menos 3 caracteres"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Nombre del espacio de trabajo actualizado"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Permisos del espacio de trabajo"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Slug del espacio de trabajo actualizado"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL del espacio de trabajo"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Nombre de usuario del espacio de trabajo"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Escribiendo"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Anual"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Sí, ofrecemos un plan gratuito para siempre para uso individual. Sin restricciones, sin muros de pago, sin límites."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Estás a punto de cambiar tu contraseña."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Siempre puedes cambiar esto más tarde en la configuración."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Puedes obtener una URL personalizada para tu espacio de trabajo, como <0>kan.bn/kan</0>, yendo a la <1>configuración de tu espacio de trabajo</1> y comprando una suscripción pro. ¡Todas las suscripciones ayudan a financiar el desarrollo del proyecto!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Puedes invitar a miembros del equipo haciendo clic en el botón \"Invitar\" en la esquina superior derecha de la <0>página de miembros</0> e ingresando su dirección de correo electrónico. Recibirán un correo con un enlace para unirse al espacio de trabajo."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Puedes auto-alojar siguiendo las instrucciones en nuestro <0>repositorio</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "No tienes permiso"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Has iniciado sesión correctamente."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Te has registrado correctamente."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "¡Te has dado de baja!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Tienes plazas ilimitadas con tu plan Pro. ¡No hay cargo adicional por nuevos miembros!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Necesitas ser administrador para gestionar los permisos del espacio de trabajo."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Has sido invitado a unirte a un espacio de trabajo en kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Has sido invitado a unirte a un espacio de trabajo."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Tu cuenta ha sido eliminada."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Tu avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Tus tableros han sido importados."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Tu nombre para mostrar ha sido actualizado."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Tu archivo se ha subido correctamente."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Tu cuenta de GitHub ha sido conectada."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Tu cuenta de GitHub ha sido desconectada."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Tu cuenta de GitHub está conectada."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Tu contraseña ha sido cambiada."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Tu imagen de perfil ha sido actualizada."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Tus proyectos han sido importados."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Tu cuenta de Trello ha sido desconectada."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Tu cuenta de Trello está conectada."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Tu enlace de cancelación de suscripción no tiene un token. Por favor, abre el último correo electrónico e inténtalo de nuevo."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Tu espacio de trabajo"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Descripción de tu espacio de trabajo"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "La descripción de tu espacio de trabajo ha sido actualizada."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Tu espacio de trabajo ha sido eliminado."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "El nombre de tu espacio de trabajo ha sido actualizado."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "El slug de tu espacio de trabajo ha sido actualizado."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "tu-espacio-de-trabajo"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "URL de YouTube"
   }
 }

--- a/apps/web/src/locales/fr/messages.json
+++ b/apps/web/src/locales/fr/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (modifié)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", ou consultez notre"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} a été ajouté à vos favoris."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} a été retiré de vos favoris."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} étiquettes"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} introuvable"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Importer le tableau (1)} other {Importer les tableaux ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Importer le projet (1)} other {Importer les projets ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/mois"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "0 $"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "10 $/mois"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "8 $/mois"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 utilisateur"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "Téléchargements de fichiers de 10 Mo"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "Essai gratuit de 14 jours · Changez de forfait ou annulez à tout moment"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Page introuvable | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Une application kanban puissante et flexible qui vous aide à organiser le travail, suivre les progrès et obtenir des résultats, le tout au même endroit."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Compte"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Compte supprimé"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Gestionnaire de compte"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Actions"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Actif"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Activité"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Journal d'activité"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Journaux d'activité"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Ajouter / modifier l'étiquette"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Ajouter une carte"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Ajouter un élément..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Ajouter une checklist"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Ajouter un commentaire... (tapez « / » pour ouvrir les commandes ou « @ » pour mentionner)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Ajouter une description... (tapez « / » pour ouvrir les commandes ou « @ » pour mentionner)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Ajouter des détails..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Ajouter une étiquette"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Ajouter un membre"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Ajouter aux favoris"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Ajouter un webhook"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "a ajouté {0} étiquettes : <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "a ajouté une checklist"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "a ajouté un élément de checklist"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "a ajouté une étiquette à la carte"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "a ajouté un membre à la carte"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "a ajouté une pièce jointe"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "a ajouté une pièce jointe <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "a ajouté la checklist <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "a ajouté l'élément de checklist <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "a ajouté l'étiquette <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Ajouté aux favoris"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "L'ajout d'un nouveau membre coûtera {price} supplémentaires ({billingType}) par siège."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Ajustez le recadrage carré pour adapter votre avatar."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Administrateur"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Rôles d'administrateur"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Contrôles d'administration avancés"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Rôles d'administrateur avancés"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Sécurité avancée, conformité et assistance dédiée pour les grandes organisations."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Toutes les fonctionnalités gratuites +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Toutes les permissions personnalisées des membres ont été réinitialisées aux valeurs par défaut de leur rôle."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Toutes les fonctionnalités Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Tous les systèmes sont opérationnels"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Toutes les fonctionnalités Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Vous avez déjà un compte ? <0><1>Se connecter</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Une erreur s'est produite lors de la connexion de votre compte GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Une erreur s'est produite lors de la déconnexion de votre compte GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Une erreur s'est produite lors de la déconnexion de votre compte Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Une erreur inattendue s'est produite. Veuillez réessayer ultérieurement."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Annuel"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Toute personne disposant de ce lien peut rejoindre votre espace de travail"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Clé API créée"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Nom de la clé API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "Le nom de la clé API ne peut pas dépasser 30 caractères"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "Le nom de la clé API est requis"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Clés API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Référence API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Candidats"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Approbation"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Archiver le tableau"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Archivé"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Êtes-vous sûr de vouloir supprimer {entityLabel} ?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Êtes-vous sûr de vouloir supprimer le webhook \"{webhookName}\" ? Cette action est irréversible."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Êtes-vous sûr de vouloir supprimer l'espace de travail {0} ?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Êtes-vous sûr de vouloir supprimer {0} ?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Êtes-vous sûr de vouloir supprimer cette carte ?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Êtes-vous sûr de vouloir supprimer cette checklist ?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Êtes-vous sûr de vouloir supprimer ce commentaire ?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Êtes-vous sûr de vouloir supprimer cette étiquette ?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Êtes-vous sûr de vouloir supprimer votre compte ?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "a assigné <0>{0}</0> à la carte"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Assignés"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Pièce jointe téléchargée"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "En attente du client"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Retour"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Kanban basique"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Roadmap basique"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Idéal pour les particuliers et créateurs solo qui débutent"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Idéal pour les grandes organisations avec des besoins avancés"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Idéal pour les petites équipes en croissance qui ont besoin de collaboration"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Idéal pour les petites équipes qui souhaitent collaborer et avancer plus rapidement ensemble."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Idéal pour les équipes qui veulent évoluer sans limites"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "facturé annuellement"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "facturé mensuellement"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Facturation"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Portail de facturation"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Article de blog"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Tableau"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Analytiques du tableau"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tableau archivé"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Le nom du tableau ne peut pas dépasser 100 caractères"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Le nom du tableau est requis"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Tableau introuvable"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Modèles de tableau"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tableau désarchivé"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "L'URL du tableau ne peut contenir que des lettres, des chiffres et des traits d'union"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "L'URL du tableau ne peut pas dépasser 60 caractères"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "URL du tableau copiée dans le presse-papiers"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "L'URL du tableau doit contenir au moins 3 caractères"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Visibilité du tableau"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Visibilité du tableau mise à jour"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Tableaux"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Les tableaux que vous archivez apparaîtront ici."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Brainstorming"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Bug"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Rapport de bug"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Peut ajouter des commentaires"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Peut créer des tableaux"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Peut créer des cartes"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Peut créer des listes"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Peut supprimer des tableaux"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Peut supprimer des cartes"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Peut supprimer des commentaires"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Peut supprimer des listes"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Peut supprimer l'espace de travail"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Peut modifier des tableaux"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Peut modifier des cartes"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Peut modifier des commentaires"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Peut modifier des listes"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Peut modifier les rôles et permissions des membres"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Peut modifier l'espace de travail"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Peut inviter des membres"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Peut gérer les paramètres de l'espace de travail"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Peut supprimer des membres"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Peut voir les tableaux"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Peut voir les cartes"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Peut voir les commentaires"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Peut voir les listes"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Peut voir les membres"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Peut voir l'espace de travail"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Annuler"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Carte"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Carte dupliquée"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Carte introuvable"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Titre de la carte"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "URL de la carte copiée dans le presse-papiers"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Changer le mot de passe"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Modifier la taille de police de l'application."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Modifiez vos préférences de langue."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "a modifié la date d'échéance en <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Découvrez quelques-uns de nos projets open source préférés."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Consultez votre boîte de réception"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nom de la checklist"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklists"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Choisir un forfait"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Effacez toutes les permissions personnalisées des membres afin que tous les membres héritent uniquement des permissions par défaut de leur rôle."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Effacer les permissions personnalisées"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Effacer les filtres"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Cliquez sur le lien que nous avons envoyé à {magicLinkRecipient} pour vous connecter."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Fermer"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Revue de code"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Collaborez facilement avec votre équipe."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Collaboration"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Bientôt disponible"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Commentaires"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Entreprise"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Terminé"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Contrôle et propriété complets :"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "a terminé un élément de checklist"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "a terminé l'élément de checklist <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Rôles utilisateur et permissions configurables"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Configurez des webhooks pour recevoir des notifications lorsque des cartes sont créées, mises à jour, déplacées ou supprimées."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Configurez les actions autorisées pour chaque rôle d'espace de travail. Ces permissions s'appliquent à tous les membres ayant ce rôle."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Confirmez vos préférences d'e-mail :"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Confirmez votre nouveau mot de passe"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Connecter"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Connecter GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Connecter Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Connectez vos outils préférés pour optimiser votre flux de travail."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Connectez votre compte GitHub pour importer des projets."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Connectez votre compte Trello pour importer des tableaux."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Contact"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Contacter les ventes"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Nous contacter"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Création de contenu"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Continuer"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Continuer avec "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Continuer avec {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Contrôlez qui peut voir et modifier vos tableaux."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Convertir en lien"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Copier le lien du tableau"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Copier le lien de la carte"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Copier les listes de contrôle"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Copier les étiquettes"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Copier le lien vers la carte"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Copier les membres"
   },
   "7mrkyO": {
-    "translation": "Copier l'ID du ticket",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Copier l'ID du ticket"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Fonctionnalités principales"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Créer {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Créer un autre"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Créer une clé API"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Créer une carte"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Créer une checklist"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Créer un lien d'invitation"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Créer une étiquette"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Créer une liste"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Créer un nouveau {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Créer une nouvelle clé"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Créer une nouvelle étiquette"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Créer une nouvelle liste"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Créer un modèle"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Créer un webhook"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Créer un espace de travail"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Créé"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "a créé la carte"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Critique"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Recadrer votre avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Le mot de passe actuel est requis"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Modèles de tableaux personnalisés"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Image de marque personnalisée"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Domaine personnalisé"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Permissions personnalisées"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "SLA personnalisé"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Les URL personnalisées nécessitent une mise à niveau vers un forfait Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Nom d'utilisateur personnalisé"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Les noms d'utilisateur personnalisés nécessitent une mise à niveau vers un forfait Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "URL d'espace de travail personnalisée"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Nom d'utilisateur d'espace de travail personnalisé"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Support client"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Sombre"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Désactiver le lien d'invitation"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Gestionnaire de compte dédié"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Nom d'utilisateur par défaut"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Supprimer"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Supprimer le compte"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Supprimer le tableau"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Supprimer la carte"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Supprimer le commentaire"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Supprimer la liste"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Supprimer le modèle"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Supprimer le webhook"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Supprimer l'espace de travail"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "a supprimé une checklist"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "a supprimé un élément de checklist"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "a supprimé la checklist <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "a supprimé l'élément de checklist <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Design"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Déconnecter GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Déconnecter Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Discutez et collaborez sur les cartes."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Nom d'affichage"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Le nom d'affichage ne peut pas dépasser 280 caractères"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Le nom d'affichage doit contenir au moins 3 caractères"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Nom d'affichage mis à jour"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Proposez-vous une offre gratuite ?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Voulez-vous vous désabonner ?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Documentation"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Vous n'avez pas de compte ? <0><1>Inscrivez-vous</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Terminé"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Échec du téléchargement"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Date d'échéance"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Échéance le mois prochain"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Échéance la semaine prochaine"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Échéance aujourd'hui"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Échéance demain"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Dupliquer"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Dupliquer la carte"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplication en cours…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Modifier"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Modifier l'URL du tableau"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Modifier le commentaire"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Modifier l'étiquette"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Modifier les permissions"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Modifier le webhook"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Modifier l'URL de l'espace de travail"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Modifier la vidéo YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Modification"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "e-mail"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "E-mail"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Notifications par e-mail"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Notifications par e-mail pour les mentions"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Visibilité de l'e-mail"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Fin de la liste"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Ingénierie"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Amélioration"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Saisissez un titre personnalisé"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Saisissez un nouveau secret pour mettre à jour"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Saisissez votre mot de passe actuel"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Saisissez votre mot de passe actuel et choisissez un nouveau mot de passe sécurisé."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Saisissez votre adresse e-mail"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Saisissez votre nom"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Saisissez votre nouveau mot de passe"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Saisissez votre mot de passe"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Entreprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Erreur"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Erreur lors du changement de mot de passe"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Erreur de connexion à GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Erreur lors de la création du lien d'invitation"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Erreur lors de la désactivation du lien d'invitation"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Erreur lors de la suppression du compte"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Erreur lors de la suppression de l'étiquette"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Erreur lors de la suppression de l'espace de travail"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Erreur de déconnexion de GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Erreur lors de la déconnexion de Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Erreur lors de l'invitation du membre"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Erreur lors de la mise à jour du nom d'affichage"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Erreur lors de la mise à jour de la description de l'espace de travail"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Erreur lors de la mise à jour du nom de l'espace de travail"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Erreur lors de la mise à jour de l'URL de l'espace de travail"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Erreur lors de la mise à niveau de l'abonnement"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Erreur lors de la mise à niveau vers Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Erreur lors du téléchargement de l'image de profil"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Événements"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Tout ce qui est inclus dans le forfait gratuit, plus :"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Tout ce dont vous avez besoin, gratuit pour toujours. Tableaux illimités, listes illimitées, cartes illimitées. Mise à niveau à tout moment."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Exécution"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Feuille de route étendue"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Échec de l'acceptation de l'invitation. Veuillez réessayer plus tard ou contacter le support client."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Échec de la copie du lien d'invitation"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Échec de la création du tableau"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Échec de la création du webhook"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Échec de la suppression du webhook"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Échec de la récupération des informations vidéo"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Échec de la connexion avec {0}. Veuillez réessayer."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Échec du test du webhook"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Échec de la mise à jour du webhook"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Échec du téléchargement de la pièce jointe. Veuillez réessayer."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "FAQ"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Fonctionnalité"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Demande de fonctionnalité"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Fonctionnalités"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Commentaires"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Commentaires envoyés"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Téléchargement de fichiers"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filtrer"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Trouvez des réponses aux questions courantes sur Kan. Vous ne trouvez pas ce que vous cherchez ? N'hésitez pas à <0>nous contacter</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Taille de police"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Pour une durabilité à long terme, nous reconnaissons que tous les bons projets open source ont besoin d'une source de revenus. La nôtre provient de l'offre cloud payante pour les espaces de travail avec plusieurs utilisateurs et pour les slugs d'espace de travail personnalisés. Il n'y a aucune obligation de l'utiliser, et vous pouvez héberger le logiciel sur votre propre infrastructure gratuitement."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Gratuit"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Gratuit pour tous"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Forfait gratuit"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Gratuit, pour toujours"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Accès complet à l'API"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Temps plein"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Amusant"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Général"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Commencer"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Commencer"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Commencez en créant un nouveau {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Commencez en créant une nouvelle liste"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Commencez gratuitement dès aujourd'hui"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Commencez gratuitement, sans limite d'utilisation. Pour la collaboration, passez à un forfait adapté à la taille de votre équipe."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Commencer sur le cloud"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Premiers pas"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub connecté"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub déconnecté"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Retour à l'accueil"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Aller à l'application"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Aller aux tableaux"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Aller à l'accueil"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Aller aux membres"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Aller aux paramètres"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Aller aux modèles"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Idéal pour les particuliers qui débutent et qui ont simplement besoin de l'essentiel."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Invité"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Priorité élevée"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Embauché"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Secret HMAC pour la vérification de signature"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Hébergez Kan sur votre propre infrastructure. Idéal pour les organisations qui ont besoin d'un contrôle total sur leurs données."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Comment obtenir une URL personnalisée ?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Comment importer mes tableaux Trello ?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Comment inviter des membres de l'équipe ?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Comment auto-héberger ?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Comment le projet est-il financé ?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Je reconnais que toutes les données de mon compte seront définitivement supprimées et je souhaite continuer."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Je reconnais que toutes les données de l'espace de travail seront définitivement supprimées et je souhaite continuer."
   },
   "VOwhhz": {
-    "translation": "ID copié",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID copié"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Idées"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Idées pour améliorer cette page..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importer"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Importation terminée"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Échec de l'importation"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importez vos tableaux Trello et démarrez rapidement."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Important"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importation depuis Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Importer vos tableaux Trello dans Kan est facile. Vous pouvez suivre notre guide étape par étape <0>ici</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Importations"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "dans"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "En cours"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inactif"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Particuliers"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Intégrations"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Recherche intelligente"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Entretien"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Adresse e-mail invalide"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Invitation invalide"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Inviter"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Lien d'invitation copié"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Lien d'invitation copié dans le presse-papiers"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Liens d'invitation"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Les liens d'invitation nécessitent un abonnement Team ou Pro. Veuillez mettre à niveau votre espace de travail."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Inviter un membre"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Inviter des membres nécessite un forfait Team. Vous serez redirigé pour mettre à niveau votre espace de travail."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Rejoindre l'espace de travail"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Rejoindre l'espace de travail | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban est meilleur en équipe. Parfait pour les petites équipes en croissance qui souhaitent collaborer."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban réinventé"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Gardez à l'esprit que cette action est irréversible."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Raccourcis clavier"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Étiquettes"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Étiquettes et filtres"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Étiquettes et filtres"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Langue"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Grande"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Offre de lancement"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Offre de lancement : obtenez un nombre illimité de membres avec Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Offre de lancement : places illimitées pour seulement 29 $/mois avec Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "En savoir plus"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Apprentissage"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Mentions légales"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licence"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Clair"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Accès API limité"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Lien copié"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Liste"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Nom de la liste"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Listes"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Charger plus d'activités"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Chargement des permissions..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Chargement..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Connexion | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Déconnexion"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Long terme"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Apprécié par des équipes du monde entier"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Priorité basse"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "lien magique"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Créer un modèle"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Gérer les membres"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "a marqué un élément de la checklist comme incomplet"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "a marqué l'élément de checklist <0>{0}</0> comme incomplet"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Moyenne"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Priorité moyenne"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Membre"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Membres"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Membres | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Mentions"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Lundi"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Mensuel"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "facturation mensuelle"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Déplacer vers une autre liste"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Déplacer vers la liste"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "a déplacé la carte de <0>{0}</0> vers <1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "a déplacé la carte vers une autre liste"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Mon webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Nom"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navigation"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Besoin d'aide ?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Nouveau"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Nouveau {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nouvelle clé API"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Nouvelle carte"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nouvelle checklist"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nouvel import"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nouvelle étiquette"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nouvelle liste"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Le nouveau mot de passe est requis"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "Le nouveau mot de passe doit être différent du mot de passe actuel"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Nouveau modèle"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Nouveau ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Nouveau webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Nouveau workspace"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Prochaines étapes"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Aucun {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Aucun tableau archivé"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Aucune méthode d'authentification n'est actuellement disponible"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Aucun tableau trouvé"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Aucune carte bancaire requise"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Aucune date"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Aucune URL de téléchargement disponible pour cette pièce jointe."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Aucun raccourci clavier enregistré."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Aucune liste"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Aucune liste n'a encore été créée"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Aucun projet trouvé"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Aucun résultat trouvé pour « {debouncedQuery} »."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Aucun rôle trouvé pour cet espace de travail pour le moment."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Aucun webhook configuré. Ajoutez un webhook pour recevoir des notifications."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Offre"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "Sur site"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Option de déploiement sur site"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Intégration"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Une fois votre compte supprimé, il n'y a pas de retour en arrière possible. Cette action ne peut pas être annulée."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Une fois votre espace de travail supprimé, il n'y a pas de retour en arrière possible. Cette action ne peut pas être annulée."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Ouvrir le menu de commandes"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Ouvrir les raccourcis clavier"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Amis open source"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "ou"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organisez et trouvez vos cartes rapidement grâce à des outils de filtrage puissants."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "Amis OSS"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "En retard"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Remplacements effacés"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Vos données vous appartiennent"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Page introuvable"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Temps partiel"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Mot de passe modifié"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Le mot de passe est requis pour se connecter."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Le mot de passe est requis pour s'inscrire."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "Le mot de passe doit contenir au moins 8 caractères"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Les mots de passe ne correspondent pas"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "En pause"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Fréquence de paiement"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "En attente"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "par utilisateur/mois"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Tarification par siège"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Parfait pour les petites équipes en croissance qui souhaitent collaborer."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Permission"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Permissions"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Permissions réinitialisées"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Permissions mises à jour"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Projet personnel"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Choisissez un forfait pour commencer. Tous les forfaits payants incluent un essai gratuit de 14 jours."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Planifié"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planification"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Plateforme"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Veuillez confirmer votre nouveau mot de passe"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Veuillez saisir une adresse e-mail valide"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Veuillez saisir un nom valide"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Veuillez saisir un mot de passe valide"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Veuillez saisir une URL valide"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Veuillez saisir une URL YouTube valide"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Veuillez sélectionner un fichier à télécharger."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Veuillez réessayer plus tard ou contacter le support client."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Veuillez réessayer plus tard."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Veuillez réessayer."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Position dans la liste (0 = premier, laisser vide pour la fin)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Tarifs"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Support e-mail prioritaire"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Politique de confidentialité"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privé"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Forfait Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Forfait Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Photo de profil mise à jour"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Photo de profil"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Public"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Publication"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Question"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Des questions ?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Victoire rapide"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Recrutement"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Rejeté"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "À distance"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Supprimer"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Retirer des favoris"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Retirer le membre"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "a retiré {0} étiquettes : <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "a retiré une étiquette de la carte"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "a retiré un membre de la carte"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "a retiré une pièce jointe"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "a retiré une pièce jointe <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Retiré des favoris"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "a retiré l'étiquette <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "a retiré la date d'échéance"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "a renommé une checklist"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "a renommé la checklist <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "a renommé l'élément de checklist en <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Demandé"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Recherche"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Réinitialiser aux valeurs par défaut du rôle"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Résolution"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Ressources"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Révision"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Roadmap"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Rôle"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Rôle mis à jour"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Rôles et permissions"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Exécuter sur votre propre infrastructure"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Samedi"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Enregistrer"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Enregistrer les modifications"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Gagnez du temps avec des modèles de tableaux réutilisables."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Filtrage"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Rechercher des tableaux et des cartes..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Secret (facultatif)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Le secret ne peut pas dépasser 512 caractères"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Sécurité"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Découvrez ce que nos utilisateurs disent de Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Sélectionner une liste"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Tout sélectionner"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Sélectionnez au moins un événement"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Sélectionner la source"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Auto-hébergement"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Auto-héberger avec Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "s'est auto-assigné la carte"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Envoyer un commentaire"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Envoyer un test"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Senior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Définir la date d'échéance"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "a défini la date d'échéance"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Configurer votre espace de travail"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Paramètres"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Paramètres | Compte"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Paramètres | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Paramètres | Facturation"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Paramètres | Intégrations"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Paramètres | Permissions"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Paramètres | Webhooks"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Paramètres | Espace de travail"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Raccourcis"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Se connecter"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Se connecter"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Se déconnecter"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "S'inscrire"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "S'inscrire | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Inscription désactivée"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "L'inscription est actuellement désactivée. Veuillez réessayer plus tard."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "S'inscrire avec "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Tarification simple"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Gestion de tâches visuelle et simple qui fonctionne tout simplement. Glissez-déposez des cartes, collaborez avec votre équipe et accomplissez davantage."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Petite"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Réseaux sociaux"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Développement logiciel"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Mettre une étoile sur Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Commencer l'essai gratuit de 14 jours"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Commencez gratuitement. Évoluez au rythme de votre équipe. Aucun frais caché, aucun contrat."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Statut"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Abonnement requis"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Succès"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Dimanche"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Boostez votre espace de travail pour seulement 29 $/mois. Voici ce que vous obtiendrez :"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Support"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Soutenir le développement du projet"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Système"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Équipe"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Forfait équipe"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Équipes"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Modèle"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Modèle créé"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Modèle créé avec succès"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Le nom du modèle ne peut pas dépasser 100 caractères"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Le nom du modèle est requis"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Modèles"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Conditions d'utilisation"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Tester"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Test échoué"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test envoyé"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Webhook de test envoyé avec succès !"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Témoignages"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Merci pour votre retour !"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "Le tableau a été archivé."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "Le tableau a été désarchivé."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "La carte a été dupliquée."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "Le mot de passe actuel que vous avez saisi est incorrect."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "La principale différence entre Kan et Trello est que Kan est open source, permettant à quiconque de consulter, modifier et contribuer à notre code. Notre offre cloud n'impose également aucune restriction sur les fonctionnalités pour un usage individuel, alors que Trello verrouille des fonctionnalités de base telles que le nombre de tableaux que vous pouvez créer derrière un paywall."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "Les permissions du membre ont été mises à jour."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "Le rôle du membre a été mis à jour."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "L'alternative open source <0/> à Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "La page que vous recherchez n'existe pas ou a été déplacée."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "La visibilité de votre tableau a été définie sur {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Thème"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Ils ne pourront pas accéder à cet espace de travail."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Cette action ne peut pas être annulée."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Cette clé API ne sera affichée qu'une seule fois. Veuillez la sauvegarder dans un endroit sécurisé."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Ce tableau est privé ou n'existe pas"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Cette URL de tableau est déjà utilisée"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Ce lien d'invitation est invalide ou a expiré."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "Les permissions de ce membre ont été réinitialisées aux valeurs par défaut de son rôle."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Cette URL est déjà prise"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Cette URL est réservée"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Cela entraînera la suppression définitive de toutes les données associées à cet espace de travail."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Cela entraînera la suppression définitive de toutes les données associées à votre compte."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Cette URL d'espace de travail est déjà utilisée"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Cette URL d'espace de travail est réservée"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Ce nom d'utilisateur d'espace de travail est déjà pris"
   },
   "pEb95p": {
-    "translation": "ID du ticket copié dans le presse-papiers",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID du ticket copié dans le presse-papiers"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Titre"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Titre (facultatif)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "À faire"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Basculer le menu"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Le jeton est requis"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Suivez toutes les modifications de carte avec un historique d'activité détaillé."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello déconnecté"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Imports Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Triage"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Utilisé par des équipes dynamiques<0/>partout dans le monde"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Impossible d'ajouter l'élément de liste de contrôle"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Impossible d'ajouter le commentaire"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Impossible d'ajouter l'étiquette"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Impossible d'effacer les remplacements"
   },
   "5MPY04": {
-    "translation": "Impossible de copier l'ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Impossible de copier l'ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Impossible de copier le lien"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Impossible de créer la carte"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Impossible de créer la liste de contrôle"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Impossible de créer la liste"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Impossible de créer le modèle"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Impossible de créer le webhook"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Impossible de créer l'espace de travail"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Impossible de supprimer la pièce jointe"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Impossible de supprimer la carte"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Impossible de supprimer la liste de contrôle"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Impossible de supprimer l'élément de liste de contrôle"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Impossible de supprimer le commentaire"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Impossible de supprimer le webhook"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Impossible de dupliquer la carte"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Impossible de déplacer la carte"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Impossible de retirer le membre"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Impossible de réorganiser l'élément de la checklist"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Impossible de réinitialiser les permissions"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Impossible d'envoyer le feedback"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Impossible de démarrer le paiement"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Impossible de tester le webhook"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Impossible de mettre à jour le tableau"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Impossible de mettre à jour l'URL du tableau"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Impossible de mettre à jour la visibilité du tableau"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Impossible de mettre à jour la carte"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Impossible de mettre à jour la checklist"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Impossible de mettre à jour l'élément de la checklist"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Impossible de mettre à jour le commentaire"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Impossible de mettre à jour la date d'échéance"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Impossible de mettre à jour les étiquettes"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Impossible de mettre à jour la liste"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Impossible de mettre à jour les membres"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Impossible de mettre à jour les permissions"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Impossible de mettre à jour le rôle"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Impossible de mettre à jour le webhook"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Désarchiver le tableau"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "a retiré <0>{0}</0> de la carte"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "s'est retiré de la carte"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "En cours de révision"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Journal d'activité illimité"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Tableaux illimités"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Tableaux illimités, listes illimitées, cartes illimitées. Aucune carte bancaire requise."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Cartes illimitées"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Commentaires illimités"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Téléchargements de fichiers illimités"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Listes illimitées"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Membres illimités"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Membres illimités et un nom d'utilisateur d'espace de travail personnalisé pour les équipes prêtes à évoluer."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Places illimitées et fonctionnalités avancées pour les équipes en croissance."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Se désabonner"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Mettre à jour"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Mettre à jour l'étiquette"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "a mis à jour un élément de la checklist"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "a mis à jour la description"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "a mis à jour la date d'échéance"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "a mis à jour le titre"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "a mis à jour le titre en <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Passer à Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Passer à Pro (29 $/mois)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Échec du téléchargement"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Urgent"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "L'URL ne peut contenir que des lettres, des chiffres et des traits d'union"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "L'URL ne peut pas dépasser 2048 caractères"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "L'URL ne peut pas dépasser 64 caractères"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "L'URL doit contenir au moins 3 caractères"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Utiliser le modèle"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Utilisé pour signer les charges utiles du webhook à des fins de vérification. Laissez vide pour conserver le secret existant."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Utilisateur"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "L'utilisateur est déjà membre de cet espace de travail"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Vidéo"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Consultez et gérez vos clés API."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Consultez et gérez votre facturation et votre abonnement."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Voir la documentation"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Lecture seule"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Consultez notre feuille de route."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Voir l'espace de travail"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Visibilité"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Nous utilisons la <0>licence AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Nous n'avons pas pu mettre à jour vos préférences. Veuillez réessayer."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Nous ne faisons que commencer."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook créé"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook créé avec succès"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook supprimé"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook supprimé avec succès"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Le nom du webhook ne peut pas dépasser 255 caractères"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Le nom du webhook est requis"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Le test du webhook a échoué"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook mis à jour"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook mis à jour avec succès"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "L'URL du webhook est requise"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooks"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Jour de début de semaine"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Bon retour"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Quelle licence utilisez-vous ?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Quelle est la différence entre Kan et Trello ?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Lorsque Trello a été lancé en 2011, il a impressionné tout le monde avec sa simplicité soigneusement conçue, mais au fil des années, il a perdu sa magie et s'est transformé en quelque chose de plus proche de \"Jira Lite\". Ce projet est notre tentative de retrouver la magie originale de la simplicité de Trello, en open source."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Pourquoi créer un Trello open source ?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Espace de travail"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Espace de travail créé avec succès. Vous pourrez effectuer une mise à niveau ultérieurement dans les paramètres.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Espace de travail supprimé"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Description de l'espace de travail"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "La description de l'espace de travail ne peut pas dépasser 280 caractères"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "La description de l'espace de travail doit contenir au moins 3 caractères"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Description de l'espace de travail mise à jour"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Membres de l'espace de travail"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Nom de l'espace de travail"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Le nom de l'espace de travail ne peut pas dépasser 64 caractères"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Le nom de l'espace de travail est requis"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Le nom de l'espace de travail doit contenir au moins 3 caractères"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Nom de l'espace de travail mis à jour"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Permissions de l'espace de travail"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Identifiant de l'espace de travail mis à jour"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL de l'espace de travail"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Nom d'utilisateur de l'espace de travail"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Écriture"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Annuel"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Oui, nous proposons un forfait gratuit à vie pour un usage individuel. Aucune restriction, aucun paywall, aucune limite."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Vous êtes sur le point de modifier votre mot de passe."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Vous pourrez toujours modifier ces paramètres plus tard dans les réglages."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Vous pouvez obtenir une URL d'espace de travail personnalisée, comme <0>kan.bn/kan</0>, en accédant aux <1>paramètres de votre espace de travail</1> et en souscrivant un abonnement pro. Tous les abonnements contribuent au financement du développement du projet !"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Vous pouvez inviter des membres de l'équipe en cliquant sur le bouton « Inviter » en haut à droite de la <0>page des membres</0> et en saisissant leur adresse e-mail. Ils recevront un e-mail avec un lien pour rejoindre l'espace de travail."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Vous pouvez auto-héberger en suivant les instructions de notre <0>dépôt</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Vous n'avez pas la permission"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Vous avez été connecté avec succès."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Vous avez été inscrit avec succès."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Vous avez été désabonné !"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Vous disposez de places illimitées avec votre forfait pro. Il n'y a aucun frais supplémentaire pour les nouveaux membres !"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Vous devez être administrateur pour gérer les permissions de l'espace de travail."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Vous avez été invité à rejoindre un espace de travail sur kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Vous avez été invité à rejoindre un espace de travail."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Votre compte a été supprimé."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Votre avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Vos tableaux ont été importés."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Votre nom d'affichage a été mis à jour."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Votre fichier a été téléchargé avec succès."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Votre compte GitHub a été connecté."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Votre compte GitHub a été déconnecté."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Votre compte GitHub est connecté."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Votre mot de passe a été modifié."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Votre image de profil a été mise à jour."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Vos projets ont été importés."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Votre compte Trello a été déconnecté."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Votre compte Trello est connecté."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Votre lien de désinscription ne contient pas de jeton. Veuillez ouvrir le dernier e-mail et réessayer."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Votre espace de travail"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "La description de votre espace de travail"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "La description de votre espace de travail a été mise à jour."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Votre espace de travail a été supprimé."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Le nom de votre espace de travail a été mis à jour."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "L'identifiant de votre espace de travail a été mis à jour."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "votre-espace-de-travail"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "URL YouTube"
   }
 }

--- a/apps/web/src/locales/it/messages.json
+++ b/apps/web/src/locales/it/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (modificato)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", oppure consulta il nostro"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} è stato aggiunto ai tuoi preferiti."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} è stato rimosso dai tuoi preferiti."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} etichette"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} non trovato"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Importa bacheca (1)} other {Importa bacheche ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Importa progetto (1)} other {Importa progetti ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/mese"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "$0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "$10/mese"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "$8/mese"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 utente"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "Caricamento file da 10 MB"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "Prova gratuita di 14 giorni · Cambia piano o annulla in qualsiasi momento"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Pagina non trovata | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Un'app kanban potente e flessibile che ti aiuta a organizzare il lavoro, monitorare i progressi e ottenere risultati, tutto in un unico posto."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Account"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Account eliminato"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Account manager"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Azioni"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Attivo"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Attività"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Registro attività"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Registri attività"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Aggiungi / modifica etichetta"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Aggiungi una card"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Aggiungi un elemento..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Aggiungi checklist"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Aggiungi commento... (digita '/' per aprire i comandi o '@' per menzionare)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Aggiungi descrizione... (digita '/' per aprire i comandi o '@' per menzionare)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Aggiungi dettagli..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Aggiungi etichetta"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Aggiungi membro"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Aggiungi ai preferiti"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Aggiungi webhook"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "ha aggiunto {0} etichette: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "ha aggiunto una checklist"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "ha aggiunto un elemento della checklist"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "ha aggiunto un'etichetta alla card"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "ha aggiunto un membro alla card"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "ha aggiunto un allegato"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "ha aggiunto un allegato <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "ha aggiunto la checklist <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "ha aggiunto l'elemento della checklist <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "ha aggiunto l'etichetta <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Aggiunto ai preferiti"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "L'aggiunta di un nuovo membro costerà {price} aggiuntivi ({billingType}) per postazione."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Regola il ritaglio quadrato per adattarlo al tuo avatar."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Admin"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Ruoli admin"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Controlli admin avanzati"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Ruoli admin avanzati"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Sicurezza avanzata, conformità e supporto dedicato per grandi organizzazioni."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Tutte le funzionalità Free +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Tutte le sostituzioni dei permessi dei membri sono state ripristinate ai valori predefiniti del loro ruolo."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Tutte le funzionalità Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Tutti i sistemi operativi"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Tutte le funzionalità Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Hai già un account? <0><1>Accedi</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Si è verificato un errore durante la connessione del tuo account GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Si è verificato un errore durante la disconnessione del tuo account GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Si è verificato un errore durante la disconnessione del tuo account Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Si è verificato un errore imprevisto. Riprova più tardi."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Annuale"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Chiunque abbia questo link può unirsi al tuo workspace"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Chiave API creata"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Nome chiave API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "Il nome della chiave API non può superare i 30 caratteri"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "Il nome della chiave API è obbligatorio"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Chiavi API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Riferimento API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Candidati"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Approvazione"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Archivia bacheca"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Archiviato"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Sei sicuro di voler rimuovere {entityLabel}?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Sei sicuro di voler eliminare il webhook \"{webhookName}\"? Questa azione non può essere annullata."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Sei sicuro di voler eliminare il workspace {0}?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Sei sicuro di voler eliminare questo {0}?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Sei sicuro di voler eliminare questa card?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Sei sicuro di voler eliminare questa checklist?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Sei sicuro di voler eliminare questo commento?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Sei sicuro di voler eliminare questa etichetta?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Sei sicuro di voler eliminare il tuo account?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "ha assegnato <0>{0}</0> alla card"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Assegnatari"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Allegato caricato"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "In attesa del cliente"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Indietro"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Kanban base"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Roadmap base"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Ideale per singoli utenti e creator che iniziano"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Ideale per grandi organizzazioni con esigenze avanzate"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Ideale per piccoli team in crescita che necessitano di collaborazione"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Ideale per piccoli team che vogliono collaborare e muoversi più velocemente insieme."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Ideale per team che vogliono scalare senza limiti"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "fatturato annualmente"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "fatturato mensilmente"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Fatturazione"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Portale di fatturazione"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Post del blog"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Board"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Analisi della board"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Bacheca archiviata"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Il nome della board non può superare i 100 caratteri"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Il nome della board è obbligatorio"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Board non trovata"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Template di board"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Bacheca ripristinata"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "L'URL della board può contenere solo lettere, numeri e trattini"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "L'URL della board non può superare i 60 caratteri"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "URL della board copiato negli appunti"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "L'URL della board deve contenere almeno 3 caratteri"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Visibilità della board"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Visibilità della board aggiornata"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Board"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Le bacheche che archivi appariranno qui."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Brainstorming"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Bug"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Segnalazione bug"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Può aggiungere commenti"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Può creare board"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Può creare card"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Può creare liste"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Può eliminare board"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Può eliminare card"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Può eliminare commenti"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Può eliminare liste"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Può eliminare workspace"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Può modificare board"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Può modificare card"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Può modificare commenti"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Può modificare liste"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Può modificare ruoli e permessi dei membri"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Può modificare workspace"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Può invitare membri"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Può gestire le impostazioni dello workspace"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Può rimuovere membri"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Può visualizzare le bacheche"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Può visualizzare le card"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Può visualizzare i commenti"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Può visualizzare le liste"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Può visualizzare i membri"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Può visualizzare lo workspace"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Annulla"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Card"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Scheda duplicata"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Card non trovata"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Titolo della card"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "URL della card copiato negli appunti"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Cambia password"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Modifica la dimensione del carattere dell'applicazione."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Modifica le tue preferenze di lingua."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "ha modificato la data di scadenza in <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Dai un'occhiata ad alcuni dei nostri progetti open source preferiti."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Controlla la tua casella di posta"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nome della checklist"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklist"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Scegli un piano"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Cancella tutti i permessi personalizzati dei membri in modo che tutti i membri ereditino solo i permessi predefiniti dal loro ruolo."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Cancella permessi personalizzati"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Cancella filtri"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Clicca sul link che abbiamo inviato a {magicLinkRecipient} per accedere."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Chiudi"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Revisione del codice"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Collabora senza problemi con il tuo team."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Collaborazione"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Prossimamente"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Commenti"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Azienda"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Completa"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Controllo e proprietà completi:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "ha completato un elemento della checklist"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "ha completato l'elemento della checklist <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Ruoli utente e permessi configurabili"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Configura i webhook per ricevere notifiche quando le schede vengono create, aggiornate, spostate o eliminate."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Configura quali azioni sono consentite per ogni ruolo del workspace. Questi permessi si applicano a tutti i membri con quel ruolo."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Conferma le tue preferenze email:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Conferma la tua nuova password"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Connetti"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Connetti GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Connetti Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Connetti i tuoi strumenti preferiti per semplificare il tuo flusso di lavoro."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Connetti il tuo account GitHub per importare progetti."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Connetti il tuo account Trello per importare le bacheche."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Contatti"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Contatta il reparto vendite"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Contattaci"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Creazione di contenuti"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Continua"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Continua con "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Continua con {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Controlla chi può visualizzare e modificare le tue board."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Converti in link"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Copia link board"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Copia link card"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Copia checklist"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Copia etichette"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Copia link alla scheda"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Copia membri"
   },
   "7mrkyO": {
-    "translation": "Copia ID ticket",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Copia ID ticket"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Funzionalità principali"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Crea {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Crea un altro"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Crea chiave API"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Crea card"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Crea checklist"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Crea link di invito"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Crea etichetta"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Crea lista"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Crea nuovo {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Crea nuova chiave"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Crea nuova etichetta"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Crea nuova lista"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Crea template"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Crea webhook"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Crea workspace"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Creato"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "ha creato la card"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Critico"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Ritaglia il tuo avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "La password attuale è obbligatoria"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Template board personalizzati"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Branding personalizzato"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Dominio personalizzato"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Permessi personalizzati"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "SLA personalizzato"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Gli URL personalizzati richiedono l'upgrade a un piano Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Username personalizzato"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "I nomi utente personalizzati richiedono l'aggiornamento a un piano Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "URL workspace personalizzato"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Username workspace personalizzato"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Assistenza clienti"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Scuro"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Disattiva link di invito"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Account manager dedicato"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Username predefinito"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Elimina"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Elimina account"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Elimina board"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Elimina card"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Elimina commento"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Elimina lista"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Elimina template"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Elimina webhook"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Elimina workspace"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "ha eliminato una checklist"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "ha eliminato un elemento della checklist"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "ha eliminato la checklist <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "ha eliminato l'elemento della checklist <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Design"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Disconnetti GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Disconnetti Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Discuti e collabora sulle card."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Nome visualizzato"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Il nome visualizzato non può superare i 280 caratteri"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Il nome visualizzato deve contenere almeno 3 caratteri"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Nome visualizzato aggiornato"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Offrite un piano gratuito?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Vuoi annullare l'iscrizione?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Documentazione"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Non hai un account? <0><1>Registrati</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Fatto"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Download non riuscito"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Data di scadenza"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Scadenza il mese prossimo"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Scadenza la prossima settimana"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Scadenza oggi"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Scadenza domani"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplica"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Duplica scheda"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplicazione in corso…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Modifica"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Modifica URL bacheca"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Modifica commento"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Modifica etichetta"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Modifica permessi"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Modifica webhook"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Modifica URL workspace"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Modifica video YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Modifica"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "email"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "Email"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Notifiche email"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Notifiche email per le menzioni"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Visibilità email"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Fine dell'elenco"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Ingegneria"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Miglioramento"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Inserisci un titolo personalizzato"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Inserisci un nuovo secret per aggiornare"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Inserisci la tua password attuale"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Inserisci la tua password attuale e scegli una nuova password sicura."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Inserisci il tuo indirizzo email"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Inserisci il tuo nome"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Inserisci la tua nuova password"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Inserisci la tua password"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Errore"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Errore durante la modifica della password"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Errore nella connessione a GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Errore durante la creazione del link di invito"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Errore durante la disattivazione del link di invito"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Errore durante l'eliminazione dell'account"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Errore durante l'eliminazione dell'etichetta"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Errore durante l'eliminazione dello spazio di lavoro"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Errore nella disconnessione da GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Errore durante la disconnessione da Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Errore durante l'invito del membro"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Errore durante l'aggiornamento del nome visualizzato"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Errore durante l'aggiornamento della descrizione dello workspace"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Errore durante l'aggiornamento del nome dello workspace"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Errore durante l'aggiornamento dell'URL dello workspace"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Errore durante l'upgrade dell'abbonamento"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Errore durante l'upgrade a Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Errore durante il caricamento dell'immagine del profilo"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Eventi"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Tutto ciò che è incluso nel piano gratuito, più:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Tutto ciò di cui hai bisogno, gratis per sempre. Board illimitate, liste illimitate, card illimitate. Fai l'upgrade quando vuoi."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Esecuzione"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Roadmap estesa"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Impossibile accettare l'invito. Riprova più tardi o contatta l'assistenza clienti."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Impossibile copiare il link di invito"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Impossibile creare la board"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Impossibile creare il webhook"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Impossibile eliminare il webhook"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Impossibile recuperare le informazioni del video"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Impossibile effettuare il login con {0}. Riprova."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Impossibile testare il webhook"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Impossibile aggiornare il webhook"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Impossibile caricare l'allegato. Riprova."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "FAQ"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Funzionalità"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Richiesta di funzionalità"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Funzionalità"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Feedback"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Feedback inviato"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Caricamento file"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filtra"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Trova risposte alle domande più comuni su Kan. Non trovi quello che cerchi? Sentiti libero di <0>contattarci</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Dimensione del carattere"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Per una sostenibilità a lungo termine, riconosciamo che tutti i buoni progetti open source necessitano di una fonte di entrate. La nostra proviene dall'offerta cloud a pagamento per workspace con più utenti e per slug workspace personalizzati. Non c'è alcun obbligo di utilizzarla e puoi ospitare il software sulla tua infrastruttura gratuitamente."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Gratuito"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Gratuito per tutti"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Piano gratuito"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Gratuito, per sempre"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Accesso API completo"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Tempo pieno"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Divertimento"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Generale"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Inizia"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Inizia"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Inizia creando un nuovo {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Inizia creando una nuova lista"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Inizia gratuitamente oggi"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Inizia gratuitamente, senza limiti di utilizzo. Per la collaborazione, passa a un piano adatto alle dimensioni del tuo team."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Inizia su Cloud"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Per iniziare"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub connesso"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub disconnesso"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Vai alla home"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Vai all'app"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Vai alle bacheche"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Vai alla homepage"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Vai ai membri"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Vai alle impostazioni"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Vai ai modelli"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Perfetto per chi inizia e ha bisogno solo delle funzionalità essenziali."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Ospite"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Priorità alta"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Assunto"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Secret HMAC per la verifica della firma"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Ospita Kan sulla tua infrastruttura. Ideale per le organizzazioni che necessitano del controllo completo sui propri dati."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Come ottengo un URL personalizzato?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Come importo le mie bacheche Trello?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Come invito i membri del team?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Come faccio il self-hosting?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Come viene finanziato il progetto?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Riconosco che tutti i dati del mio account verranno eliminati definitivamente e voglio procedere."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Riconosco che tutti i dati del workspace verranno eliminati definitivamente e voglio procedere."
   },
   "VOwhhz": {
-    "translation": "ID copiato",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID copiato"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Idee"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Idee per migliorare questa pagina..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importa"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Importazione completata"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Importazione fallita"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importa le tue bacheche Trello e inizia subito."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Importante"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importazione da Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Importare le tue bacheche Trello in Kan è facile. Puoi seguire la nostra guida passo dopo passo <0>qui</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Importazioni"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "in"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "In corso"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inattivo"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Individuali"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integrazioni"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Ricerca intelligente"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Colloquio"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Indirizzo email non valido"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Invito non valido"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Invita"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Link di invito copiato"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Link di invito copiato negli appunti"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Link di invito"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "I link di invito richiedono un abbonamento Team o Pro. Aggiorna il tuo workspace."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Invita membro"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Invitare membri richiede un piano Team. Verrai reindirizzato per aggiornare il tuo workspace."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Unisciti al workspace"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Unisciti al workspace | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban è meglio con un team. Perfetto per team piccoli e in crescita che vogliono collaborare."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban reinventato"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Tieni presente che questa azione è irreversibile."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Scorciatoie da tastiera"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Etichette"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Etichette e filtri"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Etichette e filtri"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Lingua"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Grande"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Offerta di lancio"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Offerta di lancio: membri illimitati con Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Offerta di lancio: posti illimitati a soli $29/mese con Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Scopri di più"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Apprendimento"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Legale"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licenza"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Chiaro"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Accesso API limitato"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Link copiato"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Lista"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Nome lista"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Liste"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Carica altre attività"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Caricamento permessi..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Caricamento..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Accedi | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Esci"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Lungo termine"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Amato dai team di tutto il mondo"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Bassa priorità"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "magic link"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Crea template"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Gestisci membri"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "ha contrassegnato un elemento della checklist come incompleto"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "ha contrassegnato l'elemento della checklist <0>{0}</0> come incompleto"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Medio"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Priorità media"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Membro"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Membri"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Membri | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Menzioni"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Lunedì"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Mensile"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "fatturazione mensile"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Sposta in un altro elenco"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Sposta nell'elenco"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "ha spostato la card da <0>{0}</0> a <1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "ha spostato la card in un'altra lista"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Il mio webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Nome"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navigazione"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Serve aiuto?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Nuovo"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Nuovo {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nuova chiave API"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Nuova card"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nuova checklist"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nuova importazione"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nuova etichetta"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nuova lista"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "La nuova password è obbligatoria"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "La nuova password deve essere diversa da quella attuale"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Nuovo template"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Nuovo ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Nuovo webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Nuovo workspace"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Prossimi passi"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Nessun {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Nessuna bacheca archiviata"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Nessun metodo di autenticazione attualmente disponibile"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Nessuna board trovata"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Nessuna carta di credito richiesta"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Nessuna data"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Nessun URL di download disponibile per questo allegato."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Nessuna scorciatoia da tastiera registrata."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Nessuna lista"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Nessuna lista è stata ancora creata"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Nessun progetto trovato"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Nessun risultato trovato per \"{debouncedQuery}\"."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Nessun ruolo trovato per questo workspace."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Nessun webhook configurato. Aggiungi un webhook per ricevere notifiche."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Offerta"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Opzione di deployment on-premise"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Una volta eliminato il tuo account, non si può tornare indietro. Questa azione non può essere annullata."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Una volta eliminato il tuo workspace, non si può tornare indietro. Questa azione non può essere annullata."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Apri menu comandi"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Apri scorciatoie da tastiera"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Open source friends"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "o"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organizza e trova le card rapidamente con potenti strumenti di filtraggio."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "Amici OSS"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "In ritardo"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Override cancellati"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Possiedi i tuoi dati"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Pagina non trovata"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Part-time"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Password modificata"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "La password è richiesta per accedere."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "La password è richiesta per registrarsi."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "La password deve contenere almeno 8 caratteri"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Le password non corrispondono"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "In pausa"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Frequenza di pagamento"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "In attesa"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "per utente/mese"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Prezzo per postazione"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Perfetto per team piccoli e in crescita che cercano collaborazione."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Permesso"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Permessi"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Permessi ripristinati"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Permessi aggiornati"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Progetto personale"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Scegli un piano per iniziare. Tutti i piani a pagamento includono una prova gratuita di 14 giorni."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Pianificato"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Pianificazione"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Piattaforma"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Conferma la tua nuova password"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Inserisci un indirizzo email valido"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Inserisci un nome valido"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Inserisci una password valida"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Inserisci un URL valido"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Inserisci un URL YouTube valido"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Seleziona un file da caricare."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Riprova più tardi o contatta l'assistenza clienti."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Riprova più tardi."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Riprova."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Posizione nell'elenco (0 = primo, lascia vuoto per la fine)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Prezzi"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Supporto email prioritario"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Informativa sulla privacy"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privato"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Piano Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Piano Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Immagine del profilo aggiornata"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Immagine del profilo"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Pubblico"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Pubblicazione"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Domanda"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Domande?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Quick win"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Recruiting"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Rifiutato"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Remoto"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Rimuovi"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Rimuovi dai preferiti"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Rimuovi membro"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "ha rimosso {0} etichette: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "ha rimosso un'etichetta dalla card"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "ha rimosso un membro dalla card"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "ha rimosso un allegato"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "ha rimosso un allegato <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Rimosso dai preferiti"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "ha rimosso l'etichetta <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "ha rimosso la data di scadenza"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "ha rinominato una checklist"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "ha rinominato la checklist <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "ha rinominato l'elemento della checklist in <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Richiesto"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Ricerca"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Ripristina impostazioni predefinite del ruolo"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Risoluzione"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Risorse"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Revisione"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Roadmap"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Ruolo"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Ruolo aggiornato"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Ruoli e permessi"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Esegui sulla tua infrastruttura"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Sabato"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Salva"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Salva modifiche"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Risparmia tempo con i modelli di board riutilizzabili."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Screening"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Cerca board e card..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Secret (facoltativo)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Il secret non può superare i 512 caratteri"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Sicurezza"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Scopri cosa dicono i nostri utenti su Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Seleziona un elenco"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Seleziona tutto"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Seleziona almeno un evento"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Seleziona origine"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Self host"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Self host con Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "ha auto-assegnato la card"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Invia feedback"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Invia test"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Senior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Imposta scadenza"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "ha impostato la scadenza"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Configura il tuo workspace"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Impostazioni"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Impostazioni | Account"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Impostazioni | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Impostazioni | Fatturazione"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Impostazioni | Integrazioni"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Impostazioni | Permessi"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Impostazioni | Webhook"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Impostazioni | Workspace"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Scorciatoie"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Accedi"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Accedi"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Esci"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Registrati"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Registrati | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Registrazione disabilitata"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "La registrazione è attualmente disabilitata. Riprova più tardi."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Registrati con "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Prezzi semplici"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Gestione delle attività semplice e visiva che funziona davvero. Trascina e rilascia le schede, collabora con il tuo team e porta a termine più cose."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Piccolo"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Social media"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Sviluppo software"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Metti una stella su Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Inizia la prova gratuita di 14 giorni"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Inizia gratis. Aggiorna man mano che il tuo team cresce. Nessun costo nascosto, nessun contratto."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Stato"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Abbonamento richiesto"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Successo"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Domenica"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Potenzia il tuo workspace per soli $29 al mese. Ecco cosa otterrai:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Supporto"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Sostieni lo sviluppo del progetto"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Sistema"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Team"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Piano team"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Team"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Template"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Template creato"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Template creato con successo"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Il nome del template non può superare i 100 caratteri"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Il nome del template è obbligatorio"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Template"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Termini di servizio"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Test"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Test fallito"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test inviato"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Webhook di test inviato con successo!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Testimonianze"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Grazie per il tuo feedback!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "La bacheca è stata archiviata."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "La bacheca è stata ripristinata."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "La scheda è stata duplicata."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "La password attuale inserita non è corretta."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "La principale differenza tra Kan e Trello è che Kan è open source, permettendo a chiunque di visualizzare, modificare e contribuire al nostro codice. La nostra offerta cloud non prevede inoltre alcuna restrizione sulle funzionalità per l'uso individuale, mentre Trello blocca funzionalità di base come il numero di bacheche che puoi creare dietro un paywall."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "I permessi del membro sono stati aggiornati."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "Il ruolo del membro è stato aggiornato."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "L'alternativa open source <0/> a Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "La pagina che stai cercando non esiste o è stata spostata."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "La visibilità della tua bacheca è stata impostata su {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Tema"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Non potranno accedere a questo workspace."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Questa azione non può essere annullata."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Questa chiave API verrà mostrata solo una volta. Salvala in un luogo sicuro."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Questa bacheca è privata o non esiste"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Questo URL della bacheca è già stato utilizzato"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Questo link di invito non è valido o è scaduto."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "I permessi di questo membro sono stati ripristinati ai valori predefiniti del suo ruolo."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Questo URL è già in uso"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Questo URL è riservato"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Questo comporterà l'eliminazione permanente di tutti i dati associati a questo workspace."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Questo comporterà l'eliminazione permanente di tutti i dati associati al tuo account."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Questo URL del workspace è già stato utilizzato"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Questo URL dello workspace è riservato"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Questo nome utente dello workspace è già stato utilizzato"
   },
   "pEb95p": {
-    "translation": "ID ticket copiato negli appunti",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID ticket copiato negli appunti"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Titolo"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Titolo (facoltativo)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "Da fare"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Attiva/disattiva menu"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Il token è obbligatorio"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Tieni traccia di tutte le modifiche alle card con una cronologia dettagliata delle attività."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello disconnesso"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Importazioni Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Smistamento"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Scelto da team dinamici<0/>in tutto il mondo"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Impossibile aggiungere l'elemento della checklist"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Impossibile aggiungere il commento"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Impossibile aggiungere l'etichetta"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Impossibile cancellare le sostituzioni"
   },
   "5MPY04": {
-    "translation": "Impossibile copiare l'ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Impossibile copiare l'ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Impossibile copiare il link"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Impossibile creare la card"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Impossibile creare la checklist"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Impossibile creare la lista"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Impossibile creare il template"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Impossibile creare il webhook"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Impossibile creare lo workspace"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Impossibile eliminare l'allegato"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Impossibile eliminare la card"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Impossibile eliminare la checklist"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Impossibile eliminare l'elemento della checklist"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Impossibile eliminare il commento"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Impossibile eliminare il webhook"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Impossibile duplicare la scheda"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Impossibile spostare la scheda"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Impossibile rimuovere il membro"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Impossibile riordinare l'elemento della checklist"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Impossibile ripristinare i permessi"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Impossibile inviare il feedback"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Impossibile avviare il checkout"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Impossibile testare il webhook"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Impossibile aggiornare la board"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Impossibile aggiornare l'URL della board"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Impossibile aggiornare la visibilità della board"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Impossibile aggiornare la card"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Impossibile aggiornare la checklist"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Impossibile aggiornare l'elemento della checklist"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Impossibile aggiornare il commento"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Impossibile aggiornare la data di scadenza"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Impossibile aggiornare le etichette"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Impossibile aggiornare la lista"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Impossibile aggiornare i membri"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Impossibile aggiornare i permessi"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Impossibile aggiornare il ruolo"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Impossibile aggiornare il webhook"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Ripristina bacheca"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "ha rimosso l'assegnazione di <0>{0}</0> dalla card"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "ha rimosso la propria assegnazione dalla card"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "In revisione"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Log attività illimitato"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Board illimitate"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Board illimitate, liste illimitate, card illimitate. Nessuna carta di credito richiesta."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Card illimitate"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Commenti illimitati"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Caricamenti di file illimitati"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Liste illimitate"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Membri illimitati"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Membri illimitati e un nome utente workspace personalizzato per i team pronti a crescere."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Posti illimitati e funzionalità avanzate per team in crescita."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Annulla iscrizione"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Aggiorna"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Aggiorna etichetta"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "ha aggiornato un elemento della checklist"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "ha aggiornato la descrizione"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "ha aggiornato la data di scadenza"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "ha aggiornato il titolo"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "ha aggiornato il titolo in <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Passa a Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Passa a Pro ($29/mese)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Caricamento non riuscito"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Urgente"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "L'URL può contenere solo lettere, numeri e trattini"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "L'URL non può superare i 2048 caratteri"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "L'URL non può superare i 64 caratteri"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "L'URL deve contenere almeno 3 caratteri"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Usa template"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Utilizzato per firmare i payload dei webhook per la verifica. Lasciare vuoto per mantenere il segreto esistente."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Utente"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "L'utente è già membro di questo workspace"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Video"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Visualizza e gestisci le tue chiavi API."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Visualizza e gestisci la fatturazione e l'abbonamento."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Visualizza documentazione"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Sola visualizzazione"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Visualizza la nostra roadmap."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Visualizza workspace"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Visibilità"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Utilizziamo la <0>licenza AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Non è stato possibile aggiornare le tue preferenze. Riprova."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Siamo solo all'inizio."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook creato"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook creato con successo"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook eliminato"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook eliminato con successo"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Il nome del webhook non può superare i 255 caratteri"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Il nome del webhook è obbligatorio"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Test del webhook non riuscito"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook aggiornato"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook aggiornato con successo"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "L'URL del webhook è obbligatorio"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhook"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Giorno di inizio settimana"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Bentornato"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Quale licenza stai utilizzando?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Qual è la differenza tra Kan e Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Quando Trello è stato lanciato nel 2011, ha stupito tutti con la sua semplicità accuratamente progettata, ma nel corso degli anni ha perso la sua magia e si è trasformato in qualcosa di più simile a \"Jira Lite\". Questo progetto è il nostro tentativo di recuperare la magia originale della semplicità di Trello, in open source."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Perché creare un Trello open source?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Workspace"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Workspace creato con successo. Potrai effettuare l'upgrade più tardi nelle impostazioni.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Workspace eliminato"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Descrizione workspace"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "La descrizione del workspace non può superare i 280 caratteri"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "La descrizione del workspace deve contenere almeno 3 caratteri"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Descrizione workspace aggiornata"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Membri del workspace"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Nome workspace"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Il nome del workspace non può superare i 64 caratteri"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Il nome del workspace è obbligatorio"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Il nome del workspace deve contenere almeno 3 caratteri"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Nome del workspace aggiornato"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Permessi del workspace"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Slug del workspace aggiornato"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL del workspace"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Nome utente del workspace"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Scrittura"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Annuale"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Sì, offriamo un piano gratuito per sempre per uso individuale. Nessuna restrizione, nessun paywall, nessun limite."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Stai per modificare la tua password."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Potrai sempre modificarli in seguito nelle impostazioni."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Puoi ottenere un URL personalizzato per il workspace, come <0>kan.bn/kan</0>, andando nelle <1>impostazioni del workspace</1> e acquistando un abbonamento pro. Tutti gli abbonamenti aiutano a finanziare lo sviluppo del progetto!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Puoi invitare membri del team cliccando il pulsante \"Invita\" nell'angolo in alto a destra della <0>pagina membri</0> e inserendo il loro indirizzo email. Riceveranno un'email con un link per unirsi al workspace."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Puoi effettuare il self-hosting seguendo le istruzioni nel nostro <0>repo</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Non hai i permessi necessari"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Hai effettuato l'accesso con successo."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Ti sei registrato con successo."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Hai annullato l'iscrizione!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Hai posti illimitati con il tuo piano pro. Non ci sono costi aggiuntivi per i nuovi membri!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Devi essere un amministratore per gestire i permessi del workspace."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Sei stato invitato a unirti a un workspace su kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Sei stato invitato a unirti a un workspace."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Il tuo account è stato eliminato."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Il tuo avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Le tue board sono state importate."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Il tuo nome visualizzato è stato aggiornato."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Il tuo file è stato caricato con successo."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Il tuo account GitHub è stato connesso."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Il tuo account GitHub è stato disconnesso."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Il tuo account GitHub è connesso."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "La tua password è stata modificata."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "La tua immagine del profilo è stata aggiornata."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "I tuoi progetti sono stati importati."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Il tuo account Trello è stato disconnesso."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Il tuo account Trello è connesso."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Il tuo link di disiscrizione non contiene un token. Apri l'ultima email e riprova."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Il tuo workspace"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "La descrizione del tuo workspace"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "La descrizione del tuo workspace è stata aggiornata."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Il tuo workspace è stato eliminato."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Il nome del tuo workspace è stato aggiornato."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "Lo slug del tuo workspace è stato aggiornato."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "il-tuo-workspace"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "URL YouTube"
   }
 }

--- a/apps/web/src/locales/nl/messages.json
+++ b/apps/web/src/locales/nl/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (bewerkt)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", of bekijk onze"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} is toegevoegd aan je favorieten."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} is verwijderd uit je favorieten."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} labels"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} niet gevonden"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Bord importeren (1)} other {Borden importeren ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Project importeren (1)} other {Projecten importeren ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/maand"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "€0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "€10/maand"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "€8/maand"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 gebruiker"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "10 MB bestandsuploads"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "14 dagen gratis proefperiode · Wissel van abonnement of annuleer op elk moment"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Pagina niet gevonden | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Een krachtige, flexibele kanban-app die je helpt werk te organiseren, voortgang bij te houden en resultaten te leveren—allemaal op één plek."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Account"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Account verwijderd"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Accountmanager"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Acties"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Actief"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Activiteit"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Activiteitenlogboek"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Activiteitenlogboeken"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Label toevoegen / bewerken"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Kaart toevoegen"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Voeg een item toe..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Checklist toevoegen"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Voeg opmerking toe... (typ '/' om commando's te openen of '@' om te vermelden)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Voeg beschrijving toe... (typ '/' om commando's te openen of '@' om te vermelden)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Voeg details toe..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Label toevoegen"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Lid toevoegen"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Toevoegen aan favorieten"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Webhook toevoegen"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "heeft {0} labels toegevoegd: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "heeft een checklist toegevoegd"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "heeft een checklist-item toegevoegd"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "heeft een label aan de kaart toegevoegd"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "heeft een lid aan de kaart toegevoegd"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "heeft een bijlage toegevoegd"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "heeft een bijlage toegevoegd <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "heeft checklist <0>{0}</0> toegevoegd"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "heeft checklist-item <0>{0}</0> toegevoegd"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "heeft label <0>{0}</0> toegevoegd"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Toegevoegd aan favorieten"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Het toevoegen van een nieuw lid kost {price} ({billingType}) extra per seat."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Pas de vierkante uitsnede aan zodat deze bij je avatar past."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Beheerder"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Beheerdersrollen"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Geavanceerde beheerdersinstellingen"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Geavanceerde beheerdersrollen"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Geavanceerde beveiliging, compliance en toegewijde ondersteuning voor grote organisaties."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Alle gratis functies +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Alle aangepaste rechten van leden zijn teruggezet naar de standaardinstellingen van hun rol."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Alle Pro-functies +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Alle systemen operationeel"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Alle Teams-functies +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Heb je al een account? <0><1>Inloggen</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Er is een fout opgetreden bij het verbinden van je GitHub-account."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Er is een fout opgetreden bij het loskoppelen van je GitHub-account."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Er is een fout opgetreden bij het loskoppelen van je Trello-account."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Er is een onverwachte fout opgetreden. Probeer het later opnieuw."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Jaarlijks"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Iedereen met deze link kan lid worden van je werkruimte"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "API-sleutel aangemaakt"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "API-sleutelnaam"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "API-sleutelnaam mag niet langer zijn dan 30 tekens"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "API-sleutelnaam is verplicht"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "API-sleutels"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "API-referentie"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Aanvragers"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Goedkeuring"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Board archiveren"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Gearchiveerd"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Weet je zeker dat je {entityLabel} wilt verwijderen?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Weet je zeker dat je de webhook \"{webhookName}\" wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Weet je zeker dat je de werkruimte {0} wilt verwijderen?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Weet je zeker dat je deze {0} wilt verwijderen?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Weet je zeker dat je deze kaart wilt verwijderen?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Weet je zeker dat je deze checklist wilt verwijderen?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Weet je zeker dat je deze opmerking wilt verwijderen?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Weet je zeker dat je dit label wilt verwijderen?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Weet je zeker dat je je account wilt verwijderen?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "heeft <0>{0}</0> aan de kaart toegewezen"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Toegewezen aan"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Bijlage geüpload"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Wacht op klant"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Terug"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Basis kanban"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Basis roadmap"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Het beste voor individuen en solo-makers die aan de slag gaan"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Het beste voor grote organisaties met geavanceerde behoeften"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Het beste voor kleine en groeiende teams die samenwerking nodig hebben"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Het beste voor kleine teams die willen samenwerken en sneller vooruit willen komen."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Het beste voor teams die onbeperkt willen schalen"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "jaarlijks gefactureerd"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "maandelijks gefactureerd"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Facturering"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Facturatieportaal"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Blogpost"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Bord"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Bordanalyse"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Board gearchiveerd"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Bordnaam mag niet meer dan 100 tekens bevatten"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Bordnaam is verplicht"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Bord niet gevonden"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Bordsjablonen"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Board gedearchiveerd"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "Board-URL mag alleen letters, cijfers en koppeltekens bevatten"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "Board-URL mag niet langer zijn dan 60 tekens"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "Board-URL gekopieerd naar klembord"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "Board-URL moet minimaal 3 tekens lang zijn"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Zichtbaarheid van board"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Zichtbaarheid van board bijgewerkt"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Boards"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Boards die je archiveert verschijnen hier."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Brainstormen"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Bug"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Bugrapport"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Kan opmerkingen toevoegen"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Kan boards aanmaken"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Kan kaarten aanmaken"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Kan lijsten aanmaken"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Kan boards verwijderen"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Kan kaarten verwijderen"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Kan opmerkingen verwijderen"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Kan lijsten verwijderen"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Kan workspace verwijderen"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Kan boards bewerken"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Kan kaarten bewerken"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Kan opmerkingen bewerken"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Kan lijsten bewerken"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Kan rollen en rechten van leden bewerken"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Kan workspace bewerken"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Kan leden uitnodigen"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Kan workspace-instellingen beheren"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Kan leden verwijderen"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Kan borden bekijken"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Kan kaarten bekijken"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Kan reacties bekijken"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Kan lijsten bekijken"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Kan leden bekijken"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Kan workspace bekijken"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Annuleren"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Kaart"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Kaart gedupliceerd"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Kaart niet gevonden"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Kaarttitel"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "Kaart-URL gekopieerd naar klembord"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Wachtwoord wijzigen"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Pas de lettergrootte van de applicatie aan."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Wijzig je taalvoorkeuren."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "heeft de vervaldatum gewijzigd naar <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Bekijk enkele van onze favoriete open source-projecten."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Controleer je inbox"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Checklistnaam"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklists"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Kies een abonnement"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Wis alle aangepaste ledenrechten zodat alle leden alleen rechten erven van hun standaard rolrechten."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Aangepaste rechten wissen"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Filters wissen"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Klik op de link die we naar {magicLinkRecipient} hebben gestuurd om in te loggen."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Sluiten"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Code review"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Werk naadloos samen met je team."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Samenwerking"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Binnenkort beschikbaar"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Reacties"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Bedrijf"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Voltooid"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Volledige controle en eigenaarschap:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "heeft een checklistitem voltooid"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "heeft checklistitem <0>{0}</0> voltooid"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Configureerbare gebruikersrollen en rechten"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Configureer webhooks om meldingen te ontvangen wanneer kaarten worden aangemaakt, bijgewerkt, verplaatst of verwijderd."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Configureer welke acties zijn toegestaan voor elke werkruimterol. Deze rechten gelden voor alle leden met die rol."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Bevestig je e-mailvoorkeuren:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Bevestig je nieuwe wachtwoord"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Verbinden"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "GitHub verbinden"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Verbind Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Verbind je favoriete tools om je workflow te stroomlijnen."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Verbind je GitHub-account om projecten te importeren."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Verbind je Trello-account om boards te importeren."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Contact"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Neem contact op met sales"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Neem contact met ons op"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Content creatie"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Doorgaan"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Ga verder met "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Ga verder met {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Bepaal wie je borden kan bekijken en bewerken."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Converteer naar link"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Kopieer bordlink"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Kopieer kaartlink"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Checklists kopiëren"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Labels kopiëren"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Link naar kaart kopiëren"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Leden kopiëren"
   },
   "7mrkyO": {
-    "translation": "Ticket-ID kopiëren",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Ticket-ID kopiëren"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Kernfuncties"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Maak {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Maak nog een"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Maak API-sleutel"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Maak kaart"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Maak checklist"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Maak uitnodigingslink"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Maak label"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Maak lijst"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Maak nieuwe {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Maak nieuwe sleutel"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Maak nieuw label"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Maak nieuwe lijst"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Maak sjabloon"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Webhook aanmaken"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Maak werkruimte"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Aangemaakt"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "heeft de kaart gemaakt"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Kritiek"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Bijsnijden van je avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Huidig wachtwoord is verplicht"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Aangepaste bordsjablonen"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Aangepaste branding"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Aangepast domein"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Aangepaste rechten"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "Aangepaste SLA"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Aangepaste URL's vereisen een upgrade naar een Pro-abonnement",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Aangepaste gebruikersnaam"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Aangepaste gebruikersnamen vereisen een upgrade naar een Pro-abonnement"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "Aangepaste workspace-URL"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Aangepaste workspace-gebruikersnaam"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Klantenondersteuning"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Donker"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Uitnodigingslink deactiveren"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Toegewezen accountmanager"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Standaard gebruikersnaam"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Verwijderen"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Account verwijderen"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Bord verwijderen"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Kaart verwijderen"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Reactie verwijderen"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Lijst verwijderen"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Sjabloon verwijderen"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Webhook verwijderen"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Workspace verwijderen"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "heeft een checklist verwijderd"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "heeft een checklistitem verwijderd"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "heeft checklist <0>{0}</0> verwijderd"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "heeft checklistitem <0>{0}</0> verwijderd"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Ontwerp"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "GitHub loskoppelen"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Trello loskoppelen"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Bespreek en werk samen aan kaarten."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Weergavenaam"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Weergavenaam mag niet meer dan 280 tekens bevatten"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Weergavenaam moet minimaal 3 tekens lang zijn"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Weergavenaam bijgewerkt"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Bieden jullie een gratis abonnement aan?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Wil je je uitschrijven?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Documentatie"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Nog geen account? <0><1>Registreren</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Klaar"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Download mislukt"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Vervaldatum"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Verloopt volgende maand"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Verloopt volgende week"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Verloopt vandaag"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Verloopt morgen"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Dupliceren"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Kaart dupliceren"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Dupliceren…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Bewerken"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Bord-URL bewerken"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Reactie bewerken"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Label bewerken"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Rechten bewerken"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Webhook bewerken"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Workspace-URL bewerken"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "YouTube-video bewerken"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Bewerken"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "e-mail"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "E-mail"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "E-mailmeldingen"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "E-mailmeldingen voor vermeldingen"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "E-mailzichtbaarheid"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Einde van lijst"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Engineering"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Verbetering"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Voer een aangepaste titel in"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Voer nieuw geheim in om bij te werken"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Voer je huidige wachtwoord in"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Voer je huidige wachtwoord in en kies een nieuw veilig wachtwoord."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Voer je e-mailadres in"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Voer je naam in"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Voer je nieuwe wachtwoord in"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Voer je wachtwoord in"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Fout"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Fout bij wijzigen wachtwoord"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Fout bij verbinden met GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Fout bij aanmaken uitnodigingslink"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Fout bij deactiveren uitnodigingslink"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Fout bij verwijderen account"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Fout bij verwijderen label"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Fout bij verwijderen werkruimte"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Fout bij loskoppelen van GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Fout bij loskoppelen Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Fout bij uitnodigen lid"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Fout bij bijwerken van weergavenaam"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Fout bij bijwerken van werkruimtebeschrijving"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Fout bij bijwerken van werkruimtenaam"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Fout bij bijwerken van werkruimte-URL"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Fout bij upgraden van abonnement"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Fout bij upgraden naar Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Fout bij uploaden van profielafbeelding"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Gebeurtenissen"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Alles in het gratis abonnement, plus:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Alles wat je nodig hebt, voor altijd gratis. Onbeperkt borden, onbeperkt lijsten, onbeperkt kaarten. Upgrade wanneer je maar wilt."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Uitvoering"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Uitgebreide roadmap"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Uitnodiging accepteren mislukt. Probeer het later opnieuw of neem contact op met klantenservice."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Uitnodigingslink kopiëren mislukt"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Bord aanmaken mislukt"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Webhook aanmaken mislukt"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Webhook verwijderen mislukt"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Video-informatie ophalen mislukt"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Inloggen met {0} mislukt. Probeer het opnieuw."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Webhook testen mislukt"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Webhook bijwerken mislukt"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Bijlage uploaden mislukt. Probeer het opnieuw."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "Veelgestelde vragen"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "Veelgestelde vragen"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Functie"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Functieverzoek"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Functies"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Feedback"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Feedback verzonden"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Bestandsuploads"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filter"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Vind antwoorden op veelgestelde vragen over Kan. Kun je niet vinden wat je zoekt? Neem gerust <0>contact met ons op</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Lettergrootte"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Voor duurzaamheid op lange termijn erkennen we dat alle goede open source projecten een bron van inkomsten nodig hebben. De onze komt van het betaalde cloudaanbod voor werkruimtes met meerdere gebruikers en voor aangepaste werkruimte-slugs. Er is geen verplichting om het te gebruiken, en je kunt de software gratis op je eigen infrastructuur hosten."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Gratis"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Gratis voor iedereen"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Gratis abonnement"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Gratis, voor altijd"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Volledige API-toegang"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Fulltime"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Leuk"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Algemeen"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Aan de slag"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Aan de slag"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Ga aan de slag door een nieuwe {0} te maken"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Ga aan de slag door een nieuwe lijst te maken"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Ga vandaag gratis aan de slag"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Ga gratis aan de slag, zonder gebruikslimieten. Voor samenwerking kun je upgraden naar een abonnement dat past bij de grootte van je team."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Ga aan de slag op Cloud"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Aan de slag"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub verbonden"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub losgekoppeld"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Ga naar home"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Ga naar app"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Ga naar borden"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Ga naar homepage"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Ga naar leden"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Ga naar instellingen"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Ga naar sjablonen"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Geschikt voor individuen die net beginnen en alleen de basisbehoeften hebben."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Gast"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Hoge prioriteit"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Aangenomen"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "HMAC-geheim voor handtekeningverificatie"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Host Kan op je eigen infrastructuur. Ideaal voor organisaties die volledige controle over hun data nodig hebben."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Hoe krijg ik een aangepaste URL?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Hoe importeer ik mijn Trello-borden?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Hoe nodig ik teamleden uit?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Hoe host ik zelf?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Hoe wordt het project gefinancierd?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Ik bevestig dat al mijn accountgegevens permanent worden verwijderd en wil doorgaan."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Ik bevestig dat alle werkruimtegegevens permanent worden verwijderd en wil doorgaan."
   },
   "VOwhhz": {
-    "translation": "ID gekopieerd",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID gekopieerd"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Ideeën"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Ideeën om deze pagina te verbeteren..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importeren"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Import voltooid"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Import mislukt"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importeer je Trello-borden en ga meteen aan de slag."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Belangrijk"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importeren vanuit Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Je Trello-borden importeren in Kan is eenvoudig. Je kunt onze stapsgewijze handleiding <0>hier</0> volgen."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Imports"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "in"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "Bezig"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inactief"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Individuen"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integraties"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Intelligent zoeken"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Interviewen"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Ongeldig e-mailadres"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Ongeldige uitnodiging"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Uitnodigen"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Uitnodigingslink gekopieerd"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Uitnodigingslink gekopieerd naar klembord"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Uitnodigingslinks"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Uitnodigingslinks vereisen een Team- of Pro-abonnement. Upgrade je workspace."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Lid uitnodigen"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Leden uitnodigen vereist een Team-abonnement. Je wordt doorgestuurd om je workspace te upgraden."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Deelnemen aan workspace"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Deelnemen aan workspace | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban is beter met een team. Perfect voor kleine en groeiende teams die willen samenwerken."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban opnieuw uitgevonden"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Houd er rekening mee dat deze actie onomkeerbaar is."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Sneltoetsen"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Labels"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Labels & filters"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Labels & filters"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Taal"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Groot"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Lanceringaanbieding"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Lanceringaanbieding: onbeperkt leden met Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Lanceringaanbieding: onbeperkt aantal plaatsen voor slechts €29/maand met Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Meer informatie"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Leren"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Juridisch"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licentie"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Licht"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Beperkte API-toegang"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Link gekopieerd"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Lijst"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Lijstnaam"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Lijsten"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Meer activiteiten laden"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Machtigingen laden..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Laden..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Inloggen | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Uitloggen"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Lange termijn"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Geliefd bij teams wereldwijd"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Lage prioriteit"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "magische link"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Sjabloon maken"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Leden beheren"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "heeft een checklistitem als onvolledig gemarkeerd"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "heeft checklistitem <0>{0}</0> als onvolledig gemarkeerd"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Gemiddeld"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Gemiddelde prioriteit"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Lid"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Leden"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Leden | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Vermeldingen"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Maandag"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Maandelijks"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "maandelijkse facturering"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Verplaats naar andere lijst"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Verplaats naar lijst"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "heeft de kaart verplaatst van <0>{0}</0> naar <1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "heeft de kaart naar een andere lijst verplaatst"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Mijn webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Naam"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navigatie"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Hulp nodig?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Nieuw"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Nieuwe {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nieuwe API-sleutel"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Nieuwe kaart"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nieuwe checklist"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nieuwe import"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nieuw label"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nieuwe lijst"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Nieuw wachtwoord is verplicht"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "Nieuw wachtwoord moet verschillen van het huidige wachtwoord"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Nieuwe sjabloon"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Nieuw ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Nieuwe webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Nieuwe werkruimte"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Nieuwsbrief"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Volgende stappen"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Geen {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Geen gearchiveerde boards"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Er zijn momenteel geen authenticatiemethoden beschikbaar"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Geen borden gevonden"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Geen creditcard vereist"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Geen datums"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Geen download-URL beschikbaar voor deze bijlage."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Geen sneltoetsen geregistreerd."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Geen lijsten"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Er zijn nog geen lijsten aangemaakt"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Geen projecten gevonden"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Geen resultaten gevonden voor \"{debouncedQuery}\"."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Nog geen rollen gevonden voor deze workspace."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Geen webhooks geconfigureerd. Voeg een webhook toe om meldingen te ontvangen."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Aanbieding"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "On-premise implementatieoptie"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Zodra je je account verwijdert, is er geen weg terug. Deze actie kan niet ongedaan worden gemaakt."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Zodra je je workspace verwijdert, is er geen weg terug. Deze actie kan niet ongedaan worden gemaakt."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Commandomenu openen"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Sneltoetsen openen"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Open source vrienden"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "of"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organiseer en vind kaarten snel met krachtige filtertools."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "OSS Friends"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Achterstallig"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Overschrijvingen gewist"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Beheer je eigen data"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Pagina niet gevonden"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Parttime"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Wachtwoord gewijzigd"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Wachtwoord is vereist om in te loggen."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Wachtwoord is vereist om je aan te melden."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "Wachtwoord moet minimaal 8 tekens bevatten"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Wachtwoorden komen niet overeen"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Gepauzeerd"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Betalingsfrequentie"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "In behandeling"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "per gebruiker/maand"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Prijzen per gebruiker"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Perfect voor kleine en groeiende teams die willen samenwerken."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Toestemming"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Toestemmingen"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Toestemmingen gereset"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Toestemmingen bijgewerkt"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Persoonlijk project"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Kies een abonnement om te beginnen. Alle betaalde abonnementen hebben een gratis proefperiode van 14 dagen."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Gepland"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planning"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Platform"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Bevestig je nieuwe wachtwoord"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Voer een geldig e-mailadres in"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Voer een geldige naam in"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Voer een geldig wachtwoord in"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Voer een geldige URL in"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Voer een geldige YouTube-URL in"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Selecteer een bestand om te uploaden."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Probeer het later opnieuw of neem contact op met klantenservice."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Probeer het later opnieuw."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Probeer het opnieuw."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Positie in lijst (0 = eerste, leeg laten voor het einde)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Prijzen"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Prioritaire e-mailondersteuning"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Privacybeleid"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privé"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Pro-abonnement"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Pro-abonnement ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Profielafbeelding bijgewerkt"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Profielfoto"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Openbaar"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Publiceren"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Vraag"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Vragen?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Quick win"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Recruitment"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Afgewezen"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Op afstand"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Verwijderen"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Verwijderen uit favorieten"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Lid verwijderen"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "heeft {0} labels verwijderd: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "heeft een label van de kaart verwijderd"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "heeft een lid van de kaart verwijderd"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "heeft een bijlage verwijderd"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "heeft een bijlage verwijderd <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Verwijderd uit favorieten"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "heeft label <0>{0}</0> verwijderd"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "heeft de vervaldatum verwijderd"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "heeft een checklist hernoemd"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "heeft checklist <0>{0}</0> hernoemd"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "heeft checklistitem hernoemd naar <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Aangevraagd"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Onderzoek"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Terugzetten naar rolstandaarden"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Resolutie"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Bronnen"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Beoordeling"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Roadmap"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Rol"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Rol bijgewerkt"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Rollen en machtigingen"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Draai op je eigen infrastructuur"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Zaterdag"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Opslaan"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Wijzigingen opslaan"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Bespaar tijd met herbruikbare bordsjablonen."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Screening"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Zoek borden en kaarten..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Geheim (optioneel)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Geheim mag niet meer dan 512 tekens bevatten"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Beveiliging"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Bekijk wat onze gebruikers over Kan zeggen"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Selecteer een lijst"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Alles selecteren"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Selecteer minimaal één gebeurtenis"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Selecteer bron"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Zelf hosten"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Zelf hosten met Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "heeft de kaart aan zichzelf toegewezen"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Feedback versturen"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Test verzenden"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Senior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Vervaldatum instellen"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "heeft de vervaldatum ingesteld"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Stel je werkruimte in"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Instellingen"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Instellingen | Account"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Instellingen | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Instellingen | Facturering"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Instellingen | Integraties"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Instellingen | Rechten"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Instellingen | Webhooks"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Instellingen | Werkruimte"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Sneltoetsen"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Inloggen"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Inloggen"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Uitloggen"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Registreren"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Registreren | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Registratie uitgeschakeld"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "Registratie is momenteel uitgeschakeld. Probeer het later opnieuw."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Registreren met "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Eenvoudige prijzen"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Eenvoudig, visueel taakbeheer dat gewoon werkt. Sleep kaarten, werk samen met je team en krijg meer gedaan."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Klein"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Social media"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Softwareontwikkeling"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Star op Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Start 14 dagen gratis proefperiode"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Start gratis. Upgrade naarmate je team groeit. Geen verborgen kosten, geen contracten."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Status"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Abonnement vereist"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Succes"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Zondag"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Geef je workspace een boost voor slechts €29/maand. Dit krijg je:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Ondersteuning"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Ondersteun de ontwikkeling van het project"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Systeem"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Team"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Teamabonnement"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Teams"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Sjabloon"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Sjabloon aangemaakt"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Sjabloon succesvol aangemaakt"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Sjabloonnaam mag niet meer dan 100 tekens bevatten"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Sjabloonnaam is verplicht"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Sjablonen"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Servicevoorwaarden"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Test"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Test mislukt"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test verzonden"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test webhook succesvol verzonden!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Getuigenissen"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Bedankt voor je feedback!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "Het board is gearchiveerd."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "Het board is gedearchiveerd."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "De kaart is gedupliceerd."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "Het huidige wachtwoord dat je hebt ingevoerd is onjuist."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "Het belangrijkste verschil tussen Kan en Trello is dat Kan open source is, waardoor iedereen onze code kan bekijken, aanpassen en eraan kan bijdragen. Ons cloudaanbod biedt ook geen beperkingen op functies voor individueel gebruik, terwijl Trello basisfuncties zoals het aantal borden dat je kunt maken achter een betaalmuur plaatst."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "De rechten van het lid zijn bijgewerkt."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "De rol van het lid is bijgewerkt."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "Het open source <0/> alternatief voor Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "De pagina die je zoekt bestaat niet of is verplaatst."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "De zichtbaarheid van je bord is ingesteld op {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Thema"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Ze kunnen geen toegang meer krijgen tot deze workspace."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Deze actie kan niet ongedaan worden gemaakt."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Deze API-sleutel wordt slechts één keer getoond. Bewaar deze op een veilige locatie."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Dit bord is privé of bestaat niet"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Deze bord-URL is al in gebruik"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Deze uitnodigingslink is ongeldig of verlopen."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "De rechten van dit lid zijn teruggezet naar de standaardinstellingen van hun rol."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Deze URL is al in gebruik"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Deze URL is gereserveerd"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Dit resulteert in de permanente verwijdering van alle gegevens die aan deze workspace zijn gekoppeld."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Dit resulteert in de permanente verwijdering van alle gegevens die aan je account zijn gekoppeld."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Deze workspace-URL is al in gebruik"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Deze workspace-URL is gereserveerd"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Deze workspace-gebruikersnaam is al in gebruik"
   },
   "pEb95p": {
-    "translation": "Ticket-ID gekopieerd naar klembord",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "Ticket-ID gekopieerd naar klembord"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Titel"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Titel (optioneel)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "Te doen"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Menu in-/uitschakelen"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Token is vereist"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Volg alle kaartwijzigingen met gedetailleerde activiteitengeschiedenis."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello losgekoppeld"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Trello-imports"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Triëren"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Vertrouwd door snelle teams<0/>over de hele wereld"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Kan checklistitem niet toevoegen"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Kan opmerking niet toevoegen"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Kan label niet toevoegen"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Kan overschrijvingen niet wissen"
   },
   "5MPY04": {
-    "translation": "Kan ID niet kopiëren",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Kan ID niet kopiëren"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Kan link niet kopiëren"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Kan kaart niet aanmaken"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Kan checklist niet aanmaken"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Kan lijst niet aanmaken"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Kan sjabloon niet aanmaken"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Kan webhook niet aanmaken"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Kan workspace niet aanmaken"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Kan bijlage niet verwijderen"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Kan kaart niet verwijderen"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Kan checklist niet verwijderen"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Kan checklistitem niet verwijderen"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Kan opmerking niet verwijderen"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Kan webhook niet verwijderen"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Kan kaart niet dupliceren"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Kan kaart niet verplaatsen"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Kan lid niet verwijderen"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Kan checklistitem niet opnieuw ordenen"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Kan machtigingen niet resetten"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Kan feedback niet verzenden"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Kan afrekenen niet starten"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Kan webhook niet testen"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Kan bord niet bijwerken"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Kan bord-URL niet bijwerken"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Kan zichtbaarheid van bord niet bijwerken"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Kan kaart niet bijwerken"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Kan checklist niet bijwerken"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Kan checklistitem niet bijwerken"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Kan opmerking niet bijwerken"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Kan vervaldatum niet bijwerken"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Kan labels niet bijwerken"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Kan lijst niet bijwerken"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Kan leden niet bijwerken"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Kan machtigingen niet bijwerken"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Kan rol niet bijwerken"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Kan webhook niet bijwerken"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Board dearchiveren"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "heeft <0>{0}</0> van de kaart verwijderd"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "heeft zichzelf van de kaart verwijderd"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "In behandeling"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Onbeperkt activiteitenlogboek"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Onbeperkt aantal borden"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Onbeperkt aantal borden, onbeperkt aantal lijsten, onbeperkt aantal kaarten. Geen creditcard vereist."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Onbeperkt aantal kaarten"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Onbeperkt reacties"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Onbeperkt bestandsuploads"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Onbeperkt lijsten"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Onbeperkt leden"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Onbeperkt aantal leden en een aangepaste werkruimte-URL voor teams die klaar zijn om te groeien."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Onbeperkt seats en geavanceerde functies voor groeiende teams."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Uitschrijven"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Bijwerken"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Label bijwerken"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "heeft een checklistitem bijgewerkt"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "heeft de beschrijving bijgewerkt"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "heeft de deadline bijgewerkt"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "heeft de titel bijgewerkt"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "heeft de titel bijgewerkt naar <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Upgrade naar Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Upgrade naar Pro ($29/maand)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Upload mislukt"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Urgent"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "URL mag alleen letters, cijfers en koppeltekens bevatten"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "URL mag niet langer zijn dan 2048 tekens"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "URL mag niet langer zijn dan 64 tekens"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "URL moet minimaal 3 tekens lang zijn"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Template gebruiken"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Wordt gebruikt om webhook-payloads te ondertekenen voor verificatie. Laat leeg om het bestaande geheim te behouden."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Gebruiker"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "Gebruiker is al lid van deze workspace"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Video"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Bekijk en beheer je API-sleutels."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Bekijk en beheer je facturering en abonnement."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Bekijk documentatie"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Alleen bekijken"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Bekijk onze roadmap."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Bekijk workspace"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Zichtbaarheid"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "We gebruiken de <0>AGPL-3.0-licentie</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "We konden je voorkeuren niet bijwerken. Probeer het opnieuw."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "We zijn net begonnen."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook aangemaakt"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook succesvol aangemaakt"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook verwijderd"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook succesvol verwijderd"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Webhooknaam mag niet langer zijn dan 255 tekens"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Webhooknaam is verplicht"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Webhook-test mislukt"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook bijgewerkt"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook succesvol bijgewerkt"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "Webhook-URL is verplicht"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooks"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Eerste dag van de week"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Welkom terug"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Welke licentie gebruik je?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Wat is het verschil tussen Kan en Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Toen Trello in 2011 werd gelanceerd, blies het iedereen omver met zijn zorgvuldig ontworpen eenvoud, maar door de jaren heen verloor het zijn magie en groeide het uit tot iets dat meer leek op \"Jira Lite\". Dit project is onze poging om de oorspronkelijke magie van Trello's eenvoud te heroveren, in open source."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Waarom een open source Trello maken?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Workspace"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Workspace succesvol aangemaakt. Je kunt later upgraden in de instellingen.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Workspace verwijderd"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Workspace-beschrijving"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "Workspace-beschrijving mag niet meer dan 280 tekens bevatten"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "Workspace-beschrijving moet minimaal 3 tekens lang zijn"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Workspace-beschrijving bijgewerkt"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Workspace-leden"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Workspace-naam"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Workspace-naam mag niet meer dan 64 tekens bevatten"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Workspace-naam is verplicht"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Werkruimtenaam moet minimaal 3 tekens lang zijn"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Werkruimtenaam bijgewerkt"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Werkruimte-rechten"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Werkruimte-slug bijgewerkt"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "Werkruimte-URL"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Werkruimte-gebruikersnaam"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "werkruimte-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Schrijven"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Jaarlijks"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Ja, we bieden een gratis plan voor altijd aan voor individueel gebruik. Geen beperkingen, geen paywalls, geen limieten."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Je staat op het punt je wachtwoord te wijzigen."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Je kunt dit later altijd wijzigen in de instellingen."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Je kunt een aangepaste werkruimte-URL krijgen, zoals <0>kan.bn/kan</0>, door naar je <1>werkruimte-instellingen</1> te gaan en een pro werkruimte-abonnement aan te schaffen. Alle abonnementen helpen de ontwikkeling van het project te financieren!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Je kunt teamleden uitnodigen door op de knop \"Uitnodigen\" in de rechterbovenhoek van de <0>ledenpagina</0> te klikken en hun e-mailadres in te voeren. Ze ontvangen een e-mail met een link om lid te worden van de werkruimte."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Je kunt zelf hosten door de instructies in onze <0>repo</0> te volgen."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Je hebt geen toestemming"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Je bent succesvol ingelogd."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Je bent succesvol geregistreerd."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Je bent uitgeschreven!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Je hebt onbeperkt aantal plaatsen met je Pro Plan. Er zijn geen extra kosten voor nieuwe leden!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Je moet een beheerder zijn om werkruimte-rechten te beheren."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Je bent uitgenodigd om lid te worden van een werkruimte op kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Je bent uitgenodigd om lid te worden van een werkruimte."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Je account is verwijderd."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Jouw avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Je borden zijn geïmporteerd."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Je weergavenaam is bijgewerkt."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Je bestand is succesvol geüpload."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Je GitHub-account is gekoppeld."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Je GitHub-account is ontkoppeld."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Je GitHub-account is gekoppeld."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Je wachtwoord is gewijzigd."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Je profielafbeelding is bijgewerkt."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Je projecten zijn geïmporteerd."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Je Trello-account is losgekoppeld."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Je Trello-account is gekoppeld."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Je afmeldlink mist een token. Open de nieuwste e-mail en probeer het opnieuw."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Jouw werkruimte"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Jouw werkruimtebeschrijving"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "Je werkruimtebeschrijving is bijgewerkt."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Je werkruimte is verwijderd."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Je werkruimtenaam is bijgewerkt."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "Je werkruimte-slug is bijgewerkt."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "jouw-werkruimte"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "YouTube-URL"
   }
 }

--- a/apps/web/src/locales/pl/messages.json
+++ b/apps/web/src/locales/pl/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (edytowano)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", lub zobacz nasze"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} został dodany do ulubionych."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} został usunięty z ulubionych."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} etykiety"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} nie znaleziono"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Importuj tablicę (1)} few {Importuj tablice ({boardCount})} many {Importuj tablic ({boardCount})} other {Importuj tablice ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Importuj projekt (1)} few {Importuj projekty ({projectCount})} many {Importuj projektów ({projectCount})} other {Importuj projekty ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/miesiąc"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "$0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "$10/miesiąc"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "$8/miesiąc"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 użytkownik"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "10mb przesyłania plików"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "14 dni bezpłatnego okresu próbnego · Zmień plan lub anuluj w dowolnym momencie"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Strona nie znaleziona | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Potężna, elastyczna aplikacja kanban, która pomaga organizować pracę, śledzić postępy i osiągać rezultaty — wszystko w jednym miejscu."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Konto"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Konto usunięte"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Opiekun konta"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Akcje"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Aktywna"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Aktywność"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Dziennik aktywności"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Dzienniki aktywności"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Dodaj / edytuj etykietę"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Dodaj kartę"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Dodaj element..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Dodaj checklistę"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Dodaj komentarz... (wpisz '/' aby otworzyć polecenia lub '@', aby wspomnieć)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Dodaj opis... (wpisz '/' aby otworzyć polecenia lub '@', aby wspomnieć)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Dodaj szczegóły..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Dodaj etykietę"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Dodaj członka"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Dodaj do ulubionych"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Dodaj webhook"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "dodano {0} etykiety: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "dodano checklistę"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "dodano element checklisty"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "dodano etykietę do karty"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "dodano członka do karty"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "dodano załącznik"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "dodano załącznik <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "dodano checklistę <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "dodano element checklisty <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "dodano etykietę <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Dodano do ulubionych"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Dodanie nowego członka będzie kosztować dodatkowo {price} ({billingType}) za miejsce."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Dopasuj kwadratowy kadr do swojego awatara."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Administrator"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Role administratora"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Zaawansowane opcje administratora"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Zaawansowane role administratora"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Zaawansowane zabezpieczenia, zgodność i dedykowane wsparcie dla dużych organizacji."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Wszystkie funkcje wersji Free +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Wszystkie nadpisania uprawnień członków zostały zresetowane do domyślnych ustawień ról."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Wszystkie funkcje wersji Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Wszystkie systemy działają prawidłowo"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Wszystkie funkcje wersji Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Masz już konto? <0><1>Zaloguj się</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Wystąpił błąd podczas łączenia konta GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Wystąpił błąd podczas odłączania konta GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Wystąpił błąd podczas odłączania konta Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Rocznie"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Każdy, kto ma ten link, może dołączyć do twojego workspace"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Utworzono klucz API"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Nazwa klucza API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "Nazwa klucza API nie może przekraczać 30 znaków"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "Nazwa klucza API jest wymagana"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Klucze API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Dokumentacja API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Kandydaci"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Zatwierdzenie"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Zarchiwizuj tablicę"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Zarchiwizowana"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Czy na pewno chcesz usunąć {entityLabel}?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Czy na pewno chcesz usunąć webhook \"{webhookName}\"? Tej operacji nie można cofnąć."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Czy na pewno chcesz usunąć workspace {0}?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Czy na pewno chcesz usunąć ten/ta {0}?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Czy na pewno chcesz usunąć tę kartę?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Czy na pewno chcesz usunąć tę checklistę?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Czy na pewno chcesz usunąć ten komentarz?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Czy na pewno chcesz usunąć tę etykietę?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Czy na pewno chcesz usunąć swoje konto?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "przypisano <0>{0}</0> do karty"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Przypisane osoby"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Załącznik przesłany"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Oczekiwanie na klienta"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Wstecz"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Podstawowy Kanban"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Podstawowy Roadmap"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Najlepsze dla osób indywidualnych i twórców rozpoczynających pracę"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Najlepsze dla dużych organizacji z zaawansowanymi potrzebami"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Najlepsze dla małych i rozwijających się zespołów wymagających współpracy"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Najlepszy dla małych zespołów, które chcą współpracować i działać szybciej razem."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Najlepsze dla zespołów, które chcą się rozwijać bez ograniczeń"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "rozliczane rocznie"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "rozliczane miesięcznie"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Rozliczenia"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Portal rozliczeniowy"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Post na blogu"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Tablica"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Analiza tablicy"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tablica zarchiwizowana"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Nazwa tablicy nie może przekraczać 100 znaków"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Nazwa tablicy jest wymagana"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Nie znaleziono tablicy"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Szablony tablic"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Tablica przywrócona z archiwum"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "Adres URL tablicy może zawierać tylko litery, cyfry i myślniki"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "Adres URL tablicy nie może przekraczać 60 znaków"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "Adres URL tablicy skopiowany do schowka"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "Adres URL tablicy musi mieć co najmniej 3 znaki"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Widoczność tablicy"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Zaktualizowano widoczność tablicy"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Tablice"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Zarchiwizowane tablice pojawią się tutaj."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Burza mózgów"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Błąd"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Zgłoszenie błędu"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Może dodawać komentarze"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Może tworzyć tablice"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Może tworzyć karty"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Może tworzyć listy"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Może usuwać tablice"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Może usuwać karty"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Może usuwać komentarze"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Może usuwać listy"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Może usuwać przestrzeń roboczą"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Może edytować tablice"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Może edytować karty"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Może edytować komentarze"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Może edytować listy"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Może edytować role i uprawnienia członków"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Może edytować przestrzeń roboczą"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Może zapraszać członków"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Może zarządzać ustawieniami przestrzeni roboczej"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Może usuwać członków"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Może wyświetlać tablice"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Może wyświetlać karty"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Może wyświetlać komentarze"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Może wyświetlać listy"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Może wyświetlać członków"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Może wyświetlać przestrzeń roboczą"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Anuluj"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Karta"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Karta zduplikowana"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Nie znaleziono karty"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Tytuł karty"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "Adres URL karty skopiowany do schowka"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Zmień hasło"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Zmień rozmiar czcionki aplikacji."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Zmień preferencje językowe."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "zmienił termin na <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Sprawdź niektóre z naszych ulubionych projektów open source."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Sprawdź swoją skrzynkę odbiorczą"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nazwa checklisty"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklisty"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Wybierz plan"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Wyczyść wszelkie niestandardowe uprawnienia członka, aby wszyscy członkowie dziedziczyli uprawnienia tylko z domyślnych ról."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Wyczyść niestandardowe uprawnienia"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Wyczyść filtry"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Kliknij w link, który wysłaliśmy do {magicLinkRecipient}, aby się zalogować."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Zamknij"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Code review"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Współpracuj płynnie ze swoim zespołem."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Współpraca"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Wkrótce dostępne"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Komentarze"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Firma"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Ukończ"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Pełna kontrola i własność:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "ukończono element listy kontrolnej"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "ukończono element listy kontrolnej <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Konfigurowalne role i uprawnienia użytkowników"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Skonfiguruj webhooki, aby otrzymywać powiadomienia o tworzeniu, aktualizacji, przenoszeniu lub usuwaniu kart."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Skonfiguruj, które działania są dozwolone dla każdej roli w przestrzeni roboczej. Te uprawnienia dotyczą wszystkich członków z tą rolą."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Potwierdź swoje preferencje dotyczące e-maili:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Potwierdź nowe hasło"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Połącz"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Połącz z GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Połącz Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Połącz swoje ulubione narzędzia, aby usprawnić pracę."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Połącz swoje konto GitHub, aby zaimportować projekty."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Połącz swoje konto Trello, aby zaimportować tablice."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Kontakt"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Kontakt z działem sprzedaży"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Skontaktuj się z nami"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Tworzenie treści"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Kontynuuj"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Kontynuuj przez "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Kontynuuj przez {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Kontroluj, kto może wyświetlać i edytować twoje tablice."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Konwertuj na link"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Kopiuj link do tablicy"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Kopiuj link do karty"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Kopiuj listy kontrolne"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Kopiuj etykiety"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Kopiuj link do karty"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Kopiuj członków"
   },
   "7mrkyO": {
-    "translation": "Skopiuj ID zgłoszenia",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Skopiuj ID zgłoszenia"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Funkcje podstawowe"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Utwórz {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Utwórz kolejną"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Utwórz klucz API"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Utwórz kartę"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Utwórz checklistę"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Utwórz link zaproszenia"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Utwórz etykietę"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Utwórz listę"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Utwórz nową {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Utwórz nowy klucz"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Utwórz nową etykietę"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Utwórz nową listę"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Utwórz szablon"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Utwórz webhook"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Utwórz workspace"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Utworzono"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "utworzył(a) kartę"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Krytyczne"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Przytnij swój avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Wymagane jest obecne hasło"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Niestandardowe szablony tablic"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Niestandardowy branding"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Własna domena"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Niestandardowe uprawnienia"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "Niestandardowy SLA"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Własne adresy URL wymagają przejścia na plan Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Niestandardowa nazwa użytkownika"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Niestandardowe nazwy użytkownika wymagają uaktualnienia do planu Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "Niestandardowy adres URL workspace"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Niestandardowa nazwa użytkownika workspace"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Obsługa klienta"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Ciemny"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Dezaktywuj link zaproszenia"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Dedykowany opiekun konta"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Domyślna nazwa użytkownika"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Usuń"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Usuń konto"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Usuń tablicę"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Usuń kartę"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Usuń komentarz"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Usuń listę"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Usuń szablon"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Usuń webhook"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Usuń workspace"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "usunięto checklistę"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "usunięto element checklisty"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "usunięto checklistę <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "usunięto element checklisty <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Design"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Odłącz GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Odłącz Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Dyskutuj i współpracuj nad kartami."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Nazwa wyświetlana"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Nazwa wyświetlana nie może przekraczać 280 znaków"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Nazwa wyświetlana musi mieć co najmniej 3 znaki"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Nazwa wyświetlana została zaktualizowana"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Czy oferujecie darmowy plan?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Czy chcesz zrezygnować z subskrypcji?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "dokumentacja"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Dokumentacja"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Dokumentacja"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Nie masz konta? <0><1>Zarejestruj się</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Gotowe"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Pobieranie nie powiodło się"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Termin wykonania"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Termin w przyszłym miesiącu"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Termin w przyszłym tygodniu"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Termin dzisiaj"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Termin jutro"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplikuj"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Duplikuj kartę"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplikowanie…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Edytuj"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Edytuj URL tablicy"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Edytuj komentarz"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Edytuj etykietę"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Edytuj uprawnienia"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Edytuj webhook"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Edytuj URL przestrzeni roboczej"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Edytuj film na YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Edycja"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "email"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "E-mail"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Powiadomienia e-mail"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Powiadomienia e-mail o wzmiankach"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Widoczność e-maila"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Koniec listy"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Inżynieria"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Ulepszenie"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Wprowadź własny tytuł"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Wprowadź nowy sekret, aby zaktualizować"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Wprowadź swoje obecne hasło"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Wprowadź swoje obecne hasło i wybierz nowe, bezpieczne hasło."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Wprowadź swój adres e-mail"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Wprowadź swoje imię i nazwisko"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Wprowadź nowe hasło"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Wprowadź hasło"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Błąd"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Błąd podczas zmiany hasła"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Błąd podczas łączenia z GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Błąd podczas tworzenia linku zaproszenia"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Błąd podczas dezaktywacji linku zaproszenia"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Błąd podczas usuwania konta"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Błąd podczas usuwania etykiety"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Błąd podczas usuwania przestrzeni roboczej"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Błąd podczas odłączania GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Błąd podczas odłączania Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Błąd podczas zapraszania członka"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Błąd podczas aktualizacji wyświetlanej nazwy"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Błąd podczas aktualizacji opisu przestrzeni roboczej"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Błąd podczas aktualizacji nazwy przestrzeni roboczej"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Błąd podczas aktualizacji adresu URL przestrzeni roboczej"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Błąd podczas aktualizacji subskrypcji"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Błąd podczas aktualizacji do wersji Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Błąd podczas przesyłania zdjęcia profilowego"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Zdarzenia"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Wszystko z darmowego planu oraz:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Wszystko, czego potrzebujesz, za darmo na zawsze. Nielimitowane tablice, nielimitowane listy, nielimitowane karty. Możesz uaktualnić w dowolnym momencie."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Wykonanie"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Rozszerzona mapa drogowa"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Nie udało się zaakceptować zaproszenia. Spróbuj ponownie później lub skontaktuj się z obsługą klienta."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Nie udało się skopiować linku do zaproszenia"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Nie udało się utworzyć tablicy"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Nie udało się utworzyć webhooka"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Nie udało się usunąć webhooka"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Nie udało się pobrać informacji o wideo"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Nie udało się zalogować przez {0}. Spróbuj ponownie."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Nie udało się przetestować webhooka"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Nie udało się zaktualizować webhooka"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Nie udało się przesłać załącznika. Spróbuj ponownie."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "FAQ"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Funkcja"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Prośba o funkcję"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Funkcje"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Opinia"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Opinia została wysłana"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Przesyłanie plików"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filtruj"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Znajdź odpowiedzi na najczęstsze pytania dotyczące Kan. Nie możesz znaleźć tego, czego szukasz? Śmiało <0>skontaktuj się z nami</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Rozmiar czcionki"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Aby zapewnić długoterminową stabilność, wiemy, że wszystkie dobre projekty open source potrzebują źródła finansowania. Naszym jest płatna chmura dla przestrzeni roboczych z wieloma użytkownikami oraz dla niestandardowych slugów przestrzeni roboczych. Nie ma obowiązku korzystania z tej opcji – możesz samodzielnie hostować oprogramowanie na własnej infrastrukturze bez żadnych opłat."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Darmowe"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Darmowe dla wszystkich"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Plan darmowy"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Darmowe, na zawsze"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Pełny dostęp do API"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Pełny etat"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Zabawa"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Ogólne"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Rozpocznij"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Rozpocznij"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Rozpocznij, tworząc nowy {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Rozpocznij, tworząc nową listę"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Rozpocznij za darmo już dziś"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Rozpocznij za darmo, bez limitów użytkowania. Aby współpracować, przejdź na plan dopasowany do wielkości Twojego zespołu."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Rozpocznij w chmurze"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Pierwsze kroki"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub połączony"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub odłączony"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Przejdź do strony głównej"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Przejdź do aplikacji"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Przejdź do tablic"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Przejdź do strony głównej"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Przejdź do członków"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Przejdź do ustawień"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Przejdź do szablonów"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Dobry dla osób zaczynających, które potrzebują tylko podstaw."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Gość"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Wysoki priorytet"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Zatrudniony"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Sekret HMAC do weryfikacji podpisu"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Hostuj Kan na własnej infrastrukturze. Idealne dla organizacji, które potrzebują pełnej kontroli nad swoimi danymi."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Jak uzyskać własny adres URL?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Jak zaimportować moje tablice Trello?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Jak zaprosić członków zespołu?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Jak samodzielnie hostować?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Jak finansowany jest projekt?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Potwierdzam, że wszystkie dane mojego konta zostaną trwale usunięte i chcę kontynuować."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Potwierdzam, że wszystkie dane przestrzeni roboczej zostaną trwale usunięte i chcę kontynuować."
   },
   "VOwhhz": {
-    "translation": "ID skopiowane",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID skopiowane"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Pomysły"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Pomysły na ulepszenie tej strony..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importuj"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Import zakończony"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Import nie powiódł się"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Zaimportuj swoje tablice Trello i zacznij działać od razu."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Ważne"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importowanie z Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Importowanie tablic Trello do Kan jest proste. Możesz skorzystać z naszego przewodnika krok po kroku <0>tutaj</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Importy"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "w"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "W trakcie"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Nieaktywny"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Osoby"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integracje"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Inteligentne wyszukiwanie"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Rozmowa kwalifikacyjna"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Nieprawidłowy adres e-mail"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Nieprawidłowe zaproszenie"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Zaproś"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Link do zaproszenia skopiowany"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Link do zaproszenia skopiowany do schowka"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Linki do zaproszeń"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Linki do zaproszeń wymagają subskrypcji Team lub Pro. Zaktualizuj swój workspace."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Zaproś członka"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Zapraszanie członków wymaga planu Team. Zostaniesz przekierowany(-a) do aktualizacji workspace."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Dołącz do workspace"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Dołącz do workspace | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Junior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban jest lepszy w zespole. Idealny dla małych i rozwijających się zespołów, które chcą współpracować."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Nowe spojrzenie na Kanban"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Pamiętaj, że tej akcji nie można cofnąć."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Skróty klawiaturowe"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Etykiety"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Etykiety i filtry"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Etykiety i filtry"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Język"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Duży"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Oferta na start"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Oferta na start: nielimitowana liczba członków z Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Oferta na start: nielimitowane miejsca za jedyne 29 $/mies. z Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Dowiedz się więcej"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Nauka"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Prawne"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licencja"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Jasny"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Ograniczony dostęp do API"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Link skopiowany"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Lista"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Nazwa listy"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Listy"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Załaduj więcej aktywności"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Ładowanie uprawnień..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Ładowanie..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Logowanie | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Wyloguj się"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Długoterminowy"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Doceniany przez zespoły na całym świecie"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Niski priorytet"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "magic link"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Utwórz szablon"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Zarządzaj członkami"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "oznaczył(a) element listy kontrolnej jako nieukończony"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "oznaczył(a) element listy kontrolnej <0>{0}</0> jako nieukończony"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Średni"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Średni priorytet"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Członek"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Członkowie"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Członkowie | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Wzmianki"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Poniedziałek"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Miesięcznie"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "rozliczenie miesięczne"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Przenieś do innej listy"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Przenieś do listy"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "przeniósł(-ęła) kartę z <0>{0}</0> do<1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "przeniósł(-ęła) kartę do innej listy"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Mój webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Nazwa"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Nawigacja"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Potrzebujesz pomocy?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Nowy"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Nowy {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nowy klucz API"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Nowa karta"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nowa lista kontrolna"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nowy import"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nowa etykieta"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nowa lista"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Wymagane jest nowe hasło"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "Nowe hasło musi się różnić od obecnego"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Nowy szablon"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Nowe zgłoszenie"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Nowy webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Nowy workspace"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Następne kroki"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Brak {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Brak zarchiwizowanych tablic"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Obecnie nie są dostępne żadne metody uwierzytelniania"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Nie znaleziono żadnych tablic"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Nie wymaga karty kredytowej"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Brak dat"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Brak dostępnego adresu URL do pobrania tego załącznika."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Nie zarejestrowano skrótów klawiaturowych."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Brak list"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Nie utworzono jeszcze żadnych list"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Nie znaleziono projektów"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Nie znaleziono wyników dla „{debouncedQuery}”."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Nie znaleziono jeszcze żadnych ról dla tego workspace'a."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Brak skonfigurowanych webhooków. Dodaj webhook, aby otrzymywać powiadomienia."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Oferta"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Opcja wdrożenia on-premise"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Po usunięciu konta nie będzie można tego cofnąć. Tej operacji nie da się odwrócić."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Po usunięciu workspace'a nie będzie można tego cofnąć. Tej operacji nie da się odwrócić."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Otwórz menu poleceń"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Otwórz skróty klawiaturowe"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Przyjaciele Open Source"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "lub"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organizuj i wyszukuj karty szybko dzięki zaawansowanym narzędziom filtrowania."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "OSS Friends"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Zaległe"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Nadpisania usunięte"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Zarządzaj swoimi danymi"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Strona nie znaleziona"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Niepełny etat"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Hasło zostało zmienione"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Do zalogowania wymagane jest hasło."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Do rejestracji wymagane jest hasło."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "Hasło musi mieć co najmniej 8 znaków"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Hasła nie są zgodne"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Wstrzymane"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Częstotliwość płatności"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Oczekujące"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "za użytkownika/miesiąc"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Cennik per stanowisko"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Idealne dla małych i rozwijających się zespołów, które chcą współpracować."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Uprawnienie"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Uprawnienia"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Uprawnienia zresetowane"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Uprawnienia zaktualizowane"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Projekt osobisty"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Wybierz plan, aby rozpocząć. Wszystkie płatne plany zawierają 14-dniowy bezpłatny okres próbny."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Zaplanowane"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planowanie"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Platforma"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Potwierdź nowe hasło"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Wprowadź poprawny adres e-mail"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Wprowadź poprawne imię"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Wprowadź poprawne hasło"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Wprowadź poprawny adres URL"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Wprowadź poprawny adres URL YouTube"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Wybierz plik do przesłania."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Spróbuj ponownie później lub skontaktuj się z obsługą klienta."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Spróbuj ponownie później."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Spróbuj ponownie."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Pozycja na liście (0 = pierwsza, puste pole = koniec)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Cennik"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Priorytetowe wsparcie e-mailowe"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Polityka prywatności"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Prywatne"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Plan Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Plan Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Zaktualizowano zdjęcie profilowe"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Zdjęcie profilowe"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Publiczne"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Publikowanie"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Pytanie"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Pytania?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Szybka wygrana"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Rekrutacja"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Odrzucono"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Zdalnie"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Usuń"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Usuń z ulubionych"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Usuń członka"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "usunięto {0} etykiety: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "usunięto etykietę z karty"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "usunięto członka z karty"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "usunięto załącznik"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "usunięto załącznik <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Usunięto z ulubionych"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "usunięto etykietę <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "usunięto termin"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "zmieniono nazwę checklisty"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "zmieniono nazwę checklisty <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "zmieniono nazwę elementu checklisty na <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Zażądano"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Badania"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Przywróć domyślne uprawnienia roli"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Rozwiązanie"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Zasoby"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Recenzja"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Mapa drogowa"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Rola"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Zaktualizowano rolę"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Role i uprawnienia"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Uruchom na własnej infrastrukturze"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Sobota"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Zapisz"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Zapisz zmiany"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Oszczędzaj czas dzięki szablonom tablic do wielokrotnego użytku."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Screening"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Wyszukaj tablice i karty..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Sekret (opcjonalnie)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Sekret nie może przekraczać 512 znaków"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Bezpieczeństwo"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Zobacz, co nasi użytkownicy mówią o Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Wybierz listę"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Zaznacz wszystko"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Wybierz co najmniej jedno zdarzenie"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Wybierz źródło"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Samodzielny hosting"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Samodzielny hosting z Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "samodzielnie przypisał(a) kartę"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Prześlij opinię"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Wyślij test"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Starszy"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Ustaw termin"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "ustaw termin"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Skonfiguruj swoją przestrzeń roboczą"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Ustawienia"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Ustawienia | Konto"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Ustawienia | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Ustawienia | Rozliczenia"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Ustawienia | Integracje"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Ustawienia | Uprawnienia"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Ustawienia | Webhooki"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Ustawienia | Workspace"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Skróty klawiaturowe"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Zaloguj się"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Zaloguj się"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Wyloguj się"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Zarejestruj się"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Rejestracja | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Rejestracja wyłączona"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "Rejestracja jest obecnie wyłączona. Spróbuj ponownie później."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Zarejestruj się przez "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Prosty cennik"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Proste, wizualne zarządzanie zadaniami, które po prostu działa. Przeciągaj i upuszczaj karty, współpracuj z zespołem i osiągaj więcej."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Mały"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Social Media"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Software Development"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Daj gwiazdkę na Githubie"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Rozpocznij 14-dniowy bezpłatny okres próbny"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Zacznij za darmo. Rozwijaj się wraz z zespołem. Bez ukrytych opłat, bez umów."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Status"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Wymagana subskrypcja"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Sukces"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Niedziela"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Ulepsz swoje środowisko pracy za jedyne 29$/miesiąc. Oto co otrzymasz:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Wsparcie"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Wesprzyj rozwój projektu"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "System"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Zespół"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Plan zespołowy"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Zespoły"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Szablon"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Szablon utworzony"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Szablon został pomyślnie utworzony"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Nazwa szablonu nie może przekraczać 100 znaków"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Nazwa szablonu jest wymagana"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Szablony"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Regulamin"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Test"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Test nie powiódł się"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Test wysłany"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Webhook testowy został wysłany pomyślnie!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Referencje"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Dziękujemy za Twoją opinię!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "Tablica została zarchiwizowana."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "Tablica została przywrócona z archiwum."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "Karta została zduplikowana."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "Wprowadzone obecne hasło jest nieprawidłowe."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "Główna różnica między Kan a Trello polega na tym, że Kan jest open source, co pozwala każdemu przeglądać, modyfikować i współtworzyć nasz kod. Nasza chmura nie nakłada żadnych ograniczeń na funkcje dla użytkowników indywidualnych, podczas gdy Trello blokuje podstawowe funkcje, takie jak liczba tablic, które możesz utworzyć, za paywallem."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "Uprawnienia członka zostały zaktualizowane."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "Rola członka została zaktualizowana."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "Open source’owa <0/> alternatywa dla Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "Strona, której szukasz, nie istnieje lub została przeniesiona."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "Widoczność Twojej tablicy została ustawiona na {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Motyw"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Nie będą mogli uzyskać dostępu do tego workspace’a."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Tej operacji nie można cofnąć."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Ten klucz API zostanie wyświetlony tylko raz. Zapisz go w bezpiecznym miejscu."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Ta tablica jest prywatna lub nie istnieje"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Ten adres URL tablicy jest już zajęty"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Ten link z zaproszeniem jest nieprawidłowy lub wygasł."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "Uprawnienia tego członka zostały zresetowane do domyślnych dla jego roli."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Ten adres URL jest już zajęty"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Ten adres URL jest zarezerwowany"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Spowoduje to trwałe usunięcie wszystkich danych powiązanych z tym workspace’em."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Spowoduje to trwałe usunięcie wszystkich danych powiązanych z Twoim kontem."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Ten adres URL workspace’a jest już zajęty"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Ten adres URL workspace jest zarezerwowany"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Ta nazwa użytkownika workspace jest już zajęta"
   },
   "pEb95p": {
-    "translation": "ID zgłoszenia skopiowane do schowka",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID zgłoszenia skopiowane do schowka"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Tytuł"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Tytuł (opcjonalnie)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "Do zrobienia"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Przełącz menu"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Wymagany jest token"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Śledź wszystkie zmiany kart z szczegółową historią aktywności."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello zostało odłączone"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Importy z Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Sortowanie zgłoszeń"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Zaufany przez dynamiczne zespoły<0/>na całym świecie"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Nie można dodać elementu listy kontrolnej"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Nie można dodać komentarza"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Nie można dodać etykiety"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Nie można wyczyścić nadpisań"
   },
   "5MPY04": {
-    "translation": "Nie udało się skopiować ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Nie udało się skopiować ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Nie można skopiować linku"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Nie można utworzyć karty"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Nie można utworzyć listy kontrolnej"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Nie można utworzyć listy"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Nie można utworzyć szablonu"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Nie można utworzyć webhooka"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Nie można utworzyć workspace"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Nie można usunąć załącznika"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Nie można usunąć karty"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Nie można usunąć listy kontrolnej"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Nie można usunąć elementu listy kontrolnej"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Nie można usunąć komentarza"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Nie można usunąć webhooka"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Nie można zduplikować karty"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Nie można przenieść karty"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Nie można usunąć członka"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Nie można zmienić kolejności elementu listy kontrolnej"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Nie można zresetować uprawnień"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Nie można wysłać opinii"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Nie można rozpocząć procesu płatności"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Nie można przetestować webhooka"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Nie można zaktualizować tablicy"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Nie można zaktualizować adresu URL tablicy"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Nie można zaktualizować widoczności tablicy"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Nie można zaktualizować karty"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Nie można zaktualizować listy kontrolnej"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Nie można zaktualizować elementu listy kontrolnej"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Nie można zaktualizować komentarza"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Nie można zaktualizować terminu"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Nie można zaktualizować etykiet"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Nie można zaktualizować listy"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Nie można zaktualizować członków"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Nie można zaktualizować uprawnień"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Nie można zaktualizować roli"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Nie można zaktualizować webhooka"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Przywróć tablicę z archiwum"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "<0>{0}</0> został(a) odpięty(a) od karty"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "Użytkownik odpiął się od karty"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "W trakcie przeglądu"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Nielimitowany dziennik aktywności"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Nielimitowane tablice"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Nielimitowane tablice, nielimitowane listy, nielimitowane karty. Nie wymaga karty kredytowej."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Nielimitowane karty"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Nielimitowane komentarze"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Nielimitowane przesyłanie plików"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Nielimitowane listy"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Nielimitowani członkowie"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Nieograniczona liczba członków i niestandardowa nazwa użytkownika przestrzeni roboczej dla zespołów gotowych do rozwoju."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Nielimitowane miejsca i zaawansowane funkcje dla rozwijających się zespołów."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Anuluj subskrypcję"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Aktualizuj"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Aktualizuj etykietę"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "zaktualizowano element listy kontrolnej"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "zaktualizowano opis"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "zaktualizowano termin"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "zaktualizowano tytuł"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "zaktualizowano tytuł na <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Ulepsz do Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Ulepsz do Pro (29 $/miesiąc)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Przesyłanie nie powiodło się"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Pilne"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "URL może zawierać tylko litery, cyfry i myślniki"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "URL nie może przekraczać 2048 znaków"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "URL nie może przekraczać 64 znaków"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "URL musi mieć co najmniej 3 znaki"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Użyj szablonu"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Służy do podpisywania danych webhook w celu weryfikacji. Pozostaw puste, aby zachować istniejący sekret."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Użytkownik"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "Użytkownik jest już członkiem tego workspace"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Wideo"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Wyświetlaj i zarządzaj swoimi kluczami API."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Zobacz i zarządzaj swoim rozliczeniem oraz subskrypcją."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Zobacz dokumentację"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Tylko podgląd"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Zobacz naszą mapę drogową."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Zobacz przestrzeń roboczą"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Widoczność"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Korzystamy z <0>licencji AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Nie udało się zaktualizować Twoich preferencji. Spróbuj ponownie."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Dopiero zaczynamy."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook utworzony"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook został utworzony pomyślnie"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook usunięty"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook został usunięty pomyślnie"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Nazwa webhooka nie może przekraczać 255 znaków"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Nazwa webhooka jest wymagana"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Test webhooka nie powiódł się"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook zaktualizowany"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook został zaktualizowany pomyślnie"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "URL webhooka jest wymagany"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooki"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Pierwszy dzień tygodnia"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Witaj ponownie"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Jakiej licencji używasz?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Jaka jest różnica między Kan a Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Kiedy Trello pojawiło się w 2011 roku, zachwyciło wszystkich swoją przemyślaną prostotą, ale z czasem straciło swój urok i stało się czymś w rodzaju „Jira Lite”. Ten projekt to nasza próba odzyskania tej pierwotnej magii prostoty Trello, w wersji open source."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Dlaczego stworzyć open source'owe Trello?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Przestrzeń robocza"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Przestrzeń robocza została pomyślnie utworzona. Możesz później przejść na wyższy plan w ustawieniach.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Przestrzeń robocza została usunięta"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Opis przestrzeni roboczej"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "Opis przestrzeni roboczej nie może przekraczać 280 znaków"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "Opis przestrzeni roboczej musi mieć co najmniej 3 znaki"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Opis przestrzeni roboczej zaktualizowany"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Członkowie przestrzeni roboczej"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Nazwa przestrzeni roboczej"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Nazwa przestrzeni roboczej nie może przekraczać 64 znaków"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Nazwa przestrzeni roboczej jest wymagana"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Nazwa przestrzeni roboczej musi mieć co najmniej 3 znaki"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Nazwa przestrzeni roboczej została zaktualizowana"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Uprawnienia przestrzeni roboczej"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Slug przestrzeni roboczej został zaktualizowany"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL przestrzeni roboczej"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Nazwa użytkownika przestrzeni roboczej"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Pisanie"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Rocznie"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Tak, oferujemy wiecznie darmowy plan do użytku indywidualnego. Bez ograniczeń, bez paywalla, bez limitów."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Zaraz zmienisz swoje hasło."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Zawsze możesz to później zmienić w ustawieniach."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Możesz uzyskać własny URL przestrzeni roboczej, np. <0>kan.bn/kan</0>, przechodząc do <1>ustawień przestrzeni roboczej</1> i wykupując subskrypcję pro. Wszystkie subskrypcje wspierają rozwój projektu!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Możesz zaprosić członków zespołu, klikając przycisk „Zaproś” w prawym górnym rogu <0>strony członków</0> i wpisując ich adres e-mail. Otrzymają oni wiadomość e-mail z linkiem do dołączenia do przestrzeni roboczej."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Możesz samodzielnie hostować, postępując zgodnie z instrukcjami w naszym <0>repozytorium</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Nie masz uprawnień"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Zalogowano pomyślnie."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Rejestracja zakończona sukcesem."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Zostałeś wypisany z subskrypcji!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "W ramach planu Pro masz nielimitowaną liczbę miejsc. Nie ma dodatkowych opłat za nowych członków!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Musisz być administratorem, aby zarządzać uprawnieniami przestrzeni roboczej."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Otrzymałeś zaproszenie do przestrzeni roboczej na kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Otrzymałeś zaproszenie do przestrzeni roboczej."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Twoje konto zostało usunięte."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Twój awatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Twoje tablice zostały zaimportowane."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Twoja nazwa wyświetlana została zaktualizowana."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Twój plik został pomyślnie przesłany."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Twoje konto GitHub zostało połączone."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Twoje konto GitHub zostało odłączone."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Twoje konto GitHub jest połączone."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Twoje hasło zostało zmienione."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Twoje zdjęcie profilowe zostało zaktualizowane."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Twoje projekty zostały zaimportowane."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Twoje konto Trello zostało odłączone."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Twoje konto Trello jest połączone."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Twój link do wypisania się nie zawiera tokena. Otwórz najnowszy e-mail i spróbuj ponownie."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Twoja przestrzeń robocza"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Opis Twojej przestrzeni roboczej"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "Opis Twojego workspace został zaktualizowany."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Twój workspace został usunięty."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Nazwa Twojego workspace została zaktualizowana."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "Slug Twojego workspace został zaktualizowany."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "twoja-przestrzen"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "Adres URL YouTube"
   }
 }

--- a/apps/web/src/locales/pt-BR/messages.json
+++ b/apps/web/src/locales/pt-BR/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (editado)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", ou veja nosso"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} foi adicionado aos seus favoritos."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} foi removido dos seus favoritos."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} etiquetas"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} não encontrado"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Importar quadro (1)} other {Importar quadros ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Importar projeto (1)} other {Importar projetos ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/mês"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "$0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "$10/mês"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "$8/mês"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 usuário"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "Uploads de arquivos de 10 MB"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "Teste gratuito de 14 dias · Mude de plano ou cancele a qualquer momento"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Página Não Encontrada | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Um aplicativo kanban poderoso e flexível que ajuda você a organizar o trabalho, acompanhar o progresso e entregar resultados — tudo em um só lugar."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Conta"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Conta excluída"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Gerente de conta"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Ações"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Ativo"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Atividade"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Registro de atividades"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Registros de atividades"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Adicionar / editar etiqueta"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Adicionar um cartão"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Adicionar um item..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Adicionar checklist"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Adicionar comentário... (digite '/' para abrir comandos ou '@' para mencionar)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Adicionar descrição... (digite '/' para abrir comandos ou '@' para mencionar)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Adicionar detalhes..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Adicionar etiqueta"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Adicionar membro"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Adicionar aos favoritos"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Adicionar webhook"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "adicionou {0} etiquetas: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "adicionou um checklist"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "adicionou um item do checklist"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "adicionou uma etiqueta ao cartão"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "adicionou um membro ao cartão"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "adicionou um anexo"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "adicionou um anexo <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "adicionou checklist <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "adicionou item do checklist <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "adicionou etiqueta <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Adicionado aos favoritos"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Adicionar um novo membro custará {price} ({billingType}) adicionais por assento."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Ajuste o recorte quadrado para caber no seu avatar."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Administrador"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Funções de administrador"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Controles avançados de administrador"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Funções avançadas de administrador"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Segurança avançada, conformidade e suporte dedicado para grandes organizações."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Todos os recursos gratuitos +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Todas as substituições de permissões de membros foram redefinidas para os padrões de suas funções."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Todos os recursos Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Todos os sistemas operacionais"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Todos os recursos Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Já tem uma conta? <0><1>Entrar</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Ocorreu um erro ao conectar sua conta do GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Ocorreu um erro ao desconectar sua conta do GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Ocorreu um erro ao desconectar sua conta do Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Ocorreu um erro inesperado. Por favor, tente novamente mais tarde."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Anual"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Qualquer pessoa com este link pode entrar no seu workspace"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Chave de API criada"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Nome da chave de API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "O nome da chave de API não pode exceder 30 caracteres"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "O nome da chave de API é obrigatório"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Chaves de API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Referência da API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Candidatos"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Aprovação"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Arquivar quadro"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "Arquivado"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Tem certeza de que deseja remover {entityLabel}?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Tem certeza de que deseja excluir o webhook \"{webhookName}\"? Esta ação não pode ser desfeita."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Tem certeza de que deseja excluir o workspace {0}?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Tem certeza de que deseja excluir este {0}?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Tem certeza de que deseja excluir este cartão?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Tem certeza de que deseja excluir esta checklist?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Tem certeza de que deseja excluir este comentário?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Tem certeza de que deseja excluir esta etiqueta?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Tem certeza de que deseja excluir sua conta?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "atribuiu <0>{0}</0> ao cartão"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Responsáveis"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Anexo enviado"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Aguardando cliente"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Voltar"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Backlog"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Kanban básico"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Roadmap básico"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Ideal para indivíduos e criadores solo que estão começando"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Ideal para grandes organizações com necessidades avançadas"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Ideal para equipes pequenas e em crescimento que precisam de colaboração"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Ideal para pequenas equipes que desejam colaborar e avançar mais rápido juntas."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Ideal para equipes que desejam escalar sem limites"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "cobrado anualmente"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "cobrado mensalmente"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Cobrança"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Portal de cobrança"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Post de blog"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Quadro"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Análise do quadro"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Quadro arquivado"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "O nome do quadro não pode exceder 100 caracteres"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "O nome do quadro é obrigatório"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Quadro não encontrado"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Modelos de quadro"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Quadro desarquivado"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "A URL do quadro pode conter apenas letras, números e hífens"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "A URL do quadro não pode exceder 60 caracteres"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "URL do quadro copiada para a área de transferência"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "A URL do quadro deve ter pelo menos 3 caracteres"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Visibilidade do quadro"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Visibilidade do quadro atualizada"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Quadros"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Os quadros que você arquivar aparecerão aqui."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Brainstorming"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Bug"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Relatório de bug"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Pode adicionar comentários"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Pode criar quadros"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Pode criar cartões"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Pode criar listas"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Pode excluir quadros"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Pode excluir cartões"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Pode excluir comentários"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Pode excluir listas"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Pode excluir workspace"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Pode editar quadros"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Pode editar cartões"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Pode editar comentários"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Pode editar listas"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Pode editar funções e permissões de membros"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Pode editar workspace"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Pode convidar membros"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Pode gerenciar configurações do workspace"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Pode remover membros"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Pode visualizar quadros"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Pode visualizar cartões"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Pode visualizar comentários"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Pode visualizar listas"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Pode visualizar membros"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Pode visualizar workspace"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Cancelar"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Cartão"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Cartão duplicado"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Cartão não encontrado"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Título do cartão"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "URL do cartão copiada para a área de transferência"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Alterar senha"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Altere o tamanho da fonte do aplicativo."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Altere suas preferências de idioma."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "alterou a data de vencimento para <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Confira alguns dos nossos projetos open source favoritos."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Verifique sua caixa de entrada"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nome da checklist"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Checklists"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Escolha um plano"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Limpe quaisquer permissões personalizadas de membros para que todos os membros herdem apenas as permissões padrão de suas funções."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Limpar permissões personalizadas"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Limpar filtros"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Clique no link que enviamos para {magicLinkRecipient} para fazer login."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Fechar"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Revisão de código"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Colabore perfeitamente com sua equipe."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Colaboração"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Em breve"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Comentários"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Empresa"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Concluir"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Controle e propriedade completos:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "concluiu um item da checklist"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "concluiu o item da checklist <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Funções de usuário e permissões configuráveis"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Configure webhooks para receber notificações quando cartões forem criados, atualizados, movidos ou excluídos."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Configure quais ações são permitidas para cada função do workspace. Essas permissões se aplicam a todos os membros com essa função."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Confirme suas preferências de e-mail:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Confirme sua nova senha"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Conectar"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Conectar GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Conectar Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Conecte suas ferramentas favoritas para otimizar seu fluxo de trabalho."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Conecte sua conta do GitHub para importar projetos."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Conecte sua conta do Trello para importar quadros."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Contato"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Falar com vendas"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Entre em contato"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Criação de conteúdo"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Continuar"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Continuar com "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Continuar com {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Controle quem pode visualizar e editar seus quadros."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Converter em link"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Copiar link do quadro"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Copiar link do cartão"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Copiar checklists"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Copiar etiquetas"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Copiar link do cartão"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Copiar membros"
   },
   "7mrkyO": {
-    "translation": "Copiar ID do ticket",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Copiar ID do ticket"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Recursos principais"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Criar {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Criar outro"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Criar chave de API"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Criar cartão"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Criar checklist"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Criar link de convite"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Criar etiqueta"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Criar lista"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Criar novo {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Criar nova chave"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Criar nova etiqueta"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Criar nova lista"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Criar template"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Criar webhook"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Criar workspace"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Criado"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "criou o cartão"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Crítico"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Recortar seu avatar"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Senha atual é obrigatória"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Templates de quadro personalizados"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Marca personalizada"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Domínio personalizado"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Permissões personalizadas"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "SLA personalizado"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "URLs personalizadas exigem upgrade para um plano Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Nome de usuário personalizado"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Nomes de usuário personalizados exigem atualização para um plano Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "URL do workspace personalizada"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Nome de usuário do workspace personalizado"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Suporte ao cliente"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Escuro"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Desativar link de convite"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Gerente de conta dedicado"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Nome de usuário padrão"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Excluir"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Excluir conta"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Excluir quadro"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Excluir cartão"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Excluir comentário"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Excluir lista"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Excluir modelo"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Excluir webhook"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Excluir workspace"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "excluiu uma checklist"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "excluiu um item da checklist"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "excluiu a checklist <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "excluiu o item da checklist <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Design"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Desconectar GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Desconectar Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Discuta e colabore em cartões."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Nome de exibição"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "O nome de exibição não pode exceder 280 caracteres"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "O nome de exibição deve ter pelo menos 3 caracteres"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Nome de exibição atualizado"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "Vocês oferecem um plano gratuito?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Você deseja cancelar a assinatura?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "docs"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Docs"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Documentação"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Não tem uma conta? <0><1>Cadastre-se</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Concluído"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Falha no download"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Data de vencimento"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Vence no próximo mês"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Vence na próxima semana"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Vence hoje"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Vence amanhã"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplicar"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Duplicar cartão"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Duplicando…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Editar"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Editar URL do quadro"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Editar comentário"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Editar etiqueta"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Editar permissões"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Editar webhook"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Editar URL do workspace"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Editar vídeo do YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Editando"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "email"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "Email"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Notificações por email"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Notificações por email para menções"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Visibilidade do email"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Fim da lista"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Engenharia"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Melhoria"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Insira um título personalizado"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Digite o novo segredo para atualizar"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Insira sua senha atual"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Insira sua senha atual e escolha uma nova senha segura."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Insira seu endereço de email"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Insira seu nome"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Insira sua nova senha"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Insira sua senha"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Erro"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Erro ao alterar senha"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Erro ao conectar GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Erro ao criar link de convite"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Erro ao desativar link de convite"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Erro ao excluir conta"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Erro ao excluir etiqueta"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Erro ao excluir workspace"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Erro ao desconectar GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Erro ao desconectar Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Erro ao convidar membro"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Erro ao atualizar nome de exibição"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Erro ao atualizar descrição do workspace"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Erro ao atualizar nome do workspace"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Erro ao atualizar URL do workspace"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Erro ao fazer upgrade da assinatura"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Erro ao fazer upgrade para Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Erro ao fazer upload da imagem de perfil"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "Eventos"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Tudo do plano gratuito, mais:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Tudo que você precisa, grátis para sempre. Quadros ilimitados, listas ilimitadas, cartões ilimitados. Faça upgrade a qualquer momento."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Execução"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Roadmap estendido"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Falha ao aceitar convite. Por favor, tente novamente mais tarde ou entre em contato com o suporte."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Falha ao copiar link de convite"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Falha ao criar quadro"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Falha ao criar webhook"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Falha ao excluir webhook"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Falha ao buscar informações do vídeo"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Falha ao fazer login com {0}. Por favor, tente novamente."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Falha ao testar webhook"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Falha ao atualizar webhook"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Falha ao fazer upload do anexo. Por favor, tente novamente."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "FAQs"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Funcionalidade"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Solicitação de funcionalidade"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Funcionalidades"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Feedback"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Feedback enviado"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Upload de arquivos"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Filtrar"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Encontre respostas para perguntas comuns sobre o Kan. Não encontrou o que procura? Sinta-se à vontade para <0>entrar em contato</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Tamanho da fonte"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Para sustentabilidade a longo prazo, reconhecemos que todos os bons projetos de código aberto precisam de uma fonte de receita. A nossa vem da oferta paga na nuvem para espaços de trabalho com múltiplos usuários e para slugs de espaço de trabalho personalizados. Não há obrigação de usá-la, e você pode hospedar o software em sua própria infraestrutura gratuitamente."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Grátis"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Grátis para todos"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Plano gratuito"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Grátis, para sempre"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Acesso completo à API"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Tempo integral"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Diversão"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Geral"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Começar"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Começar"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Comece criando um novo {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Comece criando uma nova lista"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Comece gratuitamente hoje"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Comece gratuitamente, sem limites de uso. Para colaboração, faça upgrade para um plano que se ajuste ao tamanho da sua equipe."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Começar na nuvem"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Primeiros passos"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub conectado"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub desconectado"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "Ir para a página inicial"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Ir para o app"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Ir para quadros"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Ir para a página inicial"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Ir para membros"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Ir para configurações"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Ir para modelos"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Bom para indivíduos começando que precisam apenas do essencial."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Convidado"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Alta prioridade"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Contratado"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Segredo HMAC para verificação de assinatura"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Hospede o Kan em sua própria infraestrutura. Ideal para organizações que precisam de controle total sobre seus dados."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Como obtenho uma URL personalizada?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Como importo meus quadros do Trello?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Como convido membros da equipe?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Como faço auto-hospedagem?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Como o projeto é financiado?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Reconheço que todos os dados da minha conta serão permanentemente excluídos e desejo prosseguir."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Reconheço que todos os dados do workspace serão permanentemente excluídos e desejo prosseguir."
   },
   "VOwhhz": {
-    "translation": "ID copiado",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID copiado"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Ideias"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Ideias para melhorar esta página..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Importar"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Importação concluída"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Falha na importação"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Importe seus quadros do Trello e comece a trabalhar imediatamente."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Importante"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Importando do Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Importar seus quadros do Trello para o Kan é fácil. Você pode seguir nosso guia passo a passo <0>aqui</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Importações"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "em"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "Em andamento"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Inativo"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Indivíduos"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Integrações"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Busca inteligente"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Entrevistando"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Endereço de e-mail inválido"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Convite inválido"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Convidar"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Link de convite copiado"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Link de convite copiado para a área de transferência"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Links de convite"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Links de convite exigem uma assinatura Team ou Pro. Faça upgrade do seu workspace."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Convidar membro"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Convidar membros requer um plano Team. Você será redirecionado para fazer upgrade do seu workspace."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Entrar no workspace"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Entrar no workspace | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Júnior"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban é melhor com uma equipe. Perfeito para equipes pequenas e em crescimento que buscam colaborar."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban reimaginado"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Tenha em mente que esta ação é irreversível."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Atalhos de teclado"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Etiquetas"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Etiquetas e filtros"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Etiquetas e filtros"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Idioma"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Grande"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Oferta de lançamento"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Oferta de lançamento: membros ilimitados com Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Oferta de lançamento: assentos ilimitados por apenas $29/mês com Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Saiba mais"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Aprendizado"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Jurídico"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Licença"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Claro"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Acesso limitado à API"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Link copiado"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Lista"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Nome da lista"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Listas"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Carregar mais atividades"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Carregando permissões..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Carregando..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Login | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Sair"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Longo prazo"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Amado por equipes no mundo todo"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Prioridade baixa"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "magic link"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Criar modelo"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Gerenciar membros"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "marcou um item da checklist como incompleto"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "marcou o item da checklist <0>{0}</0> como incompleto"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Marketing"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Médio"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Prioridade média"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Membro"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Membros"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Membros | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Menções"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Segunda-feira"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Mensal"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "cobrança mensal"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Mover para outra lista"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Mover para lista"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "moveu o cartão de <0>{0}</0> para <1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "moveu o cartão para outra lista"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Meu webhook"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Nome"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Navegação"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Precisa de ajuda?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Novo"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Novo {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Nova chave de API"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Novo cartão"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Nova checklist"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Nova importação"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Nova etiqueta"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Nova lista"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "A nova senha é obrigatória"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "A nova senha deve ser diferente da senha atual"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Novo modelo"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Novo ticket"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Novo webhook"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Novo workspace"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Newsletter"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Próximos passos"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Nenhum {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Nenhum quadro arquivado"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "Nenhum método de autenticação está disponível no momento"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Nenhum quadro encontrado"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Não é necessário cartão de crédito"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Nenhuma data"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Nenhuma URL de download disponível para este anexo."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Nenhum atalho de teclado registrado."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Nenhuma lista"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Nenhuma lista foi criada ainda"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Nenhum projeto encontrado"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "Nenhum resultado encontrado para \"{debouncedQuery}\"."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Nenhuma função encontrada para este workspace ainda."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Nenhum webhook configurado. Adicione um webhook para receber notificações."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Oferta"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "On-premise"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Opção de implantação on-premise"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Onboarding"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "Depois de excluir sua conta, não há como voltar atrás. Esta ação não pode ser desfeita."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "Depois de excluir seu workspace, não há como voltar atrás. Esta ação não pode ser desfeita."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Abrir menu de comandos"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Abrir atalhos de teclado"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Open source"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Amigos open source"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "ou"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Organize e encontre cartões rapidamente com ferramentas de filtragem poderosas."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "Amigos OSS"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Atrasado"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Substituições removidas"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Seja dono dos seus dados"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Página não encontrada"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Meio período"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Senha alterada"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "A senha é obrigatória para fazer login."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "A senha é obrigatória para se cadastrar."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "A senha deve ter pelo menos 8 caracteres"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "As senhas não coincidem"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Pausado"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Frequência de pagamento"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Pendente"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "por usuário/mês"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Preço por assento"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Perfeito para equipes pequenas e em crescimento que buscam colaborar."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Permissão"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Permissões"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Permissões redefinidas"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Permissões atualizadas"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Projeto pessoal"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Escolha um plano para começar. Todos os planos pagos incluem 14 dias de teste grátis."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Planejado"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Planejamento"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Plataforma"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Confirme sua nova senha"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Por favor, insira um endereço de e-mail válido"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Por favor, insira um nome válido"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Por favor, insira uma senha válida"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Por favor, insira uma URL válida"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Por favor, insira uma URL válida do YouTube"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Por favor, selecione um arquivo para enviar."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Por favor, tente novamente mais tarde ou entre em contato com o suporte ao cliente."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Por favor, tente novamente mais tarde."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Por favor, tente novamente."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Posição na lista (0 = primeira, deixe vazio para o final)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Preços"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Suporte prioritário por e-mail"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Política de privacidade"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Privado"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Plano Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Plano Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Imagem de perfil atualizada"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Foto de perfil"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Público"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Publicação"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Pergunta"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Dúvidas?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Vitória rápida"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Recrutamento"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Rejeitado"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Remoto"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Remover"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Remover dos favoritos"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Remover membro"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "removeu {0} etiquetas: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "removeu uma etiqueta do cartão"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "removeu um membro do cartão"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "removeu um anexo"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "removeu um anexo <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Removido dos favoritos"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "removeu a etiqueta <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "removeu a data de vencimento"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "renomeou uma lista de verificação"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "renomeou a lista de verificação <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "renomeou o item da lista de verificação para <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Solicitado"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Pesquisa"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Redefinir para padrões da função"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Resolução"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Recursos"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Revisão"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Roadmap"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Função"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Função atualizada"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Funções e permissões"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Execute em sua própria infraestrutura"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Sábado"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Salvar"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Salvar alterações"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Economize tempo com modelos de quadro reutilizáveis."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Triagem"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Pesquisar quadros e cartões..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Segredo (opcional)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "O segredo não pode exceder 512 caracteres"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Segurança"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Veja o que nossos usuários estão dizendo sobre o Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Selecione uma lista"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Selecionar tudo"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Selecione pelo menos um evento"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Selecionar origem"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Auto-hospedagem"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Auto-hospedar com Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "autoatribuiu o cartão"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Enviar feedback"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Enviar teste"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Sênior"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Definir data de vencimento"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "definiu a data de vencimento"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Configure seu workspace"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Configurações"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Configurações | Conta"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Configurações | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Configurações | Faturamento"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Configurações | Integrações"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Configurações | Permissões"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Configurações | Webhooks"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Configurações | Workspace"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Atalhos"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Entrar"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Entrar"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Sair"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Cadastrar"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Cadastrar | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Cadastro desabilitado"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "O cadastro está temporariamente desabilitado. Por favor, tente novamente mais tarde."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Cadastrar com "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Preços simples"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Gerenciamento de tarefas visual e simples que funciona. Arraste e solte cartões, colabore com sua equipe e faça mais."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Pequeno"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Redes sociais"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Desenvolvimento de software"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Solo"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Favoritar no Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Iniciar teste grátis de 14 dias"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Comece grátis. Faça upgrade conforme sua equipe cresce. Sem taxas ocultas, sem contratos."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Status"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Assinatura necessária"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Sucesso"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Domingo"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Turbine seu workspace por apenas $29/mês. Veja o que você vai receber:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Suporte"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Apoie o desenvolvimento do projeto"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Sistema"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Equipe"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Plano de equipe"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Equipes"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Modelo"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Modelo criado"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Template criado com sucesso"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "O nome do template não pode exceder 100 caracteres"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "O nome do template é obrigatório"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Templates"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Termos de serviço"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Testar"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Teste falhou"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Teste enviado"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Webhook de teste enviado com sucesso!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Depoimentos"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Obrigado pelo seu feedback!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "O quadro foi arquivado."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "O quadro foi desarquivado."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "O cartão foi duplicado."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "A senha atual que você digitou está incorreta."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "A principal diferença entre Kan e Trello é que o Kan é open source, permitindo que qualquer pessoa visualize, modifique e contribua com nosso código. Nossa oferta na nuvem também não oferece restrições de recursos para uso individual, enquanto o Trello bloqueia recursos básicos, como o número de quadros que você pode criar, atrás de um paywall."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "As permissões do membro foram atualizadas."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "A função do membro foi atualizada."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "A alternativa open source <0/> ao Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "A página que você está procurando não existe ou foi movida."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "A visibilidade do seu quadro foi definida como {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Tema"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Eles não poderão acessar este workspace."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Esta ação não pode ser desfeita."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Esta chave de API será mostrada apenas uma vez. Por favor, salve-a em um local seguro."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Este quadro é privado ou não existe"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Esta URL de quadro já foi utilizada"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Este link de convite é inválido ou expirou."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "As permissões deste membro foram redefinidas para os padrões de sua função."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Esta URL já está em uso"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Esta URL é reservada"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Isso resultará na exclusão permanente de todos os dados associados a este workspace."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Isso resultará na exclusão permanente de todos os dados associados à sua conta."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Esta URL de workspace já foi utilizada"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Esta URL de workspace está reservada"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Este nome de usuário de workspace já está em uso"
   },
   "pEb95p": {
-    "translation": "ID do ticket copiado para a área de transferência",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID do ticket copiado para a área de transferência"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Título"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Título (opcional)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "A fazer"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Alternar menu"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Token é obrigatório"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Acompanhe todas as alterações do card com histórico detalhado de atividades."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello desconectado"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Importações do Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Triagem"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Confiado por equipes ágeis<0/>ao redor do mundo"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Não foi possível adicionar item da checklist"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Não foi possível adicionar comentário"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Não foi possível adicionar etiqueta"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Não foi possível limpar substituições"
   },
   "5MPY04": {
-    "translation": "Não foi possível copiar o ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Não foi possível copiar o ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Não foi possível copiar link"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Não foi possível criar card"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Não foi possível criar checklist"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Não foi possível criar lista"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Não foi possível criar template"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Não foi possível criar o webhook"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Não foi possível criar workspace"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Não foi possível excluir anexo"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Não foi possível excluir card"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Não foi possível excluir checklist"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Não foi possível excluir item da checklist"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Não foi possível excluir o comentário"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Não foi possível excluir o webhook"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Não foi possível duplicar o cartão"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Não foi possível mover o cartão"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Não foi possível remover o membro"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Não foi possível reordenar o item da checklist"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Não foi possível redefinir as permissões"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Não foi possível enviar o feedback"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Não foi possível iniciar o checkout"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Não foi possível testar o webhook"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Não foi possível atualizar o quadro"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Não foi possível atualizar a URL do quadro"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Não foi possível atualizar a visibilidade do quadro"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Não foi possível atualizar o cartão"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Não foi possível atualizar a checklist"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Não foi possível atualizar o item da checklist"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Não foi possível atualizar o comentário"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Não foi possível atualizar a data de vencimento"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Não foi possível atualizar as etiquetas"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Não foi possível atualizar a lista"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Não foi possível atualizar os membros"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Não foi possível atualizar as permissões"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Não foi possível atualizar a função"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Não foi possível atualizar o webhook"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Desarquivar quadro"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "removeu a atribuição de <0>{0}</0> do cartão"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "removeu a própria atribuição do cartão"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Em análise"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Registro de atividades ilimitado"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Quadros ilimitados"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Quadros ilimitados, listas ilimitadas, cartões ilimitados. Não é necessário cartão de crédito."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Cartões ilimitados"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Comentários ilimitados"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Uploads de arquivos ilimitados"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Listas ilimitadas"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Membros ilimitados"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Membros ilimitados e um nome de usuário personalizado para equipes prontas para crescer."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Assentos ilimitados e recursos avançados para equipes em crescimento."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Cancelar inscrição"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Atualizar"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Atualizar etiqueta"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "atualizou um item da checklist"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "atualizou a descrição"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "atualizou a data de vencimento"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "atualizou o título"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "atualizou o título para <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Fazer upgrade para Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Fazer upgrade para Pro ($29/mês)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Falha no upload"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Urgente"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "A URL pode conter apenas letras, números e hífens"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "A URL não pode exceder 2048 caracteres"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "A URL não pode exceder 64 caracteres"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "A URL deve ter pelo menos 3 caracteres"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Usar template"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Usado para assinar cargas úteis de webhook para verificação. Deixe em branco para manter o segredo existente."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Usuário"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "O usuário já é membro deste workspace"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Vídeo"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Visualize e gerencie suas chaves de API."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Visualize e gerencie sua cobrança e assinatura."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Ver documentação"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Somente visualização"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Veja nosso roadmap."
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Ver workspace"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Visibilidade"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Estamos usando a <0>licença AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Não foi possível atualizar suas preferências. Tente novamente."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Estamos apenas começando. "
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Webhook criado"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Webhook criado com sucesso"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Webhook excluído"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Webhook excluído com sucesso"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "O nome do webhook não pode exceder 255 caracteres"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "O nome do webhook é obrigatório"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "O teste do webhook falhou"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Webhook atualizado"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Webhook atualizado com sucesso"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "A URL do webhook é obrigatória"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Webhooks"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Dia de início da semana"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "Bem-vindo de volta"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Qual licença você está usando?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "Qual é a diferença entre Kan e Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Quando o Trello foi lançado em 2011, impressionou a todos com sua simplicidade cuidadosamente projetada, mas ao longo dos anos perdeu sua magia e se transformou em algo mais próximo de \"Jira Lite\". Este projeto é nossa tentativa de resgatar a magia original da simplicidade do Trello, em código aberto."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Por que fazer um Trello de código aberto?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Workspace"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Workspace criado com sucesso. Você pode fazer upgrade depois nas configurações.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Workspace excluído"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Descrição do workspace"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "A descrição do workspace não pode exceder 280 caracteres"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "A descrição do workspace deve ter pelo menos 3 caracteres"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Descrição do workspace atualizada"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Membros do workspace"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Nome do workspace"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "O nome do workspace não pode exceder 64 caracteres"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "O nome do workspace é obrigatório"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "O nome do workspace deve ter pelo menos 3 caracteres"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Nome do workspace atualizado"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Permissões do workspace"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Slug do workspace atualizado"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL do workspace"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Nome de usuário do workspace"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Escrevendo"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Anual"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Sim, oferecemos um plano gratuito para sempre para uso individual. Sem restrições, sem paywalls, sem limites."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Você está prestes a alterar sua senha."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Você pode alterar isso depois nas configurações."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Você pode obter uma URL personalizada para o workspace, como <0>kan.bn/kan</0>, acessando as <1>configurações do workspace</1> e adquirindo uma assinatura pro do workspace. Todas as assinaturas ajudam a financiar o desenvolvimento do projeto!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Você pode convidar membros da equipe clicando no botão \"Convidar\" no canto superior direito da <0>página de membros</0> e inserindo o endereço de e-mail deles. Eles receberão um e-mail com um link para entrar no workspace."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Você pode fazer self-host seguindo as instruções em nosso <0>repositório</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "Você não tem permissão"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Você foi autenticado com sucesso."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Você se cadastrou com sucesso."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Você cancelou a inscrição!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "Você tem assentos ilimitados com seu plano pro. Não há cobrança adicional para novos membros!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Você precisa ser um administrador para gerenciar as permissões do workspace."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Você foi convidado para entrar em um workspace no kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Você foi convidado para entrar em um workspace."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Sua conta foi excluída."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Seu avatar"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Seus quadros foram importados."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Seu nome de exibição foi atualizado."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Seu arquivo foi enviado com sucesso."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Sua conta do GitHub foi conectada."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Sua conta do GitHub foi desconectada."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Sua conta do GitHub está conectada."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Sua senha foi alterada."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Sua imagem de perfil foi atualizada."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Seus projetos foram importados."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Sua conta do Trello foi desconectada."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Sua conta do Trello está conectada."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "Seu link de cancelamento de inscrição está sem um token. Por favor, abra o e-mail mais recente e tente novamente."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Seu workspace"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Descrição do seu workspace"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "A descrição do seu workspace foi atualizada."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Seu workspace foi excluído."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "O nome do seu workspace foi atualizado."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "O slug do seu workspace foi atualizado."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "seu-workspace"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "URL do YouTube"
   }
 }

--- a/apps/web/src/locales/ru/messages.json
+++ b/apps/web/src/locales/ru/messages.json
@@ -3,23 +3,40 @@
     "message": " (edited)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 153]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        153
+      ]
+    ],
     "translation": " (отредактировано)"
   },
   "lGjicL": {
     "message": ", or see our",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 102]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        102
+      ]
+    ],
     "translation": ", или смотрите нашу"
   },
   "J/hVSQ": {
     "message": "{0}",
     "placeholders": {
-      "0": ["isTemplate ? \"Templates\" : \"Boards\""]
+      "0": [
+        "isTemplate ? \"Templates\" : \"Boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 53]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        53
+      ]
+    ],
     "translation": "{0}"
   },
   "JArWcF": {
@@ -29,74 +46,130 @@
         "card?.title ?? t`Card`",
         "isTemplate ? \"Templates\" : \"Boards\""
       ],
-      "1": ["board?.name ?? t`Board`", "workspace.name ?? t`Workspace`"]
+      "1": [
+        "board?.name ?? t`Board`",
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/card/index.tsx", 317]
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
     ],
     "translation": "{0} | {1}"
   },
   "mU+M00": {
     "message": "{0} has been added to your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 59]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        59
+      ]
+    ],
     "translation": "{0} добавлен в избранное."
   },
   "bDI6VI": {
     "message": "{0} has been removed from your favorites.",
     "placeholders": {
-      "0": ["boardName ?? \"Board\""]
+      "0": [
+        "boardName ?? \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 60]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        60
+      ]
+    ],
     "translation": "{0} удалён из избранного."
   },
   "CJukzS": {
     "message": "{0} labels",
     "placeholders": {
-      "0": ["labelPublicIds.length"]
+      "0": [
+        "labelPublicIds.length"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 462]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        486
+      ]
+    ],
     "translation": "{0} метки"
   },
   "9x4DAL": {
     "message": "{0} not found",
     "placeholders": {
-      "0": ["isTemplate ? \"Template\" : \"Board\""]
+      "0": [
+        "isTemplate ? \"Template\" : \"Board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 557]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        563
+      ]
+    ],
     "translation": "{0} не найдено"
   },
   "0xWkkH": {
     "message": "{boardCount, plural, one {Import board (1)} other {Import boards ({boardCount})}}",
     "placeholders": {
-      "boardCount": ["boardCount"]
+      "boardCount": [
+        "boardCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 489]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        489
+      ]
+    ],
     "translation": "{boardCount, plural, one {Импортировать доску (1)} few {Импортировать доски ({boardCount})} many {Импортировать досок ({boardCount})} other {Импортировать доски ({boardCount})}}"
   },
   "yndBF+": {
     "message": "{projectCount, plural, one {Import project (1)} other {Import projects ({projectCount})}}",
     "placeholders": {
-      "projectCount": ["projectCount"]
+      "projectCount": [
+        "projectCount"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 341]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        341
+      ]
+    ],
     "translation": "{projectCount, plural, one {Импортировать проект (1)} few {Импортировать проекта ({projectCount})} many {Импортировать проектов ({projectCount})} other {Импортировать проекта ({projectCount})}}"
   },
   "9lFfqv": {
     "message": "/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 207]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        207
+      ]
+    ],
     "translation": "/месяц"
   },
   "be30i9": {
@@ -104,8 +177,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 30],
-      ["src/views/pricing/components/PricingTiers.tsx", 30]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        30
+      ]
     ],
     "translation": "$0"
   },
@@ -114,8 +193,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 158],
-      ["src/views/members/components/InviteMemberForm.tsx", 170]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        158
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
     ],
     "translation": "$10/месяц"
   },
@@ -123,7 +208,12 @@
     "message": "$8/month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 170]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        170
+      ]
+    ],
     "translation": "$8/месяц"
   },
   "zMlxCA": {
@@ -131,9 +221,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 82],
-      ["src/views/pricing/components/Pricing.tsx", 36],
-      ["src/views/pricing/components/PricingTiers.tsx", 35]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        82
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        36
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        35
+      ]
     ],
     "translation": "1 пользователь"
   },
@@ -141,7 +240,12 @@
     "message": "10mb file uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 90]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        90
+      ]
+    ],
     "translation": "Загрузка файлов до 10 МБ"
   },
   "gkxGkF": {
@@ -149,9 +253,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 66],
-      ["src/views/pricing/components/PricingTiers.tsx", 88],
-      ["src/views/pricing/components/PricingTiers.tsx", 263]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        66
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        88
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        263
+      ]
     ],
     "translation": "14 дней бесплатно · Сменить тариф или отменить в любой момент"
   },
@@ -159,21 +272,36 @@
     "message": "404 - Page Not Found | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 11]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        11
+      ]
+    ],
     "translation": "404 - Страница не найдена | kan.bn"
   },
   "/rn4RE": {
     "message": "A powerful, flexible kanban app that helps you organise work, track progress, and deliver results—all in one place.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 71]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        71
+      ]
+    ],
     "translation": "Мощное и гибкое kanban-приложение, которое помогает организовать работу, отслеживать прогресс и достигать результатов — всё в одном месте."
   },
   "AeXO77": {
     "message": "Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 41]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        41
+      ]
+    ],
     "translation": "Аккаунт"
   },
   "TKFUnX": {
@@ -181,7 +309,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Аккаунт удалён"
   },
@@ -190,7 +321,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 283]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        283
+      ]
     ],
     "translation": "Менеджер аккаунта"
   },
@@ -198,7 +332,12 @@
     "message": "Actions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 56]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        56
+      ]
+    ],
     "translation": "Действия"
   },
   "F6pfE9": {
@@ -206,9 +345,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 26],
-      ["src/views/settings/components/NewWebhookModal.tsx", 321],
-      ["src/views/settings/components/WebhookList.tsx", 106]
+      [
+        "src/views/boards/index.tsx",
+        26
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        321
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
     ],
     "translation": "Активно"
   },
@@ -217,8 +365,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 468],
-      ["src/views/public/board/CardModal.tsx", 205]
+      [
+        "src/views/card/index.tsx",
+        484
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        212
+      ]
     ],
     "translation": "Активность"
   },
@@ -227,7 +381,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 148]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        148
+      ]
     ],
     "translation": "Журнал активности"
   },
@@ -235,35 +392,60 @@
     "message": "Activity logs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 110]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        110
+      ]
+    ],
     "translation": "Журналы активности"
   },
   "UGCIzB": {
     "message": "Add / edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        50
+      ]
+    ],
     "translation": "Добавить / изменить метку"
   },
   "B3xxao": {
     "message": "Add a card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        136
+      ]
+    ],
     "translation": "Добавить карточку"
   },
   "qtE5nt": {
     "message": "Add an item...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        141
+      ]
+    ],
     "translation": "Добавить элемент..."
   },
   "Gxxi5J": {
     "message": "Add checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 96]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        96
+      ]
+    ],
     "translation": "Добавить чек-лист"
   },
   "ngBZOd": {
@@ -271,8 +453,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/Comment.tsx", 185],
-      ["src/views/card/components/NewCommentForm.tsx", 68]
+      [
+        "src/views/card/components/Comment.tsx",
+        185
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        68
+      ]
     ],
     "translation": "Добавить комментарий... (введите '/' для открытия команд или '@' для упоминания)"
   },
@@ -280,14 +468,24 @@
     "message": "Add description... (type '/' to open commands or '@' to mention)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/Editor.tsx", 482]],
+    "origin": [
+      [
+        "src/components/Editor.tsx",
+        482
+      ]
+    ],
     "translation": "Добавить описание... (введите '/' для открытия команд или '@' для упоминания)"
   },
   "abUZlY": {
     "message": "Add details...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        169
+      ]
+    ],
     "translation": "Добавить детали..."
   },
   "lyqwgn": {
@@ -295,8 +493,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/LabelSelector.tsx", 114],
-      ["src/views/card/components/LabelSelector.tsx", 119]
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        114
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        119
+      ]
     ],
     "translation": "Добавить метку"
   },
@@ -305,8 +509,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 135],
-      ["src/views/members/components/InviteMemberForm.tsx", 257]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        135
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        257
+      ]
     ],
     "translation": "Добавить участника"
   },
@@ -314,126 +524,222 @@
     "message": "Add to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 125]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        125
+      ]
+    ],
     "translation": "Добавить в избранное"
   },
   "cWXW+7": {
     "message": "Add webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Добавить вебхук"
   },
   "bmXKoX": {
     "message": "added {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 102]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        106
+      ]
+    ],
     "translation": "добавлено {0} меток: <0>{labelList}</0>"
   },
   "h4VV67": {
     "message": "added a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 132]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        137
+      ]
+    ],
     "translation": "добавлен чек-лист"
   },
   "O83K21": {
     "message": "added a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        140
+      ]
+    ],
     "translation": "добавлен элемент чек-листа"
   },
   "T21jY/": {
     "message": "added a label to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 128]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        133
+      ]
+    ],
     "translation": "добавлена метка на карточку"
   },
   "rs7L54": {
     "message": "added a member to the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 130]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        135
+      ]
+    ],
     "translation": "добавлен участник в карточку"
   },
   "5y6qY8": {
     "message": "added an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 140]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        145
+      ]
+    ],
     "translation": "добавлено вложение"
   },
   "CujNX4": {
     "message": "added an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 278]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        292
+      ]
+    ],
     "translation": "добавлено вложение <0>{0}</0>"
   },
   "wakO3W": {
     "message": "added checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 208]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        222
+      ]
+    ],
     "translation": "добавлен чек-лист <0>{0}</0>"
   },
   "E0t3jO": {
     "message": "added checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        246
+      ]
+    ],
     "translation": "добавлен элемент чек-листа <0>{0}</0>"
   },
   "b5FKyH": {
     "message": "added label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 192]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        206
+      ]
+    ],
     "translation": "добавлена метка <0>{0}</0>"
   },
   "pL78ec": {
     "message": "Added to favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        56
+      ]
+    ],
     "translation": "Добавлено в избранное"
   },
   "14Xi3Z": {
     "message": "Adding a new member will cost an additional {price} ({billingType}) per seat.",
     "placeholders": {
-      "price": ["price"],
-      "billingType": ["billingType"]
+      "price": [
+        "price"
+      ],
+      "billingType": [
+        "billingType"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 327]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        327
+      ]
+    ],
     "translation": "Добавление нового участника будет стоить дополнительно {price} ({billingType}) за место."
   },
   "D7/JvJ": {
     "message": "Adjust the square crop to fit your avatar.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 256]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        256
+      ]
+    ],
     "translation": "Отрегулируйте квадратную обрезку для вашего аватара."
   },
   "U3pytU": {
     "message": "Admin",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 201]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        201
+      ]
+    ],
     "translation": "Админ"
   },
   "3pIq39": {
@@ -441,11 +747,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 264],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 265],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 266],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 267],
-      ["src/views/pricing/components/Pricing.tsx", 55]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        264
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        265
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        266
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        267
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        55
+      ]
     ],
     "translation": "Роли администратора"
   },
@@ -453,7 +774,12 @@
     "message": "Advanced admin controls",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 103]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        103
+      ]
+    ],
     "translation": "Расширенные настройки администратора"
   },
   "/jd3aj": {
@@ -461,7 +787,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 268]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        268
+      ]
     ],
     "translation": "Расширенные роли администратора"
   },
@@ -469,42 +798,72 @@
     "message": "Advanced security, compliance, and dedicated support for large organizations.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        97
+      ]
+    ],
     "translation": "Расширенная безопасность, соответствие требованиям и выделенная поддержка для крупных организаций."
   },
   "h2ztFt": {
     "message": "All Free features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 56]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        56
+      ]
+    ],
     "translation": "Все функции Free +"
   },
   "nryrgW": {
     "message": "All member permission overrides have been reset to their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Все индивидуальные разрешения участников были сброшены к значениям по умолчанию для их ролей."
   },
   "ZAs2NN": {
     "message": "All Pro features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 101]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        101
+      ]
+    ],
     "translation": "Все функции Pro +"
   },
   "UQbwrz": {
     "message": "All systems operational",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 18]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        18
+      ]
+    ],
     "translation": "Все системы работают нормально"
   },
   "EII/X8": {
     "message": "All Teams features +",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 79]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        79
+      ]
+    ],
     "translation": "Все функции Teams +"
   },
   "Z3krJD": {
@@ -523,28 +882,48 @@
     "message": "Already have an account? <0><1>Sign in</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 90]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        90
+      ]
+    ],
     "translation": "Уже есть аккаунт? <0><1>Войти</1></0>"
   },
   "j1+HPc": {
     "message": "An error occurred while connecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 107]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        107
+      ]
+    ],
     "translation": "Произошла ошибка при подключении вашего аккаунта GitHub."
   },
   "Dz63YI": {
     "message": "An error occurred while disconnecting your GitHub account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        130
+      ]
+    ],
     "translation": "Произошла ошибка при отключении вашего аккаунта GitHub."
   },
   "WmPhYW": {
     "message": "An error occurred while disconnecting your Trello account.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 87]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        87
+      ]
+    ],
     "translation": "Произошла ошибка при отключении вашей учетной записи Trello."
   },
   "ZXSPJt": {
@@ -552,22 +931,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 90]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        90
+      ]
     ],
     "translation": "Произошла непредвиденная ошибка. Пожалуйста, попробуйте позже."
+  },
+  "dtxpK2": {
+    "translation": "",
+    "message": "Analyze",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        48
+      ]
+    ]
   },
   "YkfDoz": {
     "message": "Annual",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        63
+      ]
+    ],
     "translation": "Ежегодно"
   },
   "3bqt9U": {
     "message": "Anyone with this link can join your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        311
+      ]
+    ],
     "translation": "Любой, у кого есть эта ссылка, может присоединиться к вашему рабочему пространству"
   },
   "OZtEcz": {
@@ -575,8 +979,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 65],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 237]
+      [
+        "src/components/SettingsLayout.tsx",
+        65
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        237
+      ]
     ],
     "translation": "API"
   },
@@ -584,119 +994,196 @@
     "message": "API key created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        91
+      ]
+    ],
     "translation": "Ключ API создан"
   },
   "pFKC6A": {
     "message": "API key name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 161]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        161
+      ]
+    ],
     "translation": "Имя ключа API"
   },
   "nq7q3Z": {
     "message": "API key name cannot exceed 30 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        25
+      ]
+    ],
     "translation": "Имя ключа API не может превышать 30 символов"
   },
   "vbskQn": {
     "message": "API key name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        24
+      ]
+    ],
     "translation": "Требуется имя ключа API"
   },
   "5h8ooz": {
     "message": "API keys",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        22
+      ]
+    ],
     "translation": "Ключи API"
   },
   "j2+d/o": {
     "message": "API Reference",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 31]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        31
+      ]
+    ],
     "translation": "Справочник по API"
   },
   "bJZm1W": {
     "message": "Applicants",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 75]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        75
+      ]
+    ],
     "translation": "Кандидаты"
   },
   "yb/fjw": {
     "message": "Approval",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 46]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        46
+      ]
+    ],
     "translation": "Одобрение"
   },
   "aKJHG+": {
     "message": "Archive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Архивировать доску"
   },
   "TdfEV7": {
     "message": "Archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 27]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        27
+      ]
+    ],
     "translation": "В архиве"
   },
   "lo8xBK": {
     "message": "Are you sure want to remove {entityLabel}?",
     "placeholders": {
-      "entityLabel": ["entityLabel"]
+      "entityLabel": [
+        "entityLabel"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 47]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        47
+      ]
     ],
     "translation": "Вы уверены, что хотите удалить {entityLabel}?"
   },
   "Ypy5pZ": {
     "message": "Are you sure you want to delete the webhook \"{webhookName}\"? This action cannot be undone.",
     "placeholders": {
-      "webhookName": ["webhookName"]
+      "webhookName": [
+        "webhookName"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Вы уверены, что хотите удалить вебхук \"{webhookName}\"? Это действие невозможно отменить."
   },
   "BhDZlc": {
     "message": "Are you sure you want to delete the workspace {0}?",
     "placeholders": {
-      "0": ["workspace.name"]
+      "0": [
+        "workspace.name"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 62]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        62
+      ]
     ],
     "translation": "Вы уверены, что хотите удалить рабочее пространство {0}?"
   },
   "DMeWZD": {
     "message": "Are you sure you want to delete this {0}?",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/DeleteBoardConfirmation.tsx", 36]],
+    "origin": [
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        36
+      ]
+    ],
     "translation": "Вы уверены, что хотите удалить этот объект {0}?"
   },
   "ZT4Khw": {
     "message": "Are you sure you want to delete this card?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 75]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        75
+      ]
+    ],
     "translation": "Вы уверены, что хотите удалить эту карточку?"
   },
   "Fpci8b": {
@@ -704,7 +1191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 56]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        56
+      ]
     ],
     "translation": "Вы уверены, что хотите удалить этот чек-лист?"
   },
@@ -712,14 +1202,24 @@
     "message": "Are you sure you want to delete this comment?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        66
+      ]
+    ],
     "translation": "Вы уверены, что хотите удалить этот комментарий?"
   },
   "kECVpo": {
     "message": "Are you sure you want to delete this label?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 41]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        41
+      ]
+    ],
     "translation": "Вы уверены, что хотите удалить эту метку?"
   },
   "74F7N/": {
@@ -727,17 +1227,27 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 54]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        54
+      ]
     ],
     "translation": "Вы уверены, что хотите удалить свой аккаунт?"
   },
   "PyYD/v": {
     "message": "assigned <0>{0}</0> to the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 172]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        186
+      ]
+    ],
     "translation": "назначено <0>{0}</0> на карточку"
   },
   "JUce1S": {
@@ -745,7 +1255,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 199]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        199
+      ]
     ],
     "translation": "Исполнители"
   },
@@ -753,91 +1266,156 @@
     "message": "Attachment uploaded",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        45
+      ]
+    ],
     "translation": "Вложение загружено"
   },
   "1rWxEw": {
     "message": "Awaiting Customer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 59]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        59
+      ]
+    ],
     "translation": "Ожидание клиента"
   },
   "iH8pgl": {
     "message": "Back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        276
+      ]
+    ],
     "translation": "Назад"
   },
   "KNKCTb": {
     "message": "Backlog",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Бэклог"
   },
   "Vt50G1": {
     "message": "Basic Kanban",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 16]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        16
+      ]
+    ],
     "translation": "Базовый канбан"
   },
   "Pat4r8": {
     "message": "Basic Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 28]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        28
+      ]
+    ],
     "translation": "Базовый роадмап"
   },
   "Cd4sTD": {
     "message": "Best for individuals and solo creators getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 32]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        32
+      ]
+    ],
     "translation": "Лучше всего подходит для индивидуальных пользователей и соло-креаторов, начинающих работу"
   },
   "wsy94z": {
     "message": "Best for large organizations with advanced needs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        98
+      ]
+    ],
     "translation": "Лучше всего подходит для крупных организаций с расширенными потребностями"
   },
   "UoSI+i": {
     "message": "Best for small and growing teams that need collaboration",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 53]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        53
+      ]
+    ],
     "translation": "Лучше всего подходит для небольших и развивающихся команд, которым нужна совместная работа"
   },
   "zt/6cS": {
     "message": "Best for small teams who want to collaborate and move faster together.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 86]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        86
+      ]
+    ],
     "translation": "Идеально для небольших команд, которые хотят сотрудничать и работать быстрее вместе."
   },
   "qaS+1/": {
     "message": "Best for teams that want to scale without limits",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 76]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        76
+      ]
+    ],
     "translation": "Лучше всего подходит для команд, которые хотят масштабироваться без ограничений"
   },
   "ARvBT/": {
     "message": "billed annually",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "оплата ежегодно"
   },
   "+VoTOr": {
     "message": "billed monthly",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 171]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        171
+      ]
+    ],
     "translation": "оплата ежемесячно"
   },
   "R+w/Va": {
@@ -845,9 +1423,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 58],
-      ["src/views/boards/components/TemplateBoards.tsx", 68],
-      ["src/views/settings/BillingSettings.tsx", 39]
+      [
+        "src/components/SettingsLayout.tsx",
+        58
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        68
+      ],
+      [
+        "src/views/settings/BillingSettings.tsx",
+        39
+      ]
     ],
     "translation": "Выставление счетов"
   },
@@ -855,14 +1442,24 @@
     "message": "Billing portal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Портал выставления счетов"
   },
   "4RoY9J": {
     "message": "Blog Post",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Блог-пост"
   },
   "QD8opX": {
@@ -870,9 +1467,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/card/index.tsx", 317],
-      ["src/views/public/board/index.tsx", 125]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/card/index.tsx",
+        331
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ]
     ],
     "translation": "Доска"
   },
@@ -881,7 +1487,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 85]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        85
+      ]
     ],
     "translation": "Аналитика доски"
   },
@@ -889,28 +1498,48 @@
     "message": "Board archived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Доска архивирована"
   },
   "wewm3j": {
     "message": "Board name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        23
+      ]
+    ],
     "translation": "Название доски не может превышать 100 символов"
   },
   "R1c3Mq": {
     "message": "Board name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        22
+      ]
+    ],
     "translation": "Требуется указать название доски"
   },
   "jwI32v": {
     "message": "Board not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 181]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        188
+      ]
+    ],
     "translation": "Доска не найдена"
   },
   "XNxYxq": {
@@ -918,7 +1547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 116]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        116
+      ]
     ],
     "translation": "Шаблоны досок"
   },
@@ -926,21 +1558,36 @@
     "message": "Board unarchived",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        46
+      ]
+    ],
     "translation": "Доска восстановлена из архива"
   },
   "Xid3K6": {
     "message": "Board URL can only contain letters, numbers, and hyphens",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 46]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        46
+      ]
+    ],
     "translation": "URL доски может содержать только буквы, цифры и дефисы"
   },
   "gv5kbo": {
     "message": "Board URL cannot exceed 60 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        44
+      ]
+    ],
     "translation": "URL доски не может превышать 60 символов"
   },
   "8+BY11": {
@@ -948,8 +1595,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 82],
-      ["src/views/public/board/index.tsx", 79]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        82
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        86
+      ]
     ],
     "translation": "URL доски скопирован в буфер обмена"
   },
@@ -957,7 +1610,12 @@
     "message": "Board URL must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        42
+      ]
+    ],
     "translation": "URL доски должен содержать не менее 3 символов"
   },
   "qzdST2": {
@@ -965,8 +1623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 85],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 132]
+      [
+        "src/views/home/components/Features.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        132
+      ]
     ],
     "translation": "Видимость доски"
   },
@@ -974,7 +1638,12 @@
     "message": "Board visibility updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        49
+      ]
+    ],
     "translation": "Видимость доски обновлена"
   },
   "8TveY+": {
@@ -982,8 +1651,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 99],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 73]
+      [
+        "src/components/SideNavigation.tsx",
+        99
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        73
+      ]
     ],
     "translation": "Доски"
   },
@@ -991,28 +1666,52 @@
     "message": "Boards you archive will appear here.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Здесь будут отображаться архивированные вами доски."
   },
   "ZDo4HN": {
     "message": "Brainstorming",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 42]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        42
+      ]
+    ],
     "translation": "Мозговой штурм"
   },
   "vXemf6": {
     "message": "Bug",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 24]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        49
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ]
+    ],
     "translation": "Баг"
   },
   "/asTmx": {
     "message": "Bug Report",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 64]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        64
+      ]
+    ],
     "translation": "Отчёт о баге"
   },
   "t6FvJH": {
@@ -1020,8 +1719,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 146],
-      ["src/views/settings/components/RolePermissions.tsx", 35]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        146
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        35
+      ]
     ],
     "translation": "Можно добавлять комментарии"
   },
@@ -1030,8 +1735,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 131],
-      ["src/views/settings/components/RolePermissions.tsx", 20]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        131
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        20
+      ]
     ],
     "translation": "Можно создавать доски"
   },
@@ -1040,8 +1751,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 141],
-      ["src/views/settings/components/RolePermissions.tsx", 30]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        141
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        30
+      ]
     ],
     "translation": "Можно создавать карточки"
   },
@@ -1050,8 +1767,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 136],
-      ["src/views/settings/components/RolePermissions.tsx", 25]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        136
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        25
+      ]
     ],
     "translation": "Можно создавать списки"
   },
@@ -1060,8 +1783,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 133],
-      ["src/views/settings/components/RolePermissions.tsx", 22]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        133
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        22
+      ]
     ],
     "translation": "Можно удалять доски"
   },
@@ -1070,8 +1799,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 143],
-      ["src/views/settings/components/RolePermissions.tsx", 32]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        143
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        32
+      ]
     ],
     "translation": "Можно удалять карточки"
   },
@@ -1080,8 +1815,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 148],
-      ["src/views/settings/components/RolePermissions.tsx", 37]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        37
+      ]
     ],
     "translation": "Можно удалять комментарии"
   },
@@ -1090,8 +1831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 138],
-      ["src/views/settings/components/RolePermissions.tsx", 27]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        138
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        27
+      ]
     ],
     "translation": "Можно удалять списки"
   },
@@ -1100,8 +1847,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 127],
-      ["src/views/settings/components/RolePermissions.tsx", 16]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        127
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        16
+      ]
     ],
     "translation": "Можно удалить рабочее пространство"
   },
@@ -1110,8 +1863,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 132],
-      ["src/views/settings/components/RolePermissions.tsx", 21]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        132
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        21
+      ]
     ],
     "translation": "Можно редактировать доски"
   },
@@ -1120,8 +1879,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 142],
-      ["src/views/settings/components/RolePermissions.tsx", 31]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        142
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        31
+      ]
     ],
     "translation": "Можно редактировать карточки"
   },
@@ -1130,8 +1895,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 147],
-      ["src/views/settings/components/RolePermissions.tsx", 36]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        147
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        36
+      ]
     ],
     "translation": "Можно редактировать комментарии"
   },
@@ -1140,8 +1911,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 137],
-      ["src/views/settings/components/RolePermissions.tsx", 26]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        137
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        26
+      ]
     ],
     "translation": "Можно редактировать списки"
   },
@@ -1150,8 +1927,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 152],
-      ["src/views/settings/components/RolePermissions.tsx", 41]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        152
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        41
+      ]
     ],
     "translation": "Можно редактировать роли и права участников"
   },
@@ -1160,8 +1943,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 126],
-      ["src/views/settings/components/RolePermissions.tsx", 15]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        126
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        15
+      ]
     ],
     "translation": "Можно редактировать рабочее пространство"
   },
@@ -1170,8 +1959,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 151],
-      ["src/views/settings/components/RolePermissions.tsx", 40]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        40
+      ]
     ],
     "translation": "Может приглашать участников"
   },
@@ -1180,8 +1975,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 128],
-      ["src/views/settings/components/RolePermissions.tsx", 17]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        128
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        17
+      ]
     ],
     "translation": "Может управлять настройками рабочего пространства"
   },
@@ -1190,8 +1991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 153],
-      ["src/views/settings/components/RolePermissions.tsx", 42]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        153
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        42
+      ]
     ],
     "translation": "Может удалять участников"
   },
@@ -1200,8 +2007,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 130],
-      ["src/views/settings/components/RolePermissions.tsx", 19]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        130
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        19
+      ]
     ],
     "translation": "Может просматривать доски"
   },
@@ -1210,8 +2023,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 140],
-      ["src/views/settings/components/RolePermissions.tsx", 29]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        140
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        29
+      ]
     ],
     "translation": "Может просматривать карточки"
   },
@@ -1220,8 +2039,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 145],
-      ["src/views/settings/components/RolePermissions.tsx", 34]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        145
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        34
+      ]
     ],
     "translation": "Может просматривать комментарии"
   },
@@ -1230,8 +2055,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 135],
-      ["src/views/settings/components/RolePermissions.tsx", 24]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        135
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        24
+      ]
     ],
     "translation": "Может просматривать списки"
   },
@@ -1240,8 +2071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 150],
-      ["src/views/settings/components/RolePermissions.tsx", 39]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        150
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        39
+      ]
     ],
     "translation": "Может просматривать участников"
   },
@@ -1250,8 +2087,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 125],
-      ["src/views/settings/components/RolePermissions.tsx", 14]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        125
+      ],
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        14
+      ]
     ],
     "translation": "Может просматривать рабочее пространство"
   },
@@ -1260,26 +2103,74 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 49],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 176],
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 267],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 44],
-      ["src/views/card/components/Comment.tsx", 195],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 86],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 64],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 77],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 55],
-      ["src/views/onboarding/select-plan/index.tsx", 209],
-      ["src/views/settings/components/Avatar.tsx", 287],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 168],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        49
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        176
+      ],
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        267
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        195
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        86
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        77
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        209
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        287
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        168
+      ],
       [
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         40
       ],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 88],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 75],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 98],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 108]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        88
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        75
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        108
+      ]
     ],
     "translation": "Отмена"
   },
@@ -1287,7 +2178,12 @@
     "message": "Card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 317]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        331
+      ]
+    ],
     "translation": "Карточка"
   },
   "sU2uWc": {
@@ -1295,7 +2191,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 67]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        67
+      ]
     ],
     "translation": "Карточка продублирована"
   },
@@ -1304,8 +2203,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 376],
-      ["src/views/card/index.tsx", 413]
+      [
+        "src/views/card/index.tsx",
+        392
+      ],
+      [
+        "src/views/card/index.tsx",
+        429
+      ]
     ],
     "translation": "Карточка не найдена"
   },
@@ -1313,7 +2218,12 @@
     "message": "Card title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 328]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        346
+      ]
+    ],
     "translation": "Название карточки"
   },
   "rQXTmd": {
@@ -1321,9 +2231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 308],
-      ["src/views/card/components/Dropdown.tsx", 47],
-      ["src/views/public/board/CardModal.tsx", 38]
+      [
+        "src/views/board/index.tsx",
+        314
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        47
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        39
+      ]
     ],
     "translation": "URL карточки скопирован в буфер обмена"
   },
@@ -1332,10 +2251,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 88],
-      ["src/views/settings/AccountSettings.tsx", 98],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 109],
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 178]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        88
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        98
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        109
+      ],
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        178
+      ]
     ],
     "translation": "Сменить пароль"
   },
@@ -1343,33 +2274,72 @@
     "message": "Change the application font size.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 63]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        63
+      ]
+    ],
     "translation": "Изменить размер шрифта приложения."
   },
   "yD3ZSw": {
     "message": "Change your language preferences.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Измените языковые настройки."
   },
   "gZxH/p": {
     "message": "changed the due date to <0>{formattedDate}</0>",
     "placeholders": {
-      "formattedDate": ["formattedDate"]
+      "formattedDate": [
+        "formattedDate"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 303],
-      ["src/views/card/components/ActivityList.tsx", 317]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        317
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        331
+      ]
     ],
     "translation": "изменил(а) срок выполнения на <0>{formattedDate}</0>"
+  },
+  "88XnH6": {
+    "translation": "",
+    "message": "changed the type to <0>{0}</0>",
+    "placeholders": {
+      "0": [
+        "getCardTypeLabel(toCardType)"
+      ]
+    },
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        165
+      ]
+    ]
   },
   "pFGfsR": {
     "message": "Check out some of our favorite open source projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 61]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        61
+      ]
+    ],
     "translation": "Ознакомьтесь с нашими любимыми open source проектами."
   },
   "5IXWmO": {
@@ -1377,8 +2347,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 43],
-      ["src/views/auth/signup/index.tsx", 71]
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ]
     ],
     "translation": "Проверьте свой почтовый ящик"
   },
@@ -1386,7 +2362,12 @@
     "message": "Checklist name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 119]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        119
+      ]
+    ],
     "translation": "Название чек-листа"
   },
   "EH8IL3": {
@@ -1394,8 +2375,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 108],
-      ["src/views/pricing/components/PricingTiers.tsx", 39]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        108
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        39
+      ]
     ],
     "translation": "Чек-листы"
   },
@@ -1403,7 +2390,12 @@
     "message": "Choose a plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 122]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        122
+      ]
+    ],
     "translation": "Выберите тариф"
   },
   "VHS0aJ": {
@@ -1422,7 +2414,12 @@
     "message": "Clear any custom member permissions so that all members only inherit permissions from their role defaults.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 67]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        67
+      ]
+    ],
     "translation": "Очистить все индивидуальные разрешения участников, чтобы все участники наследовали только разрешения по умолчанию для своей роли."
   },
   "jL82rC": {
@@ -1434,7 +2431,10 @@
         "src/views/settings/components/ClearCustomPermissionsConfirmation.tsx",
         48
       ],
-      ["src/views/settings/PermissionsSettings.tsx", 80]
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        80
+      ]
     ],
     "translation": "Очистить пользовательские разрешения"
   },
@@ -1442,18 +2442,31 @@
     "message": "Clear filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 227]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        247
+      ]
+    ],
     "translation": "Сбросить фильтры"
   },
   "RRn9jf": {
     "message": "Click on the link we've sent to {magicLinkRecipient} to sign in.",
     "placeholders": {
-      "magicLinkRecipient": ["magicLinkRecipient"]
+      "magicLinkRecipient": [
+        "magicLinkRecipient"
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/auth/login/index.tsx", 48],
-      ["src/views/auth/signup/index.tsx", 76]
+      [
+        "src/views/auth/login/index.tsx",
+        48
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        76
+      ]
     ],
     "translation": "Перейдите по ссылке, которую мы отправили на {magicLinkRecipient}, чтобы войти."
   },
@@ -1462,9 +2475,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/index.tsx", 367],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 172],
-      ["src/views/settings/components/NewApiKeyModal.tsx", 136]
+      [
+        "src/views/card/index.tsx",
+        383
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        172
+      ],
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        136
+      ]
     ],
     "translation": "Закрыть"
   },
@@ -1472,14 +2494,36 @@
     "message": "Code Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 23]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
+    ],
     "translation": "Code Review"
+  },
+  "i2BTio": {
+    "translation": "",
+    "message": "Coding",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        47
+      ]
+    ]
   },
   "EvArWh": {
     "message": "Collaborate seamlessly with your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        91
+      ]
+    ],
     "translation": "Бесшовно сотрудничайте с вашей командой."
   },
   "dtQIWT": {
@@ -1487,7 +2531,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 309]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        309
+      ]
     ],
     "translation": "Сотрудничество"
   },
@@ -1496,8 +2543,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 67],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 88]
+      [
+        "src/views/home/components/Features.tsx",
+        67
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        88
+      ]
     ],
     "translation": "Скоро появится"
   },
@@ -1506,8 +2559,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 105],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 156]
+      [
+        "src/views/home/components/Features.tsx",
+        105
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        156
+      ]
     ],
     "translation": "Комментарии"
   },
@@ -1515,65 +2574,112 @@
     "message": "Company",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        95
+      ]
+    ],
     "translation": "Компания"
   },
   "bD8I7O": {
     "message": "Complete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 94]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        94
+      ]
+    ],
     "translation": "Завершить"
   },
   "cAgBMh": {
     "message": "Complete control and ownership:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 70]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        70
+      ]
+    ],
     "translation": "Полный контроль и владение:"
   },
   "Lt+ZP3": {
     "message": "completed a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 137]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        142
+      ]
+    ],
     "translation": "завершил(а) пункт контрольного списка"
   },
   "29sSki": {
     "message": "completed checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 249]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        263
+      ]
+    ],
     "translation": "завершён пункт контрольного списка <0>{0}</0>"
   },
   "tOZp9v": {
     "message": "Configurable user roles and permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 82]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        82
+      ]
+    ],
     "translation": "Настраиваемые роли и права пользователей"
   },
   "t0dTPm": {
     "message": "Configure webhooks to receive notifications when cards are created, updated, moved, or deleted.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 31]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        31
+      ]
+    ],
     "translation": "Настройте вебхуки для получения уведомлений при создании, обновлении, перемещении или удалении карточек."
   },
   "/f3t6v": {
     "message": "Configure which actions are allowed for each workspace role. These permissions apply to all members with that role.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 56]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        56
+      ]
+    ],
     "translation": "Настройте, какие действия разрешены для каждой роли в рабочем пространстве. Эти права применяются ко всем участникам с этой ролью."
   },
   "86XI28": {
     "message": "Confirm your email preferences:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 81]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        81
+      ]
+    ],
     "translation": "Подтвердите ваши настройки электронной почты:"
   },
   "479pdJ": {
@@ -1581,7 +2687,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 150]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        150
+      ]
     ],
     "translation": "Подтвердите новый пароль"
   },
@@ -1589,42 +2698,72 @@
     "message": "Connect",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Подключить"
   },
   "3jod3l": {
     "message": "Connect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 212]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        212
+      ]
+    ],
     "translation": "Подключить GitHub"
   },
   "nk7caK": {
     "message": "Connect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 162]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        162
+      ]
+    ],
     "translation": "Подключить Trello"
   },
   "sDLCvT": {
     "message": "Connect your favorite tools to streamline your workflow.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 122]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        122
+      ]
+    ],
     "translation": "Подключите любимые инструменты, чтобы упростить рабочий процесс."
   },
   "MCIXdZ": {
     "message": "Connect your GitHub account to import projects.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 191]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        191
+      ]
+    ],
     "translation": "Подключите свой аккаунт GitHub, чтобы импортировать проекты."
   },
   "5eZwRW": {
     "message": "Connect your Trello account to import boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 149]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        149
+      ]
+    ],
     "translation": "Подключите ваш аккаунт Trello для импорта досок."
   },
   "jfC/xh": {
@@ -1632,8 +2771,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 38],
-      ["src/views/home/components/Header.tsx", 42]
+      [
+        "src/views/home/components/Footer.tsx",
+        38
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        42
+      ]
     ],
     "translation": "Контакты"
   },
@@ -1641,7 +2786,12 @@
     "message": "Contact Sales",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 95]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        95
+      ]
+    ],
     "translation": "Связаться с отделом продаж"
   },
   "Bhgd0l": {
@@ -1649,9 +2799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 96],
-      ["src/views/pricing/components/PricingTiers.tsx", 96]
+      [
+        "src/components/FeedbackModal.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        96
+      ]
     ],
     "translation": "Связаться с нами"
   },
@@ -1659,7 +2818,12 @@
     "message": "Content Creation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 40]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        40
+      ]
+    ],
     "translation": "Создание контента"
   },
   "xGVfLh": {
@@ -1667,8 +2831,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 212],
-      ["src/views/onboarding/workspace-details/index.tsx", 292]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        212
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        292
+      ]
     ],
     "translation": "Продолжить"
   },
@@ -1676,44 +2846,76 @@
     "message": "Continue with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Продолжить с "
   },
   "gkzAEM": {
     "message": "Continue with {0}",
     "placeholders": {
-      "0": ["key === \"oidc\" ? oidcProviderName : provider.name"]
+      "0": [
+        "key === \"oidc\" ? oidcProviderName : provider.name"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 355]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        355
+      ]
+    ],
     "translation": "Продолжить с {0}"
   },
   "va/3u1": {
     "message": "Control who can view and edit your boards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        86
+      ]
+    ],
     "translation": "Управляйте тем, кто может просматривать и редактировать ваши доски."
   },
   "zQPhSa": {
     "message": "Convert to link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 47]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        47
+      ]
+    ],
     "translation": "Преобразовать в ссылку"
   },
   "5RkSzq": {
     "message": "Copy board link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugButton.tsx", 87]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        87
+      ]
+    ],
     "translation": "Скопировать ссылку на доску"
   },
   "F0YmUY": {
     "message": "Copy card link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        80
+      ]
+    ],
     "translation": "Скопировать ссылку на карточку"
   },
   "0utuU6": {
@@ -1721,7 +2923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 257]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        257
+      ]
     ],
     "translation": "Копировать чек-листы"
   },
@@ -1730,7 +2935,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 221]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        221
+      ]
     ],
     "translation": "Копировать метки"
   },
@@ -1738,7 +2946,12 @@
     "message": "Copy link to card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 62]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        62
+      ]
+    ],
     "translation": "Копировать ссылку на карточку"
   },
   "uvH2xS": {
@@ -1746,33 +2959,51 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 239]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        239
+      ]
     ],
     "translation": "Копировать участников"
   },
   "7mrkyO": {
-    "translation": "Скопировать ID задачи",
     "message": "Copy ticket ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 87]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        87
+      ]
+    ],
+    "translation": "Скопировать ID задачи"
   },
   "9PaIxv": {
     "message": "Core features",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 305]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        305
+      ]
     ],
     "translation": "Основные функции"
   },
   "b9XOHo": {
     "message": "Create {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 166]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        166
+      ]
+    ],
     "translation": "Создать {0}"
   },
   "vgdzLf": {
@@ -1780,9 +3011,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 213],
-      ["src/views/board/components/NewCardForm.tsx", 527],
-      ["src/views/board/components/NewListForm.tsx", 141]
+      [
+        "src/components/LabelForm.tsx",
+        213
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        551
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        141
+      ]
     ],
     "translation": "Создать ещё одну"
   },
@@ -1790,53 +3030,91 @@
     "message": "Create API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 175]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        175
+      ]
+    ],
     "translation": "Создать API-ключ"
   },
   "dsLT3m": {
     "message": "Create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 537]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        561
+      ]
+    ],
     "translation": "Создать карточку"
   },
   "d33Usy": {
     "message": "Create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 135]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        135
+      ]
+    ],
     "translation": "Создать чек-лист"
   },
   "zKY5xi": {
     "message": "Create invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 349]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        349
+      ]
+    ],
     "translation": "Создать пригласительную ссылку"
   },
   "QtACvI": {
     "message": "Create label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Создать метку"
   },
   "XTKtey": {
     "message": "Create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 153]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        153
+      ]
+    ],
     "translation": "Создать список"
   },
   "VKoDQD": {
     "message": "Create new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
     "origin": [
-      ["src/views/boards/components/BoardsList.tsx", 80],
-      ["src/views/boards/index.tsx", 41]
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        80
+      ],
+      [
+        "src/views/boards/index.tsx",
+        41
+      ]
     ],
     "translation": "Создать новый {0}"
   },
@@ -1844,7 +3122,12 @@
     "message": "Create new key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Создать новый ключ"
   },
   "0+0/3e": {
@@ -1852,8 +3135,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewCardForm.tsx", 424],
-      ["src/views/card/components/LabelSelector.tsx", 101]
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        448
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        101
+      ]
     ],
     "translation": "Создать новую метку"
   },
@@ -1862,8 +3151,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 92],
-      ["src/views/board/index.tsx", 671]
+      [
+        "src/views/board/index.tsx",
+        94
+      ],
+      [
+        "src/views/board/index.tsx",
+        677
+      ]
     ],
     "translation": "Создать новый список"
   },
@@ -1871,14 +3166,24 @@
     "message": "Create template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        132
+      ]
+    ],
     "translation": "Создать шаблон"
   },
   "SiPp29": {
     "message": "Create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Создать вебхук"
   },
   "FdtSNC": {
@@ -1886,8 +3191,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 226],
-      ["src/components/WorkspaceMenu.tsx", 160]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        226
+      ],
+      [
+        "src/components/WorkspaceMenu.tsx",
+        160
+      ]
     ],
     "translation": "Создать рабочее пространство"
   },
@@ -1895,14 +3206,24 @@
     "message": "Created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 238]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        238
+      ]
+    ],
     "translation": "Создан"
   },
   "f8lDFq": {
     "message": "created the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 124]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        128
+      ]
+    ],
     "translation": "создал(а) карточку"
   },
   "J5nbej": {
@@ -1910,9 +3231,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Критично"
   },
@@ -1920,7 +3250,12 @@
     "message": "Crop your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 253]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        253
+      ]
+    ],
     "translation": "Обрежьте свой аватар"
   },
   "D3C4Yx": {
@@ -1928,7 +3263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 19]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        19
+      ]
     ],
     "translation": "Требуется текущий пароль"
   },
@@ -1936,7 +3274,12 @@
     "message": "Custom board templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        38
+      ]
+    ],
     "translation": "Пользовательские шаблоны досок"
   },
   "A42Dqn": {
@@ -1944,8 +3287,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 172],
-      ["src/views/pricing/components/PricingTiers.tsx", 83]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        172
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        83
+      ]
     ],
     "translation": "Пользовательский брендинг"
   },
@@ -1953,28 +3302,48 @@
     "message": "Custom domain",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 74]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        74
+      ]
+    ],
     "translation": "Пользовательский домен"
   },
   "2M84k3": {
     "message": "Custom permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 64]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        64
+      ]
+    ],
     "translation": "Пользовательские разрешения"
   },
   "UirJfL": {
     "message": "Custom SLA",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 105]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        105
+      ]
+    ],
     "translation": "Пользовательское SLA"
   },
   "u2+JIh": {
     "message": "Custom URLs require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 283]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        283
+      ]
+    ],
     "translation": "Для пользовательских URL требуется переход на тариф Pro",
     "obsolete": true
   },
@@ -1983,8 +3352,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 100],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 101]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        101
+      ]
     ],
     "translation": "Пользовательское имя"
   },
@@ -1992,7 +3367,12 @@
     "message": "Custom usernames require upgrading to a Pro plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 221]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        221
+      ]
+    ],
     "translation": "Для пользовательских имен пользователей требуется обновление до тарифа Pro"
   },
   "j9IZZ0": {
@@ -2000,7 +3380,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 78]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        78
+      ]
     ],
     "translation": "Пользовательский URL рабочего пространства"
   },
@@ -2008,35 +3391,60 @@
     "message": "Custom workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 81]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        81
+      ]
+    ],
     "translation": "Пользовательское имя рабочего пространства"
   },
   "n+xLOH": {
     "message": "Customer Support",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 54]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        54
+      ]
+    ],
     "translation": "Служба поддержки клиентов"
   },
   "pvnfJD": {
     "message": "Dark",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 158]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        158
+      ]
+    ],
     "translation": "Тёмная тема"
   },
   "cp1rsD": {
     "message": "Deactivate invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 348]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        348
+      ]
+    ],
     "translation": "Деактивировать ссылку-приглашение"
   },
   "bKzM8L": {
     "message": "Dedicated account manager",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 104]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        104
+      ]
+    ],
     "translation": "Выделенный менеджер аккаунта"
   },
   "P8Cunr": {
@@ -2044,8 +3452,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 98],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 99]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        98
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        99
+      ]
     ],
     "translation": "Имя пользователя по умолчанию"
   },
@@ -2054,15 +3468,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 51],
-      ["src/components/LabelForm.tsx", 228],
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 52],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 47],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 92],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 67],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 83],
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 82],
-      ["src/views/settings/components/WebhookList.tsx", 140]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        51
+      ],
+      [
+        "src/components/LabelForm.tsx",
+        228
+      ],
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        52
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        92
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        83
+      ],
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        82
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        140
+      ]
     ],
     "translation": "Удалить"
   },
@@ -2071,9 +3512,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/AccountSettings.tsx", 70],
-      ["src/views/settings/AccountSettings.tsx", 80],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 96]
+      [
+        "src/views/settings/AccountSettings.tsx",
+        70
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        96
+      ]
     ],
     "translation": "Удалить аккаунт"
   },
@@ -2081,7 +3531,12 @@
     "message": "Delete board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Удалить доску"
   },
   "nabda1": {
@@ -2089,8 +3544,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMenu.tsx", 74],
-      ["src/views/card/components/Dropdown.tsx", 107]
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        107
+      ]
     ],
     "translation": "Удалить карточку"
   },
@@ -2098,21 +3559,36 @@
     "message": "Delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 120]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        120
+      ]
+    ],
     "translation": "Удалить комментарий"
   },
   "lYT7pQ": {
     "message": "Delete list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/List.tsx", 147]],
+    "origin": [
+      [
+        "src/views/board/components/List.tsx",
+        147
+      ]
+    ],
     "translation": "Удалить список"
   },
   "DFjdv0": {
     "message": "Delete template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        136
+      ]
+    ],
     "translation": "Удалить шаблон"
   },
   "snMaH4": {
@@ -2120,7 +3596,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 55]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        55
+      ]
     ],
     "translation": "Удалить вебхук"
   },
@@ -2129,9 +3608,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 106],
-      ["src/views/settings/WorkspaceSettings.tsx", 125],
-      ["src/views/settings/WorkspaceSettings.tsx", 136]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        106
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        125
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        136
+      ]
     ],
     "translation": "Удалить рабочее пространство"
   },
@@ -2139,116 +3627,200 @@
     "message": "deleted a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 134]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        139
+      ]
+    ],
     "translation": "удалил(а) чек-лист"
   },
   "W5r8Qh": {
     "message": "deleted a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 139]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        144
+      ]
+    ],
     "translation": "удалил(а) элемент чек-листа"
   },
   "BMkVQ3": {
     "message": "deleted checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 224]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        238
+      ]
+    ],
     "translation": "удалил(а) чек-лист <0>{0}</0>"
   },
   "CHZ1jC": {
     "message": "deleted checklist item <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(fromTitle)"]
+      "0": [
+        "truncate(fromTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 267]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        281
+      ]
+    ],
     "translation": "удалил(а) элемент чек-листа <0>{0}</0>"
   },
   "f8fH8W": {
     "message": "Design",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 45]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        45
+      ]
+    ],
     "translation": "Дизайн"
   },
   "Odv3J6": {
     "message": "Disconnect GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 223]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        223
+      ]
+    ],
     "translation": "Отключить GitHub"
   },
   "YBBifR": {
     "message": "Disconnect Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 177]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        177
+      ]
+    ],
     "translation": "Отключить Trello"
   },
   "1sRmLC": {
     "message": "Discuss and collaborate on cards.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 106]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        106
+      ]
+    ],
     "translation": "Обсуждайте и сотрудничайте по карточкам."
   },
   "pfa8F0": {
     "message": "Display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 36]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        36
+      ]
+    ],
     "translation": "Отображаемое имя"
   },
   "MlyjJu": {
     "message": "Display name cannot exceed 280 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 22]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        22
+      ]
+    ],
     "translation": "Отображаемое имя не может превышать 280 символов"
   },
   "KFJgmZ": {
     "message": "Display name must be at least 3 characters long",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        19
+      ]
+    ],
     "translation": "Отображаемое имя должно содержать не менее 3 символов"
   },
   "x8GeCD": {
     "message": "Display name updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 41]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        41
+      ]
+    ],
     "translation": "Отображаемое имя обновлено"
   },
   "evj0lK": {
     "message": "Do you offer a free plan?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 83]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        83
+      ]
+    ],
     "translation": "У вас есть бесплатный тариф?"
   },
   "jDRt4n": {
     "message": "Do you want to unsubscribe?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 78]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        78
+      ]
+    ],
     "translation": "Вы хотите отписаться?"
   },
   "JyXBgS": {
     "message": "docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 109]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        109
+      ]
+    ],
     "translation": "документация"
   },
   "TbjyhA": {
     "message": "Docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 20]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        20
+      ]
+    ],
     "translation": "Документация"
   },
   "TvY/XA": {
@@ -2256,12 +3828,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 209],
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36],
-      ["src/views/home/components/Footer.tsx", 78],
-      ["src/views/home/components/Header.tsx", 36]
+      [
+        "src/components/UserMenu.tsx",
+        209
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        78
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        36
+      ]
     ],
     "translation": "Документация"
   },
@@ -2269,7 +3859,12 @@
     "message": "Don't have an account? <0><1>Sign up</1></0>",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 63]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        63
+      ]
+    ],
     "translation": "Нет аккаунта? <0><1>Зарегистрируйтесь</1></0>"
   },
   "DPfwMq": {
@@ -2277,15 +3872,42 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 36],
-      ["src/views/board/components/CardContextLabelsModal.tsx", 48],
-      ["src/views/board/components/CardContextMembersModal.tsx", 68],
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 48],
-      ["src/views/boards/components/TemplateBoards.tsx", 61]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        36
+      ],
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        48
+      ],
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        68
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        48
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        61
+      ]
     ],
     "translation": "Готово"
   },
@@ -2293,7 +3915,12 @@
     "message": "Download failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        142
+      ]
+    ],
     "translation": "Не удалось загрузить"
   },
   "XicmhT": {
@@ -2301,9 +3928,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/Filters.tsx", 171],
-      ["src/views/board/components/NewCardForm.tsx", 479],
-      ["src/views/card/index.tsx", 153]
+      [
+        "src/views/board/components/Filters.tsx",
+        190
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        503
+      ],
+      [
+        "src/views/card/index.tsx",
+        163
+      ]
     ],
     "translation": "Срок выполнения"
   },
@@ -2311,28 +3947,48 @@
     "message": "Due next month",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 132]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        145
+      ]
+    ],
     "translation": "Срок — в следующем месяце"
   },
   "iHcdea": {
     "message": "Due next week",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 127]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        140
+      ]
+    ],
     "translation": "Срок — на следующей неделе"
   },
   "1iShX0": {
     "message": "Due today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 117]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        130
+      ]
+    ],
     "translation": "Срок — сегодня"
   },
   "zxKs+y": {
     "message": "Due tomorrow",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 122]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        135
+      ]
+    ],
     "translation": "Срок — завтра"
   },
   "euc6Ns": {
@@ -2340,7 +3996,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Дублировать"
   },
@@ -2349,8 +4008,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 111],
-      ["src/views/board/components/CardContextMenu.tsx", 68]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        111
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        68
+      ]
     ],
     "translation": "Дублировать карточку"
   },
@@ -2359,7 +4024,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 279]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        279
+      ]
     ],
     "translation": "Дублирование…"
   },
@@ -2368,8 +4036,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/YouTubeDropdown.tsx", 42],
-      ["src/views/settings/components/WebhookList.tsx", 132]
+      [
+        "src/components/YouTubeEmbed/YouTubeDropdown.tsx",
+        42
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        132
+      ]
     ],
     "translation": "Редактировать"
   },
@@ -2378,8 +4052,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/BoardDropdown.tsx", 105],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 116]
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        105
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        116
+      ]
     ],
     "translation": "Изменить URL доски"
   },
@@ -2387,14 +4067,24 @@
     "message": "Edit comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 111]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        111
+      ]
+    ],
     "translation": "Редактировать комментарий"
   },
   "dgr4Kq": {
     "message": "Edit label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Редактировать метку"
   },
   "TCOMOO": {
@@ -2402,8 +4092,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 162],
-      ["src/views/members/index.tsx", 224]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        162
+      ],
+      [
+        "src/views/members/index.tsx",
+        224
+      ]
     ],
     "translation": "Изменить права доступа"
   },
@@ -2411,35 +4107,60 @@
     "message": "Edit webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Редактировать вебхук"
   },
   "klpSmb": {
     "message": "Edit workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 162]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        162
+      ]
+    ],
     "translation": "Изменить URL рабочего пространства"
   },
   "PRofO0": {
     "message": "Edit YouTube Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 108]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        108
+      ]
+    ],
     "translation": "Редактировать видео на YouTube"
   },
   "gGx5tM": {
     "message": "Editing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 44]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        44
+      ]
+    ],
     "translation": "Редактирование"
   },
   "b/LfJo": {
     "message": "email",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "email"
   },
   "O3oNi5": {
@@ -2447,8 +4168,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 272],
-      ["src/views/settings/AccountSettings.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        272
+      ],
+      [
+        "src/views/settings/AccountSettings.tsx",
+        43
+      ]
     ],
     "translation": "Email"
   },
@@ -2457,7 +4184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 191]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        191
+      ]
     ],
     "translation": "Уведомления по email"
   },
@@ -2465,14 +4195,24 @@
     "message": "Email notifications for mentions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 60]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        60
+      ]
+    ],
     "translation": "Уведомления по email о упоминаниях"
   },
   "IqjpYe": {
     "message": "Email visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Видимость email"
   },
   "bFREhu": {
@@ -2480,7 +4220,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 200]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        200
+      ]
     ],
     "translation": "Конец списка"
   },
@@ -2488,7 +4231,12 @@
     "message": "Engineering",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Разработка"
   },
   "0+ewPp": {
@@ -2496,9 +4244,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Улучшение"
   },
@@ -2506,14 +4263,24 @@
     "message": "Enter a custom title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 131]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        131
+      ]
+    ],
     "translation": "Введите собственный заголовок"
   },
   "rQRXo8": {
     "message": "Enter new secret to update",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 258]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        258
+      ]
+    ],
     "translation": "Введите новый секретный ключ для обновления"
   },
   "fR9laE": {
@@ -2521,7 +4288,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 122]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        122
+      ]
     ],
     "translation": "Введите текущий пароль"
   },
@@ -2530,7 +4300,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 111]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        111
+      ]
     ],
     "translation": "Введите текущий пароль и выберите новый надёжный пароль."
   },
@@ -2538,14 +4311,24 @@
     "message": "Enter your email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 402]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        402
+      ]
+    ],
     "translation": "Введите адрес электронной почты"
   },
   "n9V+ps": {
     "message": "Enter your name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 390]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        390
+      ]
+    ],
     "translation": "Введите имя"
   },
   "0StR7t": {
@@ -2553,7 +4336,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 136]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        136
+      ]
     ],
     "translation": "Введите новый пароль"
   },
@@ -2561,7 +4347,12 @@
     "message": "Enter your password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 416]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        416
+      ]
+    ],
     "translation": "Введите пароль"
   },
   "GpB8YV": {
@@ -2569,8 +4360,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 334],
-      ["src/views/pricing/components/PricingTiers.tsx", 92]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        334
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        92
+      ]
     ],
     "translation": "Enterprise"
   },
@@ -2579,9 +4376,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 77],
-      ["src/views/boards/components/NewBoardForm.tsx", 92],
-      ["src/views/members/components/InviteMemberForm.tsx", 215]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        77
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        92
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        215
+      ]
     ],
     "translation": "Ошибка"
   },
@@ -2590,7 +4396,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 89]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        89
+      ]
     ],
     "translation": "Ошибка при смене пароля"
   },
@@ -2598,21 +4407,36 @@
     "message": "Error connecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        106
+      ]
+    ],
     "translation": "Ошибка подключения GitHub"
   },
   "cji2nM": {
     "message": "Error creating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 128]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        128
+      ]
+    ],
     "translation": "Ошибка при создании ссылки-приглашения"
   },
   "USVCGU": {
     "message": "Error deactivating invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 144]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        144
+      ]
+    ],
     "translation": "Ошибка при деактивации ссылки-приглашения"
   },
   "bqAQaT": {
@@ -2620,7 +4444,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 39]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        39
+      ]
     ],
     "translation": "Ошибка при удалении аккаунта"
   },
@@ -2628,7 +4455,12 @@
     "message": "Error deleting label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/DeleteLabelConfirmation.tsx", 25]],
+    "origin": [
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        25
+      ]
+    ],
     "translation": "Ошибка при удалении метки"
   },
   "9s9O5h": {
@@ -2636,7 +4468,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 45]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        45
+      ]
     ],
     "translation": "Ошибка при удалении рабочего пространства"
   },
@@ -2644,14 +4479,24 @@
     "message": "Error disconnecting GitHub",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        129
+      ]
+    ],
     "translation": "Ошибка при отключении GitHub"
   },
   "lKAvEd": {
     "message": "Error disconnecting Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Ошибка при отключении Trello"
   },
   "rarRW/": {
@@ -2659,8 +4504,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 97],
-      ["src/views/members/components/InviteMemberForm.tsx", 103]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        97
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        103
+      ]
     ],
     "translation": "Ошибка при приглашении участника"
   },
@@ -2668,7 +4519,12 @@
     "message": "Error updating display name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 54]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        54
+      ]
+    ],
     "translation": "Ошибка при обновлении отображаемого имени"
   },
   "CkVV1t": {
@@ -2676,7 +4532,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        63
+      ]
     ],
     "translation": "Ошибка при обновлении описания рабочего пространства"
   },
@@ -2685,7 +4544,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 58]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        58
+      ]
     ],
     "translation": "Ошибка при обновлении названия рабочего пространства"
   },
@@ -2694,7 +4556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 75]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        75
+      ]
     ],
     "translation": "Ошибка при обновлении URL рабочего пространства"
   },
@@ -2703,8 +4568,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 43]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        43
+      ]
     ],
     "translation": "Ошибка при обновлении подписки"
   },
@@ -2712,7 +4583,12 @@
     "message": "Error upgrading to Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 146]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        146
+      ]
+    ],
     "translation": "Ошибка при переходе на Pro",
     "obsolete": true
   },
@@ -2721,8 +4597,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/Avatar.tsx", 69],
-      ["src/views/settings/components/Avatar.tsx", 199]
+      [
+        "src/views/settings/components/Avatar.tsx",
+        69
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        199
+      ]
     ],
     "translation": "Ошибка при загрузке изображения профиля"
   },
@@ -2731,8 +4613,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 271],
-      ["src/views/settings/components/WebhookList.tsx", 226]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        271
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        226
+      ]
     ],
     "translation": "События"
   },
@@ -2740,42 +4628,72 @@
     "message": "Everything in the free plan, plus:",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        52
+      ]
+    ],
     "translation": "Всё из бесплатного тарифа, а также:"
   },
   "ANyn0x": {
     "message": "Everything you need, free forever. Unlimited boards, unlimited lists, unlimited cards. Upgrade any time.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 33]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        33
+      ]
+    ],
     "translation": "Всё, что вам нужно, бесплатно навсегда. Неограниченные доски, списки и карточки. Можно перейти на другой тариф в любой момент."
   },
   "t+R8+P": {
     "message": "Execution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 91]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        91
+      ]
+    ],
     "translation": "Выполнение"
   },
   "GwNIE2": {
     "message": "Extended Roadmap",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 34]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        34
+      ]
+    ],
     "translation": "Расширённая дорожная карта"
   },
   "HYV6Lq": {
     "message": "Failed to accept invitation. Please try again later, or contact customer support.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 41]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        41
+      ]
+    ],
     "translation": "Не удалось принять приглашение. Пожалуйста, попробуйте позже или обратитесь в службу поддержки."
   },
   "lXvXNI": {
     "message": "Failed to copy invite link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 216]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        216
+      ]
+    ],
     "translation": "Не удалось скопировать ссылку-приглашение"
   },
   "53QYh8": {
@@ -2783,8 +4701,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/NewBoardForm.tsx", 78],
-      ["src/views/boards/components/NewBoardForm.tsx", 93]
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        78
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        93
+      ]
     ],
     "translation": "Не удалось создать доску"
   },
@@ -2792,7 +4716,12 @@
     "message": "Failed to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        119
+      ]
+    ],
     "translation": "Не удалось создать вебхук"
   },
   "9YPBHv": {
@@ -2800,7 +4729,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 37]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Не удалось удалить вебхук"
   },
@@ -2808,16 +4740,28 @@
     "message": "Failed to fetch video information",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 82]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        82
+      ]
+    ],
     "translation": "Не удалось получить информацию о видео"
   },
   "YtUfwW": {
     "message": "Failed to login with {0}. Please try again.",
     "placeholders": {
-      "0": ["provider.at(0)?.toUpperCase() + provider.slice(1)"]
+      "0": [
+        "provider.at(0)?.toUpperCase() + provider.slice(1)"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 291]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        291
+      ]
+    ],
     "translation": "Не удалось войти через {0}. Пожалуйста, попробуйте ещё раз."
   },
   "5ntVtp": {
@@ -2825,8 +4769,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 164],
-      ["src/views/settings/components/WebhookList.tsx", 186]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        164
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        186
+      ]
     ],
     "translation": "Не удалось протестировать вебхук"
   },
@@ -2834,21 +4784,36 @@
     "message": "Failed to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        138
+      ]
+    ],
     "translation": "Не удалось обновить вебхук"
   },
   "ZL1A+p": {
     "message": "Failed to upload attachment. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 52]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        52
+      ]
+    ],
     "translation": "Не удалось загрузить вложение. Пожалуйста, попробуйте ещё раз."
   },
   "/lDBHm": {
     "message": "FAQ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        41
+      ]
+    ],
     "translation": "FAQ"
   },
   "aJ4pMe": {
@@ -2856,8 +4821,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Faqs.tsx", 143],
-      ["src/views/home/components/Footer.tsx", 52]
+      [
+        "src/views/home/components/Faqs.tsx",
+        143
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        52
+      ]
     ],
     "translation": "Часто задаваемые вопросы"
   },
@@ -2866,9 +4837,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 24],
-      ["src/views/boards/components/TemplateBoards.tsx", 30],
-      ["src/views/boards/components/TemplateBoards.tsx", 36]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        24
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        30
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        36
+      ]
     ],
     "translation": "Функция"
   },
@@ -2876,7 +4856,12 @@
     "message": "Feature Request",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 65]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        65
+      ]
+    ],
     "translation": "Запрос функции"
   },
   "PpZkda": {
@@ -2884,10 +4869,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 132],
-      ["src/views/home/components/Footer.tsx", 50],
-      ["src/views/home/components/Header.tsx", 17],
-      ["src/views/home/components/Header.tsx", 33]
+      [
+        "src/views/home/components/Features.tsx",
+        132
+      ],
+      [
+        "src/views/home/components/Footer.tsx",
+        50
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        17
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        33
+      ]
     ],
     "translation": "Функции"
   },
@@ -2896,8 +4893,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/FeedbackModal.tsx", 59],
-      ["src/components/UserMenu.tsx", 217]
+      [
+        "src/components/CardTypeBadge.tsx",
+        50
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        59
+      ],
+      [
+        "src/components/UserMenu.tsx",
+        217
+      ]
     ],
     "translation": "Обратная связь"
   },
@@ -2905,42 +4912,72 @@
     "message": "Feedback sent",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 33]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        33
+      ]
+    ],
     "translation": "Отзыв отправлен"
   },
   "F6m23G": {
     "message": "File uploads",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 89]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        89
+      ]
+    ],
     "translation": "Загрузка файлов"
   },
   "o7J4JM": {
     "message": "Filter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 221]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        241
+      ]
+    ],
     "translation": "Фильтр"
   },
   "l31EoQ": {
     "message": "Find answers to common questions about Kan. Can't find what you're looking for? Feel free to <0>contact us</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 150]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        150
+      ]
+    ],
     "translation": "Найдите ответы на часто задаваемые вопросы о Kan. Не нашли то, что искали? Не стесняйтесь <0>связаться с нами</0>."
   },
   "q3il6U": {
     "message": "Font size",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 60]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        60
+      ]
+    ],
     "translation": "Размер шрифта"
   },
   "+3TYXa": {
     "message": "For long-term sustainability, we recognise all good open source projects need a source of revenue. Ours comes from the paid cloud offering for workspaces with multiple users and for custom workspace slugs. There's no obligation to use it, and you can self-host the software on your own infrastructure free of charge.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 41]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        41
+      ]
+    ],
     "translation": "Для долгосрочной устойчивости мы понимаем, что всем хорошим open source-проектам необходим источник дохода. Наш — это платное облачное решение для рабочих пространств с несколькими пользователями и для индивидуальных адресов рабочих пространств. Нет обязательства использовать его — вы можете развернуть ПО на своей инфраструктуре бесплатно."
   },
   "2POOFK": {
@@ -2948,12 +4985,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 77],
-      ["src/views/onboarding/select-plan/index.tsx", 78],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 331],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/Pricing.tsx", 32],
-      ["src/views/pricing/components/PricingTiers.tsx", 26]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        77
+      ],
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        78
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        331
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        32
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        26
+      ]
     ],
     "translation": "Бесплатно"
   },
@@ -2961,7 +5016,12 @@
     "message": "Free for everyone",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 31]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        31
+      ]
+    ],
     "translation": "Бесплатно для всех"
   },
   "W/nQk1": {
@@ -2969,8 +5029,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 333],
-      ["src/views/members/index.tsx", 293]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        333
+      ],
+      [
+        "src/views/members/index.tsx",
+        293
+      ]
     ],
     "translation": "Бесплатный тариф"
   },
@@ -2978,7 +5044,12 @@
     "message": "Free, forever",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 34]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        34
+      ]
+    ],
     "translation": "Бесплатно, навсегда"
   },
   "6uBU1F": {
@@ -2986,9 +5057,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 239],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 240],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 241]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        239
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        240
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        241
+      ]
     ],
     "translation": "Полный доступ к API"
   },
@@ -2996,21 +5076,36 @@
     "message": "Full-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Полная занятость"
   },
   "rmN315": {
     "message": "Fun",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Весело"
   },
   "Weq9zb": {
     "message": "General",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 54]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        54
+      ]
+    ],
     "translation": "Общее"
   },
   "ZDIydz": {
@@ -3018,12 +5113,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 71],
-      ["src/views/home/components/Cta.tsx", 61],
-      ["src/views/home/components/Header.tsx", 106],
-      ["src/views/pricing/components/PricingTiers.tsx", 29],
-      ["src/views/pricing/components/PricingTiers.tsx", 50],
-      ["src/views/pricing/components/PricingTiers.tsx", 73]
+      [
+        "src/views/auth/signup/index.tsx",
+        71
+      ],
+      [
+        "src/views/home/components/Cta.tsx",
+        61
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        106
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        29
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        50
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        73
+      ]
     ],
     "translation": "Начать"
   },
@@ -3032,53 +5145,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 31],
-      ["src/views/pricing/components/Pricing.tsx", 49]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        31
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        49
+      ]
     ],
     "translation": "Начать"
   },
   "6FsGbN": {
     "message": "Get started by creating a new {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        66
+      ]
+    ],
     "translation": "Начните с создания нового {0}"
   },
   "zC8Whw": {
     "message": "Get started by creating a new list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 656]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        662
+      ]
+    ],
     "translation": "Начните с создания нового списка"
   },
   "oW13KZ": {
     "message": "Get started for free today",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 54]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        54
+      ]
+    ],
     "translation": "Начните бесплатно уже сегодня"
   },
   "+OhFss": {
     "message": "Get started for free, with no usage limits. For collaboration, upgrade to a plan that fits the size of your team.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 92]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        92
+      ]
+    ],
     "translation": "Начните бесплатно, без ограничений по использованию. Для совместной работы выберите тариф, подходящий по размеру вашей команды."
   },
   "rD6UIt": {
     "message": "Get started on Cloud",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 75]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        75
+      ]
+    ],
     "translation": "Начать в облаке"
   },
   "7hktsm": {
     "message": "Getting started",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        25
+      ]
+    ],
     "translation": "Начало работы"
   },
   "RkXlPZ": {
@@ -3086,8 +5237,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 37],
-      ["src/views/settings/IntegrationsSettings.tsx", 186]
+      [
+        "src/views/home/components/Footer.tsx",
+        37
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        186
+      ]
     ],
     "translation": "GitHub"
   },
@@ -3095,21 +5252,36 @@
     "message": "GitHub connected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 99]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        99
+      ]
+    ],
     "translation": "GitHub подключён"
   },
   "/bBVaD": {
     "message": "GitHub disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 122]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        122
+      ]
+    ],
     "translation": "GitHub отключён"
   },
   "7eMo+U": {
     "message": "Go Home",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 113]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        113
+      ]
+    ],
     "translation": "На главную"
   },
   "UveK6V": {
@@ -3117,8 +5289,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Header.tsx", 100],
-      ["src/views/invite/index.tsx", 144]
+      [
+        "src/views/home/components/Header.tsx",
+        100
+      ],
+      [
+        "src/views/invite/index.tsx",
+        144
+      ]
     ],
     "translation": "Перейти в приложение"
   },
@@ -3127,8 +5305,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 107],
-      ["src/pages/404.tsx", 44]
+      [
+        "src/components/SideNavigation.tsx",
+        107
+      ],
+      [
+        "src/pages/404.tsx",
+        44
+      ]
     ],
     "translation": "Перейти к доскам"
   },
@@ -3136,35 +5320,60 @@
     "message": "Go to homepage",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 38]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        38
+      ]
+    ],
     "translation": "Перейти на главную"
   },
   "KAsRdK": {
     "message": "Go to members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 131]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        131
+      ]
+    ],
     "translation": "Перейти к участникам"
   },
   "1WuwiM": {
     "message": "Go to settings",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 143]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        143
+      ]
+    ],
     "translation": "Перейти к настройкам"
   },
   "csFbe+": {
     "message": "Go to templates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SideNavigation.tsx", 119]],
+    "origin": [
+      [
+        "src/components/SideNavigation.tsx",
+        119
+      ]
+    ],
     "translation": "Перейти к шаблонам"
   },
   "SUvm1Y": {
     "message": "Good for individuals starting out who just need the essentials.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 79]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        79
+      ]
+    ],
     "translation": "Подходит для начинающих пользователей, которым нужны только базовые функции."
   },
   "cdyS7J": {
@@ -3172,9 +5381,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 257],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 258],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 259]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        257
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        258
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        259
+      ]
     ],
     "translation": "Google SSO"
   },
@@ -3183,7 +5401,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 260]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        260
+      ]
     ],
     "translation": "Google SSO + SAML"
   },
@@ -3191,77 +5412,132 @@
     "message": "Guest",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 203]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        203
+      ]
+    ],
     "translation": "Гость"
   },
   "CB/NpV": {
     "message": "High Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Высокий приоритет"
   },
   "XXbgHS": {
     "message": "Hired",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 80]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        80
+      ]
+    ],
     "translation": "Принят на работу"
   },
   "SRvxId": {
     "message": "HMAC secret for signature verification",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 259]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        259
+      ]
+    ],
     "translation": "Секретный ключ HMAC для проверки подписи"
   },
   "LrcnbT": {
     "message": "Host Kan on your own infrastructure. Ideal for organisations that need complete control over their data.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 69]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        69
+      ]
+    ],
     "translation": "Разместите Kan на собственной инфраструктуре. Идеально для организаций, которым нужен полный контроль над своими данными."
   },
   "WI4eGo": {
     "message": "How do I get a custom URL?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 64]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        64
+      ]
+    ],
     "translation": "Как получить собственный URL?"
   },
   "yV7o5I": {
     "message": "How do I import my Trello boards?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 46]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        46
+      ]
+    ],
     "translation": "Как импортировать мои доски Trello?"
   },
   "nol/Fb": {
     "message": "How do I invite team members?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 108]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        108
+      ]
+    ],
     "translation": "Как пригласить участников команды?"
   },
   "KuSt9W": {
     "message": "How do I self-host?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 124]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        124
+      ]
+    ],
     "translation": "Как развернуть самостоятельно?"
   },
   "UeDFpo": {
     "message": "How is the project funded?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 38]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        38
+      ]
+    ],
     "translation": "Как финансируется проект?"
   },
   "6S8zjx": {
     "message": "https://www.youtube.com/watch?v=...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 151]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        151
+      ]
+    ],
     "translation": "https://www.youtube.com/watch?v=..."
   },
   "2liqDZ": {
@@ -3269,7 +5545,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 82]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        82
+      ]
     ],
     "translation": "Я подтверждаю, что все данные моего аккаунта будут безвозвратно удалены, и хочу продолжить."
   },
@@ -3278,36 +5557,59 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 92]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        92
+      ]
     ],
     "translation": "Я подтверждаю, что все данные рабочего пространства будут безвозвратно удалены, и хочу продолжить."
   },
   "VOwhhz": {
-    "translation": "ID скопирован",
     "message": "ID copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 64]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        64
+      ]
+    ],
+    "translation": "ID скопирован"
   },
   "iwr7AP": {
     "message": "Ideas",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 88]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        88
+      ]
+    ],
     "translation": "Идеи"
   },
   "F/vB2g": {
     "message": "Ideas to improve this page...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 75]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        75
+      ]
+    ],
     "translation": "Идеи по улучшению этой страницы..."
   },
   "l3s5ri": {
     "message": "Import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/index.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/index.tsx",
+        73
+      ]
+    ],
     "translation": "Импорт"
   },
   "2MPcep": {
@@ -3315,8 +5617,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 229],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 381]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        229
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        381
+      ]
     ],
     "translation": "Импорт завершён"
   },
@@ -3325,8 +5633,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 242],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 394]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        242
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        394
+      ]
     ],
     "translation": "Ошибка импорта"
   },
@@ -3334,28 +5648,48 @@
     "message": "Import your Trello boards and hit the ground running.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 96]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        96
+      ]
+    ],
     "translation": "Импортируйте свои доски Trello и сразу приступайте к работе."
   },
   "c/IAuR": {
     "message": "Important",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Важно"
   },
   "xMn+V9": {
     "message": "Importing from Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 27]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        27
+      ]
+    ],
     "translation": "Импорт из Trello"
   },
   "g2xBxu": {
     "message": "Importing your Trello boards into Kan is easy. You can follow our step-by-step guide <0>here</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 49]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        49
+      ]
+    ],
     "translation": "Импортировать ваши доски Trello в Kan очень просто. Следуйте нашему пошаговому руководству <0>здесь</0>."
   },
   "02i3WU": {
@@ -3363,7 +5697,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 313]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        313
+      ]
     ],
     "translation": "Импорт"
   },
@@ -3371,7 +5708,12 @@
     "message": "in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 177]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        177
+      ]
+    ],
     "translation": "в"
   },
   "WbTDwg": {
@@ -3379,11 +5721,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23],
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35],
-      ["src/views/boards/components/TemplateBoards.tsx", 58]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        58
+      ]
     ],
     "translation": "В процессе"
   },
@@ -3391,14 +5748,24 @@
     "message": "Inactive",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 106]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        106
+      ]
+    ],
     "translation": "Неактивен"
   },
   "6mbe4b": {
     "message": "Individuals",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 28]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        28
+      ]
+    ],
     "translation": "Индивидуальные участники"
   },
   "nbfdhU": {
@@ -3406,8 +5773,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 77],
-      ["src/views/home/components/Features.tsx", 121]
+      [
+        "src/components/SettingsLayout.tsx",
+        77
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        121
+      ]
     ],
     "translation": "Интеграции"
   },
@@ -3416,7 +5789,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 140]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        140
+      ]
     ],
     "translation": "Интеллектуальный поиск"
   },
@@ -3424,42 +5800,72 @@
     "message": "Interviewing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 77]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        77
+      ]
+    ],
     "translation": "Собеседование"
   },
   "XILg0L": {
     "message": "Invalid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 51]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        51
+      ]
+    ],
     "translation": "Недействительный адрес электронной почты"
   },
   "odFCYX": {
     "message": "Invalid invitation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 105]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        105
+      ]
+    ],
     "translation": "Недействительное приглашение"
   },
   "MFKlMB": {
     "message": "Invite",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 306]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        306
+      ]
+    ],
     "translation": "Пригласить"
   },
   "KLJ4eD": {
     "message": "Invite link copied",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 209]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        209
+      ]
+    ],
     "translation": "Ссылка-приглашение скопирована"
   },
   "mZGPxt": {
     "message": "Invite link copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        210
+      ]
+    ],
     "translation": "Ссылка-приглашение скопирована в буфер обмена"
   },
   "D9ROdV": {
@@ -3467,8 +5873,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 207],
-      ["src/views/pricing/components/PricingTiers.tsx", 58]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        207
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        58
+      ]
     ],
     "translation": "Ссылки-приглашения"
   },
@@ -3476,7 +5888,12 @@
     "message": "Invite links require a Team or Pro subscription. Please upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 123]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        123
+      ]
+    ],
     "translation": "Ссылки-приглашения доступны только с подпиской Team или Pro. Пожалуйста, обновите тариф вашего рабочего пространства."
   },
   "+djOzj": {
@@ -3484,8 +5901,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/MemberSelector.tsx", 115],
-      ["src/views/members/components/InviteMemberForm.tsx", 367]
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        115
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        367
+      ]
     ],
     "translation": "Пригласить участника"
   },
@@ -3493,7 +5916,12 @@
     "message": "Inviting members requires a Team Plan. You'll be redirected to upgrade your workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 336]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        336
+      ]
+    ],
     "translation": "Приглашение участников доступно только на тарифе Team. Вы будете перенаправлены для обновления рабочего пространства."
   },
   "c9AJhn": {
@@ -3501,8 +5929,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/invite/index.tsx", 79],
-      ["src/views/invite/index.tsx", 129]
+      [
+        "src/views/invite/index.tsx",
+        79
+      ],
+      [
+        "src/views/invite/index.tsx",
+        129
+      ]
     ],
     "translation": "Присоединиться к рабочему пространству"
   },
@@ -3510,28 +5944,48 @@
     "message": "Join workspace | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 91]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        91
+      ]
+    ],
     "translation": "Присоединиться к рабочему пространству | kan.bn"
   },
   "wM8xd8": {
     "message": "Junior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Джуниор"
   },
   "aWDhU5": {
     "message": "Kanban is better with a team. Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 51]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        51
+      ]
+    ],
     "translation": "Kanban эффективнее в команде. Идеально для небольших и растущих команд, стремящихся к совместной работе."
   },
   "Xjj/kS": {
     "message": "Kanban reimagined",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 136]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        136
+      ]
+    ],
     "translation": "Kanban по-новому"
   },
   "JbXXUW": {
@@ -3539,8 +5993,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 57],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 67]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        57
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        67
+      ]
     ],
     "translation": "Обратите внимание: это действие необратимо."
   },
@@ -3548,7 +6008,12 @@
     "message": "Keyboard Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 321]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        321
+      ]
+    ],
     "translation": "Горячие клавиши"
   },
   "h8DugX": {
@@ -3556,10 +6021,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextLabelsModal.tsx", 31],
-      ["src/views/board/components/Filters.tsx", 155],
-      ["src/views/board/components/NewCardForm.tsx", 428],
-      ["src/views/card/index.tsx", 133]
+      [
+        "src/views/board/components/CardContextLabelsModal.tsx",
+        31
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        168
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        452
+      ],
+      [
+        "src/views/card/index.tsx",
+        143
+      ]
     ],
     "translation": "Метки"
   },
@@ -3568,7 +6045,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 124]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        124
+      ]
     ],
     "translation": "Метки и фильтры"
   },
@@ -3576,21 +6056,36 @@
     "message": "Labels & Filters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 100]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        100
+      ]
+    ],
     "translation": "Метки и фильтры"
   },
   "vXIe7J": {
     "message": "Language",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 50]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        50
+      ]
+    ],
     "translation": "Язык"
   },
   "k7rCa/": {
     "message": "Large",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 9]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        9
+      ]
+    ],
     "translation": "Крупный"
   },
   "8Is1ih": {
@@ -3598,8 +6093,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/PricingTiers.tsx", 159],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 71]
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        159
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        71
+      ]
     ],
     "translation": "Стартовое предложение"
   },
@@ -3607,49 +6108,84 @@
     "message": "Launch offer: Get unlimited members with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 276]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        276
+      ]
+    ],
     "translation": "Стартовое предложение: неограниченное количество участников с Pro"
   },
   "sDuhfK": {
     "message": "Launch offer: unlimited seats for just $29/month with Pro",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 98]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        98
+      ]
+    ],
     "translation": "Стартовое предложение: неограниченное количество мест всего за $29 в месяц с Pro"
   },
   "zwWKhA": {
     "message": "Learn more",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 110]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        110
+      ]
+    ],
     "translation": "Узнать больше"
   },
   "wqxglO": {
     "message": "Learning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Обучение"
   },
   "vifyyw": {
     "message": "Legal",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 131]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        131
+      ]
+    ],
     "translation": "Юридическая информация"
   },
   "iQmbPb": {
     "message": "License",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 45]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        45
+      ]
+    ],
     "translation": "Лицензия"
   },
   "1njn7W": {
     "message": "Light",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 172]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        172
+      ]
+    ],
     "translation": "Светлая тема"
   },
   "TCt/8K": {
@@ -3657,7 +6193,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 238]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        238
+      ]
     ],
     "translation": "Ограниченный доступ к API"
   },
@@ -3666,11 +6205,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 80],
-      ["src/views/board/index.tsx", 306],
-      ["src/views/card/components/Dropdown.tsx", 45],
-      ["src/views/public/board/CardModal.tsx", 36],
-      ["src/views/public/board/index.tsx", 77]
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        80
+      ],
+      [
+        "src/views/board/index.tsx",
+        312
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        45
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        37
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        84
+      ]
     ],
     "translation": "Ссылка скопирована"
   },
@@ -3679,8 +6233,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 117],
-      ["src/views/card/index.tsx", 124]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        117
+      ],
+      [
+        "src/views/card/index.tsx",
+        134
+      ]
     ],
     "translation": "Список"
   },
@@ -3688,21 +6248,36 @@
     "message": "List name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 129]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        129
+      ]
+    ],
     "translation": "Название списка"
   },
   "h16FyT": {
     "message": "Lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 163]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        176
+      ]
+    ],
     "translation": "Списки"
   },
   "1rVAfU": {
     "message": "Load more activities",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Загрузить ещё действия"
   },
   "0qyZ4b": {
@@ -3710,7 +6285,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 180]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        180
+      ]
     ],
     "translation": "Загрузка разрешений..."
   },
@@ -3718,56 +6296,96 @@
     "message": "Loading...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 579]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        597
+      ]
+    ],
     "translation": "Загрузка..."
   },
   "N/bcWA": {
     "message": "Login | kan.bn",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 33]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        33
+      ]
+    ],
     "translation": "Вход | kan.bn"
   },
   "nOhz3x": {
     "message": "Logout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 227]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        227
+      ]
+    ],
     "translation": "Выйти"
   },
   "vuxdLS": {
     "message": "Long-term",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Долгосрочный"
   },
   "RHZu7R": {
     "message": "Loved by teams worldwide",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 236]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        236
+      ]
+    ],
     "translation": "Любим командами по всему миру"
   },
   "O9jVbx": {
     "message": "Low Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Низкий приоритет"
   },
   "JnWJXY": {
     "message": "magic link",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 438]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        438
+      ]
+    ],
     "translation": "магическая ссылка"
   },
   "DbZgsJ": {
     "message": "Make template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 94]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        94
+      ]
+    ],
     "translation": "Создать шаблон"
   },
   "hB02vO": {
@@ -3775,8 +6393,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextMembersModal.tsx", 51],
-      ["src/views/board/components/CardContextMenu.tsx", 38]
+      [
+        "src/views/board/components/CardContextMembersModal.tsx",
+        51
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        38
+      ]
     ],
     "translation": "Управление участниками"
   },
@@ -3784,37 +6408,64 @@
     "message": "marked a checklist item as incomplete",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 138]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        143
+      ]
+    ],
     "translation": "отметил элемент контрольного списка как невыполненный"
   },
   "jl3aEJ": {
     "message": "marked checklist item <0>{0}</0> as incomplete",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 258]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        272
+      ]
+    ],
     "translation": "отметил элемент контрольного списка <0>{0}</0> как невыполненный"
   },
   "vo2a+a": {
     "message": "Marketing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
+    ],
     "translation": "Маркетинг"
   },
   "agPptk": {
     "message": "Medium",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 8]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        8
+      ]
+    ],
     "translation": "Средний"
   },
   "W/Elkg": {
     "message": "Medium Priority",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 18]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        18
+      ]
+    ],
     "translation": "Средний приоритет"
   },
   "OvoEq7": {
@@ -3822,9 +6473,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 55],
-      ["src/views/card/components/ActivityList.tsx", 88],
-      ["src/views/members/index.tsx", 202]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        57
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        92
+      ],
+      [
+        "src/views/members/index.tsx",
+        202
+      ]
     ],
     "translation": "Участник"
   },
@@ -3833,22 +6493,47 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 123],
-      ["src/views/board/components/Filters.tsx", 147],
-      ["src/views/board/components/NewCardForm.tsx", 386],
-      ["src/views/card/index.tsx", 143],
-      ["src/views/members/index.tsx", 263],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 81]
+      [
+        "src/components/SideNavigation.tsx",
+        123
+      ],
+      [
+        "src/views/board/components/Filters.tsx",
+        160
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        410
+      ],
+      [
+        "src/views/card/index.tsx",
+        153
+      ],
+      [
+        "src/views/members/index.tsx",
+        263
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        81
+      ]
     ],
     "translation": "Участники"
   },
   "9u5BOr": {
     "message": "Members | {0}",
     "placeholders": {
-      "0": ["workspace.name ?? t`Workspace`"]
+      "0": [
+        "workspace.name ?? t`Workspace`"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 258]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        258
+      ]
+    ],
     "translation": "Участники | {0}"
   },
   "/bZzdR": {
@@ -3856,7 +6541,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 183]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        183
+      ]
     ],
     "translation": "Упоминания"
   },
@@ -3865,7 +6553,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 53]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        53
+      ]
     ],
     "translation": "Понедельник"
   },
@@ -3874,9 +6565,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 62],
-      ["src/views/pricing/components/Pricing.tsx", 14],
-      ["src/views/pricing/index.tsx", 20]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        62
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        14
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        20
+      ]
     ],
     "translation": "Ежемесячно"
   },
@@ -3884,45 +6584,79 @@
     "message": "monthly billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 159]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        159
+      ]
+    ],
     "translation": "ежемесячная оплата"
   },
   "51UCsN": {
     "message": "Move to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMenu.tsx", 44]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        44
+      ]
+    ],
     "translation": "Переместить в другой список"
   },
   "J4+OTA": {
     "message": "Move to list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 70]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        70
+      ]
+    ],
     "translation": "Переместить в список"
   },
   "BOqTi5": {
     "message": "moved the card from <0>{0}</0> to<1>{1}</1>",
     "placeholders": {
-      "0": ["truncate(fromList)"],
-      "1": ["truncate(toList)"]
+      "0": [
+        "truncate(fromList)"
+      ],
+      "1": [
+        "truncate(toList)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 160]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        174
+      ]
+    ],
     "translation": "переместил(а) карточку из <0>{0}</0> в<1>{1}</1>"
   },
   "T7LJic": {
     "message": "moved the card to another list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 127]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        132
+      ]
+    ],
     "translation": "переместил(а) карточку в другой список"
   },
   "uEGGDs": {
     "message": "My webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 231]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        231
+      ]
+    ],
     "translation": "Мой вебхук"
   },
   "6YtxFj": {
@@ -3930,11 +6664,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/LabelForm.tsx", 135],
-      ["src/views/board/components/NewTemplateForm.tsx", 118],
-      ["src/views/boards/components/NewBoardForm.tsx", 134],
-      ["src/views/settings/components/NewWebhookModal.tsx", 227],
-      ["src/views/settings/components/WebhookList.tsx", 214]
+      [
+        "src/components/LabelForm.tsx",
+        135
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        118
+      ],
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        134
+      ],
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        227
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        214
+      ]
     ],
     "translation": "Имя"
   },
@@ -3942,14 +6691,24 @@
     "message": "Navigation",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 55]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        55
+      ]
+    ],
     "translation": "Навигация"
   },
   "HBI6nY": {
     "message": "Need help?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 95]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        95
+      ]
+    ],
     "translation": "Нужна помощь?"
   },
   "isRobC": {
@@ -3957,53 +6716,91 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/index.tsx", 95],
-      ["src/views/home/components/Features.tsx", 73]
+      [
+        "src/views/boards/index.tsx",
+        95
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        73
+      ]
     ],
     "translation": "Новый"
   },
   "6WSYbN": {
     "message": "New {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"template\" : \"board\""]
+      "0": [
+        "isTemplate ? \"template\" : \"board\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        120
+      ]
+    ],
     "translation": "Новый {0}"
   },
   "TjREUS": {
     "message": "New API key",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 147]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        147
+      ]
+    ],
     "translation": "Новый API-ключ"
   },
   "pnrmSP": {
     "message": "New card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 311]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        329
+      ]
+    ],
     "translation": "Новая карточка"
   },
   "cWcxrL": {
     "message": "New checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 103]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        103
+      ]
+    ],
     "translation": "Новый чек-лист"
   },
   "WYwN1G": {
     "message": "New import",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 513]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        513
+      ]
+    ],
     "translation": "Новый импорт"
   },
   "n1GRql": {
     "message": "New label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 119]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        119
+      ]
+    ],
     "translation": "Новая метка"
   },
   "Sb2gYF": {
@@ -4011,8 +6808,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewListForm.tsx", 113],
-      ["src/views/board/index.tsx", 620]
+      [
+        "src/views/board/components/NewListForm.tsx",
+        113
+      ],
+      [
+        "src/views/board/index.tsx",
+        626
+      ]
     ],
     "translation": "Новый список"
   },
@@ -4021,7 +6824,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 23]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        23
+      ]
     ],
     "translation": "Требуется новый пароль"
   },
@@ -4030,7 +6836,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 31]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        31
+      ]
     ],
     "translation": "Новый пароль должен отличаться от текущего"
   },
@@ -4038,151 +6847,260 @@
     "message": "New template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 104]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        104
+      ]
+    ],
     "translation": "Новый шаблон"
   },
   "RJA+sg": {
     "message": "New Ticket",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 56]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        56
+      ]
+    ],
     "translation": "Новый тикет"
   },
   "sbNNyi": {
     "message": "New webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 210]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        210
+      ]
+    ],
     "translation": "Новый вебхук"
   },
   "curoK5": {
     "message": "New workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 145]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        145
+      ]
+    ],
     "translation": "Новый рабочий пространство"
   },
   "5ACX4z": {
     "message": "Newsletter",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Рассылка"
   },
   "HeFWjW": {
     "message": "Next Steps",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 93]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        93
+      ]
+    ],
     "translation": "Дальнейшие шаги"
   },
   "/glL9Q": {
     "message": "No {0}",
     "placeholders": {
-      "0": ["isTemplate ? \"templates\" : \"boards\""]
+      "0": [
+        "isTemplate ? \"templates\" : \"boards\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Нет {0}"
   },
   "tlhgDC": {
     "message": "No archived boards",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/BoardsList.tsx", 63]],
+    "origin": [
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        63
+      ]
+    ],
     "translation": "Нет архивированных досок"
   },
   "Eg99Sc": {
     "message": "No authentication methods are currently available",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 369]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        369
+      ]
+    ],
     "translation": "В данный момент нет доступных методов аутентификации"
   },
   "2Bu8xj": {
     "message": "No boards found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 432]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        432
+      ]
+    ],
     "translation": "Доски не найдены"
   },
   "OpNhRn": {
     "message": "No credit card required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 85]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        85
+      ]
+    ],
     "translation": "Кредитная карта не требуется"
   },
   "MK16u2": {
     "message": "No dates",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 137]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        150
+      ]
+    ],
     "translation": "Нет дат"
   },
   "sY2lzr": {
     "message": "No download URL available for this attachment.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        143
+      ]
+    ],
     "translation": "Для этого вложения нет доступной ссылки для скачивания."
   },
   "TXO5TM": {
     "message": "No keyboard shortcuts registered.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 334]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        334
+      ]
+    ],
     "translation": "Горячие клавиши не зарегистрированы."
   },
   "hXMFoN": {
     "message": "No lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 652]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        658
+      ]
+    ],
     "translation": "Нет списков"
   },
   "fvLNDy": {
     "message": "No lists have been created yet",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/index.tsx", 657]],
+    "origin": [
+      [
+        "src/views/board/index.tsx",
+        663
+      ]
+    ],
     "translation": "Списки ещё не созданы"
   },
   "i30J2U": {
     "message": "No projects found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 283]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        283
+      ]
+    ],
     "translation": "Проекты не найдены"
   },
   "ERpq2P": {
     "message": "No results found for \"{debouncedQuery}\".",
     "placeholders": {
-      "debouncedQuery": ["debouncedQuery"]
+      "debouncedQuery": [
+        "debouncedQuery"
+      ]
     },
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 193]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        193
+      ]
+    ],
     "translation": "По запросу «{debouncedQuery}» ничего не найдено."
   },
   "Q9pQaX": {
     "message": "No roles found for this workspace yet.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        110
+      ]
+    ],
     "translation": "Для этого рабочего пространства пока не найдено ролей."
   },
   "TX0bT7": {
     "message": "No webhooks configured. Add a webhook to receive notifications.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 196]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        196
+      ]
+    ],
     "translation": "Вебхуки не настроены. Добавьте вебхук для получения уведомлений."
   },
   "9h7RDh": {
     "message": "Offer",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 78]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        78
+      ]
+    ],
     "translation": "Предложение"
   },
   "QnzD50": {
@@ -4190,7 +7108,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 245]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        245
+      ]
     ],
     "translation": "Локально"
   },
@@ -4198,42 +7119,72 @@
     "message": "On-premise deployment option",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 106]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        106
+      ]
+    ],
     "translation": "Вариант локального развертывания"
   },
   "gukxZ5": {
     "message": "Onboarding",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 79]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        79
+      ]
+    ],
     "translation": "Онбординг"
   },
   "usVytm": {
     "message": "Once you delete your account, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 73]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        73
+      ]
+    ],
     "translation": "После удаления аккаунта возврата не будет. Это действие необратимо."
   },
   "dmKdk0": {
     "message": "Once you delete your workspace, there is no going back. This action cannot be undone.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 128]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        128
+      ]
+    ],
     "translation": "После удаления рабочего пространства возврата не будет. Это действие необратимо."
   },
   "69b7aE": {
     "message": "Open command menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/WorkspaceMenu.tsx", 34]],
+    "origin": [
+      [
+        "src/components/WorkspaceMenu.tsx",
+        34
+      ]
+    ],
     "translation": "Открыть командное меню"
   },
   "cFQEU/": {
     "message": "Open keyboard shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/providers/keyboard-shortcuts.tsx", 172]],
+    "origin": [
+      [
+        "src/providers/keyboard-shortcuts.tsx",
+        172
+      ]
+    ],
     "translation": "Открыть горячие клавиши"
   },
   "v+Wp++": {
@@ -4241,7 +7192,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 229]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        229
+      ]
     ],
     "translation": "Открытый исходный код"
   },
@@ -4249,21 +7203,36 @@
     "message": "Open Source Friends",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/oss-friends/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/oss-friends/index.tsx",
+        58
+      ]
+    ],
     "translation": "Друзья Open Source"
   },
   "BzEFor": {
     "message": "or",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 380]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        380
+      ]
+    ],
     "translation": "или"
   },
   "ZqDqbi": {
     "message": "Organize and find cards quickly with powerful filtering tools.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 101]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        101
+      ]
+    ],
     "translation": "Быстро организуйте и находите карточки с помощью мощных инструментов фильтрации."
   },
   "Un80BR": {
@@ -4271,8 +7240,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 39],
-      ["src/views/oss-friends/index.tsx", 52]
+      [
+        "src/views/home/components/Footer.tsx",
+        39
+      ],
+      [
+        "src/views/oss-friends/index.tsx",
+        52
+      ]
     ],
     "translation": "OSS Friends"
   },
@@ -4280,35 +7255,60 @@
     "message": "Overdue",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/Filters.tsx", 112]],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        125
+      ]
+    ],
     "translation": "Просрочено"
   },
   "P6dJdq": {
     "message": "Overrides cleared",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Переопределения сброшены"
   },
   "SPLN9O": {
     "message": "Own your data",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 73]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        73
+      ]
+    ],
     "translation": "Владейте своими данными"
   },
   "8F1i42": {
     "message": "Page not found",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 24]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        24
+      ]
+    ],
     "translation": "Страница не найдена"
   },
   "Uworke": {
     "message": "Part-time",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Частичная занятость"
   },
   "IrZaAn": {
@@ -4316,7 +7316,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 69]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Пароль изменён"
   },
@@ -4324,14 +7327,24 @@
     "message": "Password is required to login.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 258]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        258
+      ]
+    ],
     "translation": "Для входа требуется пароль."
   },
   "tTbref": {
     "message": "Password is required to sign up.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 257]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        257
+      ]
+    ],
     "translation": "Для регистрации требуется пароль."
   },
   "vwGkYB": {
@@ -4339,7 +7352,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 22]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        22
+      ]
     ],
     "translation": "Пароль должен содержать не менее 8 символов"
   },
@@ -4348,7 +7364,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Пароли не совпадают"
   },
@@ -4356,7 +7375,12 @@
     "message": "Paused",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "Приостановлено"
   },
   "UbYdrA": {
@@ -4364,8 +7388,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 100],
-      ["src/views/pricing/components/PricingTiers.tsx", 120]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        100
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        120
+      ]
     ],
     "translation": "Частота платежей"
   },
@@ -4373,7 +7403,12 @@
     "message": "Pending",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 210]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        210
+      ]
+    ],
     "translation": "В ожидании"
   },
   "oVBq1w": {
@@ -4381,10 +7416,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 15],
-      ["src/views/pricing/components/Pricing.tsx", 20],
-      ["src/views/pricing/index.tsx", 21],
-      ["src/views/pricing/index.tsx", 26]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        15
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        20
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        21
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        26
+      ]
     ],
     "translation": "за пользователя/месяц"
   },
@@ -4392,28 +7439,48 @@
     "message": "Per-seat pricing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 83]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        83
+      ]
+    ],
     "translation": "Цена за место"
   },
   "mrhyIB": {
     "message": "Perfect for small and growing teams looking to collaborate.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 52]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        52
+      ]
+    ],
     "translation": "Идеально для небольших и развивающихся команд, которые хотят сотрудничать."
   },
   "TH3Irz": {
     "message": "Permission",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/RolePermissions.tsx", 119]],
+    "origin": [
+      [
+        "src/views/settings/components/RolePermissions.tsx",
+        119
+      ]
+    ],
     "translation": "Разрешение"
   },
   "9cDpsw": {
     "message": "Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/SettingsLayout.tsx", 53]],
+    "origin": [
+      [
+        "src/components/SettingsLayout.tsx",
+        53
+      ]
+    ],
     "translation": "Разрешения"
   },
   "Jgaz7E": {
@@ -4421,7 +7488,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 80]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        80
+      ]
     ],
     "translation": "Разрешения сброшены"
   },
@@ -4430,8 +7500,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 34],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 57]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        34
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        57
+      ]
     ],
     "translation": "Разрешения обновлены"
   },
@@ -4439,14 +7515,24 @@
     "message": "Personal Project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 86]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        86
+      ]
+    ],
     "translation": "Личный проект"
   },
   "Oi+J+N": {
     "message": "Pick a plan to get started. All paid plans include a 14-day free trial.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 125]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        125
+      ]
+    ],
     "translation": "Выберите тариф, чтобы начать. Все платные тарифы включают 14-дневный бесплатный пробный период."
   },
   "Iqh0Uv": {
@@ -4454,8 +7540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Запланировано"
   },
@@ -4463,7 +7555,12 @@
     "message": "Planning",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 90]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        90
+      ]
+    ],
     "translation": "Планирование"
   },
   "F3bW6y": {
@@ -4471,7 +7568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 317]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        317
+      ]
     ],
     "translation": "Платформа"
   },
@@ -4480,7 +7580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 24]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        24
+      ]
     ],
     "translation": "Пожалуйста, подтвердите новый пароль"
   },
@@ -4488,28 +7591,48 @@
     "message": "Please enter a valid email address",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 406]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        406
+      ]
+    ],
     "translation": "Пожалуйста, введите корректный адрес электронной почты"
   },
   "CJ3zUq": {
     "message": "Please enter a valid name",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 394]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        394
+      ]
+    ],
     "translation": "Пожалуйста, введите корректное имя"
   },
   "7b2yuC": {
     "message": "Please enter a valid password",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 421]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        421
+      ]
+    ],
     "translation": "Пожалуйста, введите корректный пароль"
   },
   "jEw0Mr": {
     "message": "Please enter a valid URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        24
+      ]
+    ],
     "translation": "Пожалуйста, введите корректный URL"
   },
   "tmlJN1": {
@@ -4517,8 +7640,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 58],
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 98]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        58
+      ],
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        98
+      ]
     ],
     "translation": "Пожалуйста, введите корректную ссылку на YouTube"
   },
@@ -4526,7 +7655,12 @@
     "message": "Please select a file to upload.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 70]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        70
+      ]
+    ],
     "translation": "Пожалуйста, выберите файл для загрузки."
   },
   "tyHiOa": {
@@ -4534,56 +7668,210 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 26],
-      ["src/components/FeedbackModal.tsx", 41],
-      ["src/components/NewWorkspaceForm.tsx", 109],
-      ["src/views/board/components/BoardDropdown.tsx", 68],
-      ["src/views/board/components/NewCardForm.tsx", 193],
-      ["src/views/board/components/NewListForm.tsx", 79],
-      ["src/views/board/components/NewTemplateForm.tsx", 61],
-      ["src/views/board/components/NewTemplateForm.tsx", 77],
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 73],
-      ["src/views/board/components/VisibilityButton.tsx", 57],
-      ["src/views/board/index.tsx", 218],
-      ["src/views/board/index.tsx", 274],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 243],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 395],
-      ["src/views/card/components/AttachmentThumbnails.tsx", 74],
-      ["src/views/card/components/ChecklistItemRow.tsx", 67],
-      ["src/views/card/components/ChecklistItemRow.tsx", 95],
-      ["src/views/card/components/ChecklistNameInput.tsx", 47],
-      ["src/views/card/components/Checklists.tsx", 81],
-      ["src/views/card/components/Comment.tsx", 93],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 52],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 38],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 46],
-      ["src/views/card/components/DueDateSelector.tsx", 64],
-      ["src/views/card/components/LabelSelector.tsx", 75],
-      ["src/views/card/components/ListSelector.tsx", 55],
-      ["src/views/card/components/MemberSelector.tsx", 82],
-      ["src/views/card/components/NewChecklistForm.tsx", 71],
-      ["src/views/card/components/NewChecklistItemForm.tsx", 90],
-      ["src/views/card/components/NewCommentForm.tsx", 37],
-      ["src/views/card/index.tsx", 232],
-      ["src/views/card/index.tsx", 245],
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 28],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 42],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 65],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 93],
-      ["src/views/members/components/InviteMemberForm.tsx", 104],
-      ["src/views/members/components/InviteMemberForm.tsx", 241],
-      ["src/views/members/index.tsx", 66],
-      ["src/views/onboarding/workspace-details/index.tsx", 102],
-      ["src/views/onboarding/workspace-details/index.tsx", 151],
-      ["src/views/settings/components/Avatar.tsx", 200],
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 40],
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 46],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 55],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 64],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 59],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 76],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 44],
-      ["src/views/settings/PermissionsSettings.tsx", 40]
+      [
+        "src/components/CardTypeSelector.tsx",
+        61
+      ],
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        26
+      ],
+      [
+        "src/components/FeedbackModal.tsx",
+        41
+      ],
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        109
+      ],
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        68
+      ],
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        209
+      ],
+      [
+        "src/views/board/components/NewListForm.tsx",
+        79
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        61
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        77
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        73
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        57
+      ],
+      [
+        "src/views/board/index.tsx",
+        224
+      ],
+      [
+        "src/views/board/index.tsx",
+        280
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        243
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        395
+      ],
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        74
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        67
+      ],
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        95
+      ],
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        47
+      ],
+      [
+        "src/views/card/components/Checklists.tsx",
+        81
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        93
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        52
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        38
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        64
+      ],
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        75
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        55
+      ],
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        82
+      ],
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        71
+      ],
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        90
+      ],
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        37
+      ],
+      [
+        "src/views/card/index.tsx",
+        246
+      ],
+      [
+        "src/views/card/index.tsx",
+        259
+      ],
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        28
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        42
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        65
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        93
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        104
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        241
+      ],
+      [
+        "src/views/members/index.tsx",
+        66
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        102
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        151
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        200
+      ],
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        40
+      ],
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        46
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        55
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        64
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        59
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        76
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        40
+      ]
     ],
     "translation": "Пожалуйста, попробуйте позже или обратитесь в службу поддержки."
   },
@@ -4592,8 +7880,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 129],
-      ["src/views/members/components/InviteMemberForm.tsx", 145]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        129
+      ],
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        145
+      ]
     ],
     "translation": "Пожалуйста, попробуйте позже."
   },
@@ -4602,13 +7896,34 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 76],
-      ["src/views/board/components/CardContextMoveListModal.tsx", 42],
-      ["src/views/board/index.tsx", 315],
-      ["src/views/card/components/Dropdown.tsx", 54],
-      ["src/views/card/components/Dropdown.tsx", 73],
-      ["src/views/public/board/CardModal.tsx", 45],
-      ["src/views/public/board/index.tsx", 86]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        76
+      ],
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        42
+      ],
+      [
+        "src/views/board/index.tsx",
+        321
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        54
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        73
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        46
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        93
+      ]
     ],
     "translation": "Пожалуйста, попробуйте ещё раз."
   },
@@ -4617,7 +7932,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 193]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        193
+      ]
     ],
     "translation": "Позиция в списке (0 = первая, оставьте пустым для конца)"
   },
@@ -4626,12 +7944,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 51],
-      ["src/views/home/components/Header.tsx", 18],
-      ["src/views/home/components/Header.tsx", 34],
-      ["src/views/pricing/components/Pricing.tsx", 85],
-      ["src/views/pricing/index.tsx", 34],
-      ["src/views/pricing/index.tsx", 40]
+      [
+        "src/views/home/components/Footer.tsx",
+        51
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        18
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        34
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        40
+      ]
     ],
     "translation": "Цены"
   },
@@ -4640,10 +7976,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 275],
-      ["src/views/pricing/components/Pricing.tsx", 56],
-      ["src/views/pricing/components/PricingTiers.tsx", 61],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 95]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        275
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        56
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        61
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        95
+      ]
     ],
     "translation": "Приоритетная поддержка по электронной почте"
   },
@@ -4651,14 +7999,24 @@
     "message": "Privacy policy",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 43]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        43
+      ]
+    ],
     "translation": "Политика конфиденциальности"
   },
   "zwBp5t": {
     "message": "Private",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 84]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        84
+      ]
+    ],
     "translation": "Приватно"
   },
   "3fPjUY": {
@@ -4666,9 +8024,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 333],
-      ["src/views/pricing/components/PricingTiers.tsx", 70]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        333
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        70
+      ]
     ],
     "translation": "Pro"
   },
@@ -4676,84 +8043,144 @@
     "message": "Pro Plan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 290]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        290
+      ]
+    ],
     "translation": "Тариф Pro"
   },
   "Qtzfdk": {
     "message": "Pro Plan ∞",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ]
+    ],
     "translation": "Тариф Pro ∞"
   },
   "0rPv1T": {
     "message": "Profile image updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 189]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        189
+      ]
+    ],
     "translation": "Изображение профиля обновлено"
   },
   "4XF0BB": {
     "message": "Profile picture",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 30]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        30
+      ]
+    ],
     "translation": "Фото профиля"
   },
   "7d1a0d": {
     "message": "Public",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 79]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        79
+      ]
+    ],
     "translation": "Публично"
   },
   "ABCjd9": {
     "message": "Publishing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 47]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        47
+      ]
+    ],
     "translation": "Публикация"
   },
   "bfgr/e": {
     "message": "Question",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 66]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        66
+      ]
+    ],
     "translation": "Вопрос"
   },
   "1H5u1m": {
     "message": "Questions?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 147]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        147
+      ]
+    ],
     "translation": "Вопросы?"
   },
   "kfOGMr": {
     "message": "Quick Win",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 96]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        96
+      ]
+    ],
     "translation": "Быстрая победа"
   },
   "6EWT6T": {
     "message": "Recruitment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 73]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        73
+      ]
+    ],
     "translation": "Набор персонала"
   },
   "ekCRTP": {
     "message": "Rejected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "Отклонено"
   },
   "qlAIQ1": {
     "message": "Remote",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Удалённо"
   },
   "t/YqKh": {
@@ -4761,7 +8188,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 58]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        58
+      ]
     ],
     "translation": "Удалить"
   },
@@ -4769,70 +8199,123 @@
     "message": "Remove from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 124]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        124
+      ]
+    ],
     "translation": "Удалить из избранного"
   },
   "99VIgC": {
     "message": "Remove member",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 233]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        233
+      ]
+    ],
     "translation": "Удалить участника"
   },
   "BZkYSt": {
     "message": "removed {0} labels: <0>{labelList}</0>",
     "placeholders": {
-      "0": ["mergedLabels.length"],
-      "labelList": ["labelList"]
+      "0": [
+        "mergedLabels.length"
+      ],
+      "labelList": [
+        "labelList"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 116]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        120
+      ]
+    ],
     "translation": "удалено {0} меток: <0>{labelList}</0>"
   },
   "kQwvU8": {
     "message": "removed a label from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 129]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        134
+      ]
+    ],
     "translation": "удалена метка с карточки"
   },
   "uck1tz": {
     "message": "removed a member from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 131]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        136
+      ]
+    ],
     "translation": "удалён участник из карточки"
   },
   "KEim/+": {
     "message": "removed an attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 141]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        146
+      ]
+    ],
     "translation": "удалено вложение"
   },
   "zwTiVn": {
     "message": "removed an attachment <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(filename)"]
+      "0": [
+        "truncate(filename)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 288]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        302
+      ]
+    ],
     "translation": "удалено вложение <0>{0}</0>"
   },
   "Qh7QmR": {
     "message": "Removed from favorites",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 57]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        57
+      ]
+    ],
     "translation": "Удалено из избранного"
   },
   "YVT40D": {
     "message": "removed label <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(label)"]
+      "0": [
+        "truncate(label)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 200]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        214
+      ]
+    ],
     "translation": "удалена метка <0>{0}</0>"
   },
   "aHRWVI": {
@@ -4840,8 +8323,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/ActivityList.tsx", 144],
-      ["src/views/card/components/ActivityList.tsx", 324]
+      [
+        "src/views/card/components/ActivityList.tsx",
+        149
+      ],
+      [
+        "src/views/card/components/ActivityList.tsx",
+        338
+      ]
     ],
     "translation": "удалена дата выполнения"
   },
@@ -4849,25 +8338,44 @@
     "message": "renamed a checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 133]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        138
+      ]
+    ],
     "translation": "переименован чек-лист"
   },
   "3ZjRJY": {
     "message": "renamed checklist <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 216]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        230
+      ]
+    ],
     "translation": "переименован чек-лист <0>{0}</0>"
   },
   "NH54UR": {
     "message": "renamed checklist item to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 240]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        254
+      ]
+    ],
     "translation": "переименован пункт чек-листа в <0>{0}</0>"
   },
   "Yx0Ud8": {
@@ -4875,8 +8383,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 29],
-      ["src/views/boards/components/TemplateBoards.tsx", 35]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        29
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
     ],
     "translation": "Запрошено"
   },
@@ -4884,7 +8398,16 @@
     "message": "Research",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 89]],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        46
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        89
+      ]
+    ],
     "translation": "Исследование"
   },
   "e4hPSt": {
@@ -4892,7 +8415,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 245]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        245
+      ]
     ],
     "translation": "Сбросить к настройкам роли по умолчанию"
   },
@@ -4900,21 +8426,36 @@
     "message": "Resolution",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 60]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        60
+      ]
+    ],
     "translation": "Решение"
   },
   "s+MGs7": {
     "message": "Resources",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        114
+      ]
+    ],
     "translation": "Ресурсы"
   },
   "5k0NLb": {
     "message": "Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 92]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        92
+      ]
+    ],
     "translation": "Рецензия"
   },
   "/gaSVU": {
@@ -4922,10 +8463,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Footer.tsx", 36],
-      ["src/views/home/components/Header.tsx", 13],
-      ["src/views/home/components/Header.tsx", 28],
-      ["src/views/onboarding/workspace-details/index.tsx", 162]
+      [
+        "src/views/home/components/Footer.tsx",
+        36
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        13
+      ],
+      [
+        "src/views/home/components/Header.tsx",
+        28
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        162
+      ]
     ],
     "translation": "Дорожная карта"
   },
@@ -4933,14 +8486,24 @@
     "message": "Role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 328]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        328
+      ]
+    ],
     "translation": "Роль"
   },
   "jQ6I8X": {
     "message": "Role updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 58]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        58
+      ]
+    ],
     "translation": "Роль обновлена"
   },
   "RzxgOE": {
@@ -4948,7 +8511,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 164]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        164
+      ]
     ],
     "translation": "Роли и разрешения"
   },
@@ -4956,14 +8522,24 @@
     "message": "Run on your own infrastructure",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 72]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        72
+      ]
+    ],
     "translation": "Запустить на собственной инфраструктуре"
   },
   "YEOVrT": {
     "message": "SAML SSO",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 102]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        102
+      ]
+    ],
     "translation": "SAML SSO"
   },
   "+5kO8P": {
@@ -4971,7 +8547,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 54]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        54
+      ]
     ],
     "translation": "Суббота"
   },
@@ -4980,9 +8559,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 183],
-      ["src/views/card/components/Comment.tsx", 202],
-      ["src/views/settings/components/Avatar.tsx", 290]
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        183
+      ],
+      [
+        "src/views/card/components/Comment.tsx",
+        202
+      ],
+      [
+        "src/views/settings/components/Avatar.tsx",
+        290
+      ]
     ],
     "translation": "Сохранить"
   },
@@ -4990,42 +8578,72 @@
     "message": "Save changes",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 344]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        344
+      ]
+    ],
     "translation": "Сохранить изменения"
   },
   "MdwUGG": {
     "message": "Save time with reusable board templates.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 116]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        116
+      ]
+    ],
     "translation": "Экономьте время с шаблонами досок для повторного использования."
   },
   "cOh+MI": {
     "message": "Screening",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 76]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        76
+      ]
+    ],
     "translation": "Скрининг"
   },
   "SkCNhl": {
     "message": "Search boards and cards...",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/CommandPallette.tsx", 105]],
+    "origin": [
+      [
+        "src/components/CommandPallette.tsx",
+        105
+      ]
+    ],
     "translation": "Поиск досок и карточек..."
   },
   "e1v+J3": {
     "message": "Secret (optional)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 251]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        251
+      ]
+    ],
     "translation": "Секретный ключ (необязательно)"
   },
   "OkTY4+": {
     "message": "Secret cannot exceed 512 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 28]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        28
+      ]
+    ],
     "translation": "Секретный ключ не может превышать 512 символов"
   },
   "a3LDKx": {
@@ -5033,7 +8651,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 321]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        321
+      ]
     ],
     "translation": "Безопасность"
   },
@@ -5041,7 +8662,12 @@
     "message": "See what our users are saying about Kan",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 239]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        239
+      ]
+    ],
     "translation": "Посмотрите, что наши пользователи говорят о Kan"
   },
   "zYRVNp": {
@@ -5049,7 +8675,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 131]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        131
+      ]
     ],
     "translation": "Выберите список"
   },
@@ -5058,8 +8687,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/ImportBoardsForm.tsx", 315],
-      ["src/views/boards/components/ImportBoardsForm.tsx", 464]
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        315
+      ],
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        464
+      ]
     ],
     "translation": "Выбрать всё"
   },
@@ -5067,56 +8702,96 @@
     "message": "Select at least one event",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 32]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        32
+      ]
+    ],
     "translation": "Выберите хотя бы одно событие"
   },
   "rYUZIe": {
     "message": "Select source",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 195]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        195
+      ]
+    ],
     "translation": "Выбрать источник"
   },
   "ppaRWv": {
     "message": "Self Host",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 64]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        64
+      ]
+    ],
     "translation": "Самостоятельный хостинг"
   },
   "l2PIAy": {
     "message": "Self host with Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 81]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        81
+      ]
+    ],
     "translation": "Самостоятельный хостинг с Github"
   },
   "VXk54Y": {
     "message": "self-assigned the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 169]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        183
+      ]
+    ],
     "translation": "самостоятельно назначил(а) карточку"
   },
   "RoafuO": {
     "message": "Send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 116]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        116
+      ]
+    ],
     "translation": "Отправить отзыв"
   },
   "eus61c": {
     "message": "Send test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 338]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        338
+      ]
+    ],
     "translation": "Отправить тест"
   },
   "v3YoMA": {
     "message": "Senior",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 82]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        82
+      ]
+    ],
     "translation": "Старший"
   },
   "8AbRER": {
@@ -5124,9 +8799,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDueDateModal.tsx", 20],
-      ["src/views/board/components/CardContextMenu.tsx", 56],
-      ["src/views/card/components/DueDateSelector.tsx", 121]
+      [
+        "src/views/board/components/CardContextDueDateModal.tsx",
+        20
+      ],
+      [
+        "src/views/board/components/CardContextMenu.tsx",
+        56
+      ],
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        121
+      ]
     ],
     "translation": "Установить срок"
   },
@@ -5134,14 +8818,36 @@
     "message": "set the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 142]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        147
+      ]
+    ],
     "translation": "установить срок"
+  },
+  "d75lEw": {
+    "translation": "",
+    "message": "Set type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        100
+      ]
+    ]
   },
   "JjEJSy": {
     "message": "Set up your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 180]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        180
+      ]
+    ],
     "translation": "Настройте ваше рабочее пространство"
   },
   "Tz0i8g": {
@@ -5149,8 +8855,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 102],
-      ["src/components/SideNavigation.tsx", 135]
+      [
+        "src/components/SettingsLayout.tsx",
+        102
+      ],
+      [
+        "src/components/SideNavigation.tsx",
+        135
+      ]
     ],
     "translation": "Настройки"
   },
@@ -5158,70 +8870,120 @@
     "message": "Settings | Account",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 26]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        26
+      ]
+    ],
     "translation": "Настройки | Аккаунт"
   },
   "iy1wb+": {
     "message": "Settings | API",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 18]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        18
+      ]
+    ],
     "translation": "Настройки | API"
   },
   "ADEin1": {
     "message": "Settings | Billing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 35]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        35
+      ]
+    ],
     "translation": "Настройки | Оплата"
   },
   "hYzsXr": {
     "message": "Settings | Integrations",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 138]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        138
+      ]
+    ],
     "translation": "Настройки | Интеграции"
   },
   "F/FPk/": {
     "message": "Settings | Permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 49]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        49
+      ]
+    ],
     "translation": "Настройки | Разрешения"
   },
   "+h2faV": {
     "message": "Settings | Webhooks",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WebhookSettings.tsx", 24]],
+    "origin": [
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        24
+      ]
+    ],
     "translation": "Настройки | Вебхуки"
   },
   "Ci/KUX": {
     "message": "Settings | Workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 59]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        59
+      ]
+    ],
     "translation": "Настройки | Рабочее пространство"
   },
   "CTqTgr": {
     "message": "Shortcuts",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 187]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        187
+      ]
+    ],
     "translation": "Горячие клавиши"
   },
   "5lWFkC": {
     "message": "Sign in",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 104]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        104
+      ]
+    ],
     "translation": "Войти"
   },
   "n1ekoW": {
     "message": "Sign In",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 154]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        154
+      ]
+    ],
     "translation": "Войти"
   },
   "fcWrnU": {
@@ -5229,8 +8991,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/select-plan/index.tsx", 284],
-      ["src/views/onboarding/workspace-details/index.tsx", 363]
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        284
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        363
+      ]
     ],
     "translation": "Выйти"
   },
@@ -5238,7 +9006,12 @@
     "message": "Sign Up",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 162]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        162
+      ]
+    ],
     "translation": "Зарегистрироваться"
   },
   "sUZo7y": {
@@ -5246,8 +9019,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/auth/signup/index.tsx", 36],
-      ["src/views/auth/signup/index.tsx", 61]
+      [
+        "src/views/auth/signup/index.tsx",
+        36
+      ],
+      [
+        "src/views/auth/signup/index.tsx",
+        61
+      ]
     ],
     "translation": "Регистрация | kan.bn"
   },
@@ -5255,21 +9034,36 @@
     "message": "Sign up disabled",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 46]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        46
+      ]
+    ],
     "translation": "Регистрация отключена"
   },
   "s6iE/c": {
     "message": "Sign up is currently disabled. Please try again later.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/signup/index.tsx", 49]],
+    "origin": [
+      [
+        "src/views/auth/signup/index.tsx",
+        49
+      ]
+    ],
     "translation": "Регистрация сейчас недоступна. Пожалуйста, попробуйте позже."
   },
   "6FDocz": {
     "message": "Sign up with ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 437]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        437
+      ]
+    ],
     "translation": "Зарегистрироваться через "
   },
   "m2nk0i": {
@@ -5277,8 +9071,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 89],
-      ["src/views/pricing/index.tsx", 44]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        89
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        44
+      ]
     ],
     "translation": "Простые тарифы"
   },
@@ -5286,7 +9086,12 @@
     "message": "Simple, visual task management that just works. Drag and drop cards, collaborate with your team, and get more done.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 139]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        139
+      ]
+    ],
     "translation": "Простое и наглядное управление задачами, которое действительно работает. Перетаскивайте карточки, работайте с командой и достигайте большего."
   },
   "zEcnBA": {
@@ -5294,7 +9099,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 291]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        291
+      ]
     ],
     "translation": "SLA"
   },
@@ -5302,36 +9110,71 @@
     "message": "Small",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FontSizeSelector.tsx", 7]],
+    "origin": [
+      [
+        "src/components/FontSizeSelector.tsx",
+        7
+      ]
+    ],
     "translation": "Мелкий"
   },
   "++rVAm": {
     "message": "Social Media",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Социальные сети"
   },
   "wIb7Ng": {
     "message": "Software Development",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 22]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        22
+      ]
+    ],
     "translation": "Разработка ПО"
   },
   "6sKjjx": {
     "message": "Solo",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        76
+      ]
+    ],
     "translation": "Индивидуальный"
+  },
+  "LbPk58": {
+    "translation": "",
+    "message": "Spike",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        45
+      ]
+    ]
   },
   "vnS6Rf": {
     "message": "SSO",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 256]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        256
+      ]
     ],
     "translation": "SSO"
   },
@@ -5339,7 +9182,12 @@
     "message": "Star on Github",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 37]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        37
+      ]
+    ],
     "translation": "Поставьте звезду на Github"
   },
   "veIDCY": {
@@ -5347,8 +9195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 359],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 113]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        359
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        113
+      ]
     ],
     "translation": "Начните 14-дневный бесплатный пробный период"
   },
@@ -5356,21 +9210,36 @@
     "message": "Start free. Upgrade as your team grows. No hidden fees, no contracts.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/index.tsx", 47]],
+    "origin": [
+      [
+        "src/views/pricing/index.tsx",
+        47
+      ]
+    ],
     "translation": "Начните бесплатно. Переходите на новый тариф по мере роста команды. Без скрытых платежей и контрактов."
   },
   "uAQUqI": {
     "message": "Status",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 232]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        232
+      ]
+    ],
     "translation": "Статус"
   },
   "WYDptz": {
     "message": "Subscription Required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 122]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        122
+      ]
+    ],
     "translation": "Требуется подписка"
   },
   "zzDlyQ": {
@@ -5378,17 +9247,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/AuthForm.tsx", 215],
-      ["src/components/AuthForm.tsx", 232]
+      [
+        "src/components/AuthForm.tsx",
+        215
+      ],
+      [
+        "src/components/AuthForm.tsx",
+        232
+      ]
     ],
     "translation": "Успех"
+  },
+  "YledUl": {
+    "translation": "",
+    "message": "Suggestion",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeBadge.tsx",
+        51
+      ]
+    ]
   },
   "DBC3t5": {
     "message": "Sunday",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWeekStartDayForm.tsx", 52]
+      [
+        "src/views/settings/components/UpdateWeekStartDayForm.tsx",
+        52
+      ]
     ],
     "translation": "Воскресенье"
   },
@@ -5397,7 +9287,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 59]
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        59
+      ]
     ],
     "translation": "Улучшите свой workspace всего за $29 в месяц. Вы получите:"
   },
@@ -5406,8 +9299,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/UserMenu.tsx", 198],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 325]
+      [
+        "src/components/UserMenu.tsx",
+        198
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        325
+      ]
     ],
     "translation": "Поддержка"
   },
@@ -5415,21 +9314,36 @@
     "message": "Support the development of the project",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 57]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        57
+      ]
+    ],
     "translation": "Поддержите развитие проекта"
   },
   "D+NlUC": {
     "message": "System",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 144]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        144
+      ]
+    ],
     "translation": "Система"
   },
   "KM6m8p": {
     "message": "Team",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 83]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        83
+      ]
+    ],
     "translation": "Команда"
   },
   "bff61F": {
@@ -5437,8 +9351,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/InviteMemberForm.tsx", 322],
-      ["src/views/members/index.tsx", 292]
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        322
+      ],
+      [
+        "src/views/members/index.tsx",
+        292
+      ]
     ],
     "translation": "Тариф для команды"
   },
@@ -5447,9 +9367,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 332],
-      ["src/views/pricing/components/Pricing.tsx", 46],
-      ["src/views/pricing/components/PricingTiers.tsx", 47]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        332
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        46
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        47
+      ]
     ],
     "translation": "Команды"
   },
@@ -5458,8 +9387,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 530],
-      ["src/views/board/index.tsx", 566]
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/board/index.tsx",
+        572
+      ]
     ],
     "translation": "Шаблон"
   },
@@ -5467,28 +9402,48 @@
     "message": "Template created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        67
+      ]
+    ],
     "translation": "Шаблон создан"
   },
   "QHhZeE": {
     "message": "Template created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 68]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        68
+      ]
+    ],
     "translation": "Шаблон успешно создан"
   },
   "notwF1": {
     "message": "Template name cannot exceed 100 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 19]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        19
+      ]
+    ],
     "translation": "Имя шаблона не может превышать 100 символов"
   },
   "6OTo9n": {
     "message": "Template name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewTemplateForm.tsx", 18]],
+    "origin": [
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        18
+      ]
+    ],
     "translation": "Необходимо указать имя шаблона"
   },
   "iTylMl": {
@@ -5496,8 +9451,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 111],
-      ["src/views/home/components/Features.tsx", 115]
+      [
+        "src/components/SideNavigation.tsx",
+        111
+      ],
+      [
+        "src/views/home/components/Features.tsx",
+        115
+      ]
     ],
     "translation": "Шаблоны"
   },
@@ -5505,14 +9466,24 @@
     "message": "Terms of service",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Footer.tsx", 42]],
+    "origin": [
+      [
+        "src/views/home/components/Footer.tsx",
+        42
+      ]
+    ],
     "translation": "Условия использования"
   },
   "NnH3pK": {
     "message": "Test",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/WebhookList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        136
+      ]
+    ],
     "translation": "Тест"
   },
   "InJcdo": {
@@ -5520,8 +9491,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 154],
-      ["src/views/settings/components/WebhookList.tsx", 177]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        154
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        177
+      ]
     ],
     "translation": "Тест не пройден"
   },
@@ -5530,8 +9507,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 148],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        148
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Тест отправлен"
   },
@@ -5540,8 +9523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 149],
-      ["src/views/settings/components/WebhookList.tsx", 174]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        149
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        174
+      ]
     ],
     "translation": "Тестовый вебхук успешно отправлен!"
   },
@@ -5549,28 +9538,48 @@
     "message": "Testimonials",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Testimonials.tsx", 232]],
+    "origin": [
+      [
+        "src/views/home/components/Testimonials.tsx",
+        232
+      ]
+    ],
     "translation": "Отзывы"
   },
   "nhMhRr": {
     "message": "Thank you for your feedback!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 34]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        34
+      ]
+    ],
     "translation": "Спасибо за ваш отзыв!"
   },
   "NcFrgC": {
     "message": "The board has been archived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 48]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        48
+      ]
+    ],
     "translation": "Доска была архивирована."
   },
   "C6gv54": {
     "message": "The board has been unarchived.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 49]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        49
+      ]
+    ],
     "translation": "Доска была восстановлена из архива."
   },
   "nKBUeF": {
@@ -5578,7 +9587,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 69]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        69
+      ]
     ],
     "translation": "Карточка была продублирована."
   },
@@ -5587,7 +9599,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 84]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        84
+      ]
     ],
     "translation": "Введённый вами текущий пароль неверен."
   },
@@ -5595,7 +9610,12 @@
     "message": "The main difference between Kan and Trello is that Kan is open source, allowing anyone to view, modify, and contribute to our code. Our cloud offering also offers no restrictions on features for individual use, whereas Trello locks basic features such as the number of boards you can create behind a paywall.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 33]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        33
+      ]
+    ],
     "translation": "Главное отличие Kan от Trello в том, что Kan — это open source, и любой может просматривать, изменять и вносить вклад в наш код. В нашем облачном сервисе также нет ограничений по функциям для индивидуального использования, в то время как Trello блокирует базовые возможности, такие как количество досок, за платным доступом."
   },
   "6tDFBe": {
@@ -5603,8 +9623,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 35],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 58]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        35
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        58
+      ]
     ],
     "translation": "Права участника были обновлены."
   },
@@ -5612,37 +9638,64 @@
     "message": "The member's role has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 59]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        59
+      ]
+    ],
     "translation": "Роль участника была обновлена."
   },
   "gUX7b+": {
     "message": "The open source <0/> alternative to Trello",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/home/index.tsx",
+        65
+      ]
+    ],
     "translation": "Open source <0/> альтернатива Trello"
   },
   "0xD8Of": {
     "message": "The page you're looking for doesn't exist or has been moved.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/404.tsx", 29]],
+    "origin": [
+      [
+        "src/pages/404.tsx",
+        29
+      ]
+    ],
     "translation": "Страница, которую вы ищете, не существует или была перемещена."
   },
   "fQCrjt": {
     "message": "The visibility of your board has been set to {0}.",
     "placeholders": {
-      "0": ["isPublic ? \"public\" : \"private\""]
+      "0": [
+        "isPublic ? \"public\" : \"private\""
+      ]
     },
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 50]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        50
+      ]
+    ],
     "translation": "Видимость вашей доски установлена на {0}."
   },
   "FEr96N": {
     "message": "Theme",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/UserMenu.tsx", 131]],
+    "origin": [
+      [
+        "src/components/UserMenu.tsx",
+        131
+      ]
+    ],
     "translation": "Тема"
   },
   "Yf9FAx": {
@@ -5650,7 +9703,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 50]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        50
+      ]
     ],
     "translation": "Они не смогут получить доступ к этому рабочему пространству."
   },
@@ -5659,11 +9715,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/DeleteLabelConfirmation.tsx", 44],
-      ["src/views/board/components/DeleteBoardConfirmation.tsx", 39],
-      ["src/views/card/components/DeleteCardConfirmation.tsx", 78],
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 59],
-      ["src/views/card/components/DeleteCommentConfirmation.tsx", 69]
+      [
+        "src/components/DeleteLabelConfirmation.tsx",
+        44
+      ],
+      [
+        "src/views/board/components/DeleteBoardConfirmation.tsx",
+        39
+      ],
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        78
+      ],
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        59
+      ],
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        69
+      ]
     ],
     "translation": "Это действие нельзя отменить."
   },
@@ -5671,28 +9742,48 @@
     "message": "This API key will only be shown once. Please save it in a secure location.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewApiKeyModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewApiKeyModal.tsx",
+        129
+      ]
+    ],
     "translation": "Этот API-ключ будет показан только один раз. Пожалуйста, сохраните его в надёжном месте."
   },
   "l4asa1": {
     "message": "This board is private or does not exist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 184]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        191
+      ]
+    ],
     "translation": "Эта доска приватная или не существует"
   },
   "wY+6Ye": {
     "message": "This board URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 136]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        136
+      ]
+    ],
     "translation": "Этот URL доски уже занят"
   },
   "mTwGOf": {
     "message": "This invitation link is invalid or has expired.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 108]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        108
+      ]
+    ],
     "translation": "Эта ссылка-приглашение недействительна или истекла."
   },
   "vlxQFL": {
@@ -5700,7 +9791,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 81]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        81
+      ]
     ],
     "translation": "Права этого участника были сброшены до значений по умолчанию для его роли."
   },
@@ -5708,14 +9802,24 @@
     "message": "This URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 74]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        74
+      ]
+    ],
     "translation": "Этот URL уже занят"
   },
   "gKmoow": {
     "message": "This URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 76]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        76
+      ]
+    ],
     "translation": "Этот URL зарезервирован"
   },
   "OAYToL": {
@@ -5735,7 +9839,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Это приведёт к безвозвратному удалению всех данных, связанных с этим рабочим пространством."
   },
@@ -5744,7 +9851,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 60]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        60
+      ]
     ],
     "translation": "Это приведёт к безвозвратному удалению всех данных, связанных с вашим аккаунтом."
   },
@@ -5752,14 +9862,24 @@
     "message": "This workspace URL has already been taken",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 189]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        189
+      ]
+    ],
     "translation": "Этот URL рабочего пространства уже занят"
   },
   "bJtM0P": {
     "message": "This workspace URL is reserved",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 191]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        191
+      ]
+    ],
     "translation": "Этот URL рабочей области зарезервирован"
   },
   "kp6L3T": {
@@ -5767,22 +9887,35 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 125]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        125
+      ]
     ],
     "translation": "Это имя пользователя рабочей области уже занято"
   },
   "pEb95p": {
-    "translation": "ID задачи скопирован в буфер обмена",
     "message": "Ticket ID copied to clipboard",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 66]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        66
+      ]
+    ],
+    "translation": "ID задачи скопирован в буфер обмена"
   },
   "MHrjPM": {
     "message": "Title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 127]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        127
+      ]
+    ],
     "translation": "Заголовок"
   },
   "wK4OTM": {
@@ -5790,7 +9923,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 180]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        180
+      ]
     ],
     "translation": "Название (необязательно)"
   },
@@ -5799,8 +9935,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 17],
-      ["src/views/boards/components/TemplateBoards.tsx", 23]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        17
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        23
+      ]
     ],
     "translation": "К выполнению"
   },
@@ -5808,21 +9950,36 @@
     "message": "Toggle menu",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Header.tsx", 114]],
+    "origin": [
+      [
+        "src/views/home/components/Header.tsx",
+        114
+      ]
+    ],
     "translation": "Переключить меню"
   },
   "L5WQLg": {
     "message": "Token is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        19
+      ]
+    ],
     "translation": "Требуется токен"
   },
   "eEQyz+": {
     "message": "Track all card changes with detailed activity history.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        111
+      ]
+    ],
     "translation": "Отслеживайте все изменения карточек с подробной историей активности."
   },
   "dtbpdR": {
@@ -5830,8 +9987,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 218],
-      ["src/views/settings/IntegrationsSettings.tsx", 142]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        218
+      ],
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        142
+      ]
     ],
     "translation": "Trello"
   },
@@ -5839,74 +10002,155 @@
     "message": "Trello disconnected",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 79]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        79
+      ]
+    ],
     "translation": "Trello отключён"
   },
   "kxEs5t": {
     "message": "Trello imports",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 95]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        95
+      ]
+    ],
     "translation": "Импорт из Trello"
   },
   "HO+uOC": {
     "message": "Triaging",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 57]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        57
+      ]
+    ],
     "translation": "Сортировка"
   },
   "o+JCfN": {
     "message": "Trusted by fast-moving teams<0/>around the world",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Logos.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Logos.tsx",
+        67
+      ]
+    ],
     "translation": "Нам доверяют быстроразвивающиеся команды<0/>по всему миру"
+  },
+  "+zy2Nq": {
+    "translation": "",
+    "message": "Type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        125
+      ]
+    ]
+  },
+  "WtTYSX": {
+    "translation": "",
+    "message": "Types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/board/components/Filters.tsx",
+        184
+      ]
+    ]
   },
   "bZSICm": {
     "message": "Unable to add checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistItemForm.tsx", 89]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistItemForm.tsx",
+        89
+      ]
+    ],
     "translation": "Не удалось добавить элемент контрольного списка"
   },
   "T7DJ2k": {
     "message": "Unable to add comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewCommentForm.tsx", 36]],
+    "origin": [
+      [
+        "src/views/card/components/NewCommentForm.tsx",
+        36
+      ]
+    ],
     "translation": "Не удалось добавить комментарий"
   },
   "2Q871c": {
     "message": "Unable to add label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/card/index.tsx",
+        258
+      ]
+    ],
     "translation": "Не удалось добавить метку"
   },
   "LeM5RY": {
     "message": "Unable to clear overrides",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 39]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        39
+      ]
+    ],
     "translation": "Не удалось сбросить переопределения"
   },
   "5MPY04": {
-    "translation": "Не удалось скопировать ID",
     "message": "Unable to copy ID",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Dropdown.tsx", 71]]
+    "origin": [
+      [
+        "src/views/card/components/Dropdown.tsx",
+        71
+      ]
+    ],
+    "translation": "Не удалось скопировать ID"
   },
   "W1ewR0": {
     "message": "Unable to copy link",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 313],
-      ["src/views/card/components/Dropdown.tsx", 52],
-      ["src/views/public/board/CardModal.tsx", 43],
-      ["src/views/public/board/index.tsx", 84]
+      [
+        "src/views/board/index.tsx",
+        319
+      ],
+      [
+        "src/views/card/components/Dropdown.tsx",
+        52
+      ],
+      [
+        "src/views/public/board/CardModal.tsx",
+        44
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        91
+      ]
     ],
     "translation": "Не удалось скопировать ссылку"
   },
@@ -5914,21 +10158,36 @@
     "message": "Unable to create card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewCardForm.tsx", 190]],
+    "origin": [
+      [
+        "src/views/board/components/NewCardForm.tsx",
+        206
+      ]
+    ],
     "translation": "Не удалось создать карточку"
   },
   "mHhffx": {
     "message": "Unable to create checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/NewChecklistForm.tsx", 70]],
+    "origin": [
+      [
+        "src/views/card/components/NewChecklistForm.tsx",
+        70
+      ]
+    ],
     "translation": "Не удалось создать контрольный список"
   },
   "TztLaN": {
     "message": "Unable to create list",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/NewListForm.tsx", 78]],
+    "origin": [
+      [
+        "src/views/board/components/NewListForm.tsx",
+        78
+      ]
+    ],
     "translation": "Не удалось создать список"
   },
   "YcyP2z": {
@@ -5936,8 +10195,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/NewTemplateForm.tsx", 60],
-      ["src/views/board/components/NewTemplateForm.tsx", 76]
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        60
+      ],
+      [
+        "src/views/board/components/NewTemplateForm.tsx",
+        76
+      ]
     ],
     "translation": "Не удалось создать шаблон"
   },
@@ -5945,7 +10210,12 @@
     "message": "Unable to create webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 118]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        118
+      ]
+    ],
     "translation": "Не удалось создать вебхук"
   },
   "MxQXhL": {
@@ -5953,8 +10223,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 108],
-      ["src/views/onboarding/workspace-details/index.tsx", 101]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        108
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        101
+      ]
     ],
     "translation": "Не удалось создать рабочую область"
   },
@@ -5962,14 +10238,24 @@
     "message": "Unable to delete attachment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentThumbnails.tsx", 73]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentThumbnails.tsx",
+        73
+      ]
+    ],
     "translation": "Не удалось удалить вложение"
   },
   "Z6r9z1": {
     "message": "Unable to delete card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCardConfirmation.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCardConfirmation.tsx",
+        51
+      ]
+    ],
     "translation": "Не удалось удалить карточку"
   },
   "DahTzR": {
@@ -5977,7 +10263,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/card/components/DeleteChecklistConfirmation.tsx", 37]
+      [
+        "src/views/card/components/DeleteChecklistConfirmation.tsx",
+        37
+      ]
     ],
     "translation": "Не удалось удалить контрольный список"
   },
@@ -5985,14 +10274,24 @@
     "message": "Unable to delete checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 94]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        94
+      ]
+    ],
     "translation": "Не удалось удалить элемент контрольного списка"
   },
   "2QGEbi": {
     "message": "Unable to delete comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DeleteCommentConfirmation.tsx", 45]],
+    "origin": [
+      [
+        "src/views/card/components/DeleteCommentConfirmation.tsx",
+        45
+      ]
+    ],
     "translation": "Не удалось удалить комментарий"
   },
   "23nvb2": {
@@ -6000,7 +10299,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 36]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        36
+      ]
     ],
     "translation": "Не удалось удалить вебхук"
   },
@@ -6009,7 +10311,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/CardContextDuplicateModal.tsx", 75]
+      [
+        "src/views/board/components/CardContextDuplicateModal.tsx",
+        75
+      ]
     ],
     "translation": "Невозможно дублировать карточку"
   },
@@ -6017,7 +10322,12 @@
     "message": "Unable to move card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/CardContextMoveListModal.tsx", 41]],
+    "origin": [
+      [
+        "src/views/board/components/CardContextMoveListModal.tsx",
+        41
+      ]
+    ],
     "translation": "Невозможно переместить карточку"
   },
   "8yFGGF": {
@@ -6025,7 +10335,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/DeleteMemberConfirmation.tsx", 27]
+      [
+        "src/views/members/components/DeleteMemberConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Не удалось удалить участника"
   },
@@ -6033,7 +10346,12 @@
     "message": "Unable to reorder checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Checklists.tsx", 80]],
+    "origin": [
+      [
+        "src/views/card/components/Checklists.tsx",
+        80
+      ]
+    ],
     "translation": "Не удалось изменить порядок элемента контрольного списка"
   },
   "vfRdCZ": {
@@ -6041,7 +10359,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 92]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        92
+      ]
     ],
     "translation": "Не удалось сбросить разрешения"
   },
@@ -6049,14 +10370,24 @@
     "message": "Unable to send feedback",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/FeedbackModal.tsx", 40]],
+    "origin": [
+      [
+        "src/components/FeedbackModal.tsx",
+        40
+      ]
+    ],
     "translation": "Не удалось отправить отзыв"
   },
   "Q60WUZ": {
     "message": "Unable to start checkout",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 150]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        150
+      ]
+    ],
     "translation": "Не удалось начать оформление заказа"
   },
   "KNK33q": {
@@ -6064,8 +10395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 163],
-      ["src/views/settings/components/WebhookList.tsx", 185]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        163
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        185
+      ]
     ],
     "translation": "Не удалось протестировать вебхук"
   },
@@ -6073,21 +10410,36 @@
     "message": "Unable to update board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 67]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        67
+      ]
+    ],
     "translation": "Не удалось обновить доску"
   },
   "XpcjLO": {
     "message": "Unable to update board URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/UpdateBoardSlugForm.tsx", 72]],
+    "origin": [
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        72
+      ]
+    ],
     "translation": "Не удалось обновить URL доски"
   },
   "Wy6pcF": {
     "message": "Unable to update board visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 56]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        56
+      ]
+    ],
     "translation": "Не удалось обновить видимость доски"
   },
   "o9WLwO": {
@@ -6095,8 +10447,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 273],
-      ["src/views/card/index.tsx", 231]
+      [
+        "src/views/board/index.tsx",
+        279
+      ],
+      [
+        "src/views/card/index.tsx",
+        245
+      ]
     ],
     "translation": "Не удалось обновить карточку"
   },
@@ -6104,35 +10462,60 @@
     "message": "Unable to update checklist",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistNameInput.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistNameInput.tsx",
+        46
+      ]
+    ],
     "translation": "Не удалось обновить контрольный список"
   },
   "WQPDcG": {
     "message": "Unable to update checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ChecklistItemRow.tsx", 66]],
+    "origin": [
+      [
+        "src/views/card/components/ChecklistItemRow.tsx",
+        66
+      ]
+    ],
     "translation": "Не удалось обновить элемент контрольного списка"
   },
   "fYVH36": {
     "message": "Unable to update comment",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/Comment.tsx", 92]],
+    "origin": [
+      [
+        "src/views/card/components/Comment.tsx",
+        92
+      ]
+    ],
     "translation": "Не удалось обновить комментарий"
   },
   "C56tim": {
     "message": "Unable to update due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/DueDateSelector.tsx", 63]],
+    "origin": [
+      [
+        "src/views/card/components/DueDateSelector.tsx",
+        63
+      ]
+    ],
     "translation": "Не удалось обновить дату выполнения"
   },
   "delOXn": {
     "message": "Unable to update labels",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/LabelSelector.tsx", 74]],
+    "origin": [
+      [
+        "src/views/card/components/LabelSelector.tsx",
+        74
+      ]
+    ],
     "translation": "Не удалось обновить метки"
   },
   "I0gAKM": {
@@ -6140,8 +10523,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/index.tsx", 217],
-      ["src/views/card/components/ListSelector.tsx", 54]
+      [
+        "src/views/board/index.tsx",
+        223
+      ],
+      [
+        "src/views/card/components/ListSelector.tsx",
+        54
+      ]
     ],
     "translation": "Не удалось обновить список"
   },
@@ -6149,7 +10538,12 @@
     "message": "Unable to update members",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/MemberSelector.tsx", 81]],
+    "origin": [
+      [
+        "src/views/card/components/MemberSelector.tsx",
+        81
+      ]
+    ],
     "translation": "Не удалось обновить участников"
   },
   "GYv20o": {
@@ -6157,8 +10551,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 41],
-      ["src/views/members/components/EditMemberPermissionsModal.tsx", 64]
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        41
+      ],
+      [
+        "src/views/members/components/EditMemberPermissionsModal.tsx",
+        64
+      ]
     ],
     "translation": "Не удалось обновить разрешения"
   },
@@ -6166,51 +10566,100 @@
     "message": "Unable to update role",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 65]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        65
+      ]
+    ],
     "translation": "Не удалось обновить роль"
+  },
+  "HX2b+Q": {
+    "translation": "",
+    "message": "Unable to update type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/components/CardTypeSelector.tsx",
+        60
+      ]
+    ]
   },
   "V1o9Jo": {
     "message": "Unable to update webhook",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 137]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        137
+      ]
+    ],
     "translation": "Не удалось обновить вебхук"
   },
   "It4/FS": {
     "message": "Unarchive board",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/BoardDropdown.tsx", 114]],
+    "origin": [
+      [
+        "src/views/board/components/BoardDropdown.tsx",
+        114
+      ]
+    ],
     "translation": "Восстановить доску из архива"
   },
   "E8zYtd": {
     "message": "unassigned <0>{0}</0> from the card",
     "placeholders": {
-      "0": ["truncate(displayName)"]
+      "0": [
+        "truncate(displayName)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 183]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        197
+      ]
+    ],
     "translation": "<0>{0}</0> был(а) удалён(а) из карточки"
   },
   "hAMddS": {
     "message": "unassigned themselves from the card",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 180]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        194
+      ]
+    ],
     "translation": "Пользователь удалил себя из карточки"
   },
   "9Xigls": {
     "message": "Under Review",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 35]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        35
+      ]
+    ],
     "translation": "На рассмотрении"
   },
   "M9p3Vw": {
     "message": "Unlimited activity log",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 41]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        41
+      ]
+    ],
     "translation": "Неограниченный журнал активности"
   },
   "1wCGT0": {
@@ -6218,12 +10667,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 74],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 75],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 76],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 77],
-      ["src/views/pricing/components/Pricing.tsx", 37],
-      ["src/views/pricing/components/PricingTiers.tsx", 36]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        74
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        75
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        76
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        77
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        37
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        36
+      ]
     ],
     "translation": "Неограниченное количество досок"
   },
@@ -6231,7 +10698,12 @@
     "message": "Unlimited boards, unlimited lists, unlimited cards. No credit card required.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Cta.tsx", 57]],
+    "origin": [
+      [
+        "src/views/home/components/Cta.tsx",
+        57
+      ]
+    ],
     "translation": "Неограниченное количество досок, списков и карточек. Кредитная карта не требуется."
   },
   "Zz1qkk": {
@@ -6239,8 +10711,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 39],
-      ["src/views/pricing/components/PricingTiers.tsx", 37]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        39
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        37
+      ]
     ],
     "translation": "Неограниченное количество карточек"
   },
@@ -6248,7 +10726,12 @@
     "message": "Unlimited comments",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 40]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        40
+      ]
+    ],
     "translation": "Неограниченное количество комментариев"
   },
   "86FLn5": {
@@ -6256,10 +10739,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 91],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 92],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 93],
-      ["src/views/pricing/components/PricingTiers.tsx", 59]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        91
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        92
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        93
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        59
+      ]
     ],
     "translation": "Неограниченное количество загрузок файлов"
   },
@@ -6267,7 +10762,12 @@
     "message": "Unlimited lists",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 38]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        38
+      ]
+    ],
     "translation": "Неограниченное количество списков"
   },
   "mx8+1u": {
@@ -6275,10 +10775,22 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 84],
-      ["src/views/pricing/components/FeatureComparisonTable.tsx", 85],
-      ["src/views/pricing/components/PricingTiers.tsx", 80],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 68]
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        84
+      ],
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        85
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        68
+      ]
     ],
     "translation": "Неограниченное количество участников"
   },
@@ -6286,14 +10798,24 @@
     "message": "Unlimited members and a custom workspace username for teams ready to scale.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 94]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        94
+      ]
+    ],
     "translation": "Неограниченное количество участников и персональное имя рабочего пространства для команд, готовых к масштабированию."
   },
   "Ws+3X+": {
     "message": "Unlimited seats and advanced features for growing teams.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/PricingTiers.tsx", 75]],
+    "origin": [
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        75
+      ]
+    ],
     "translation": "Неограниченное количество мест и расширенные функции для развивающихся команд."
   },
   "SMaFdc": {
@@ -6301,8 +10823,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/pages/unsubscribe/index.tsx", 68],
-      ["src/pages/unsubscribe/index.tsx", 93]
+      [
+        "src/pages/unsubscribe/index.tsx",
+        68
+      ],
+      [
+        "src/pages/unsubscribe/index.tsx",
+        93
+      ]
     ],
     "translation": "Отписаться"
   },
@@ -6311,11 +10839,26 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/UpdateBoardSlugForm.tsx", 175],
-      ["src/views/settings/components/UpdateDisplayNameForm.tsx", 80],
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 94],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 89],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 157]
+      [
+        "src/views/board/components/UpdateBoardSlugForm.tsx",
+        175
+      ],
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        80
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        94
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        89
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        157
+      ]
     ],
     "translation": "Обновить"
   },
@@ -6323,54 +10866,107 @@
     "message": "Update label",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/LabelForm.tsx", 236]],
+    "origin": [
+      [
+        "src/components/LabelForm.tsx",
+        236
+      ]
+    ],
     "translation": "Обновить метку"
   },
   "L5ZPjz": {
     "message": "updated a checklist item",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 136]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        141
+      ]
+    ],
     "translation": "обновил(а) элемент контрольного списка"
   },
   "tGwwnq": {
     "message": "updated the description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 126]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        130
+      ]
+    ],
     "translation": "обновил(а) описание"
   },
   "RfgJqw": {
     "message": "updated the due date",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 143]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        148
+      ]
+    ],
     "translation": "обновил(а) срок выполнения"
   },
   "V3MPSQ": {
     "message": "updated the title",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 125]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        129
+      ]
+    ],
     "translation": "обновил(а) заголовок"
   },
   "zERArS": {
     "message": "updated the title to <0>{0}</0>",
     "placeholders": {
-      "0": ["truncate(toTitle)"]
+      "0": [
+        "truncate(toTitle)"
+      ]
     },
     "comments": [],
-    "origin": [["src/views/card/components/ActivityList.tsx", 152]],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        157
+      ]
+    ],
     "translation": "обновил(а) заголовок на <0>{0}</0>"
+  },
+  "RYmu2a": {
+    "translation": "",
+    "message": "updated the type",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/views/card/components/ActivityList.tsx",
+        131
+      ]
+    ]
   },
   "IelE1h": {
     "message": "Upgrade to Pro",
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SideNavigation.tsx", 240],
-      ["src/views/settings/components/UpgradeToProConfirmation.tsx", 55],
-      ["src/views/settings/WorkspaceSettings.tsx", 118]
+      [
+        "src/components/SideNavigation.tsx",
+        240
+      ],
+      [
+        "src/views/settings/components/UpgradeToProConfirmation.tsx",
+        55
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        118
+      ]
     ],
     "translation": "Перейти на Pro"
   },
@@ -6378,14 +10974,24 @@
     "message": "Upgrade to Pro ($29/month)",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 244]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        244
+      ]
+    ],
     "translation": "Перейти на Pro (29 $/месяц)"
   },
   "b3Thhd": {
     "message": "Upload failed",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 51]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        51
+      ]
+    ],
     "translation": "Ошибка загрузки"
   },
   "BBUDfW": {
@@ -6393,8 +10999,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/boards/components/TemplateBoards.tsx", 50],
-      ["src/views/boards/components/TemplateBoards.tsx", 67]
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ],
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        67
+      ]
     ],
     "translation": "Срочно"
   },
@@ -6403,8 +11015,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 239],
-      ["src/views/settings/components/WebhookList.tsx", 220]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        239
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        220
+      ]
     ],
     "translation": "URL"
   },
@@ -6413,8 +11031,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 31],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 38]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        31
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        38
+      ]
     ],
     "translation": "URL может содержать только буквы, цифры и дефисы"
   },
@@ -6422,7 +11046,12 @@
     "message": "URL cannot exceed 2048 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        25
+      ]
+    ],
     "translation": "URL не может превышать 2048 символов"
   },
   "i5rE2/": {
@@ -6430,8 +11059,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 29],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 36]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        29
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        36
+      ]
     ],
     "translation": "URL не может превышать 64 символа"
   },
@@ -6440,8 +11075,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 27],
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 34]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        27
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        34
+      ]
     ],
     "translation": "URL должен содержать не менее 3 символов"
   },
@@ -6449,119 +11090,204 @@
     "message": "Use template",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/NewBoardForm.tsx", 154]],
+    "origin": [
+      [
+        "src/views/boards/components/NewBoardForm.tsx",
+        154
+      ]
+    ],
     "translation": "Использовать шаблон"
   },
   "n6EWYz": {
     "message": "Used to sign webhook payloads for verification. Leave blank to keep existing secret.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 265]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        265
+      ]
+    ],
     "translation": "Используется для подписи данных вебхука для проверки. Оставьте пустым, чтобы сохранить существующий секретный ключ."
   },
   "7PzzBU": {
     "message": "User",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/index.tsx", 322]],
+    "origin": [
+      [
+        "src/views/members/index.tsx",
+        322
+      ]
+    ],
     "translation": "Пользователь"
   },
   "tYN21H": {
     "message": "User is already a member of this workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 98]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        98
+      ]
+    ],
     "translation": "Пользователь уже является участником этого рабочего пространства"
   },
   "vSJd18": {
     "message": "Video",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 50]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        50
+      ]
+    ],
     "translation": "Видео"
   },
   "FmfJjN": {
     "message": "View and manage your API keys.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/ApiSettings.tsx", 25]],
+    "origin": [
+      [
+        "src/views/settings/ApiSettings.tsx",
+        25
+      ]
+    ],
     "translation": "Просматривайте и управляйте своими API-ключами."
   },
   "t2nDzl": {
     "message": "View and manage your billing and subscription.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/BillingSettings.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/BillingSettings.tsx",
+        42
+      ]
+    ],
     "translation": "Просматривайте и управляйте своими платежами и подпиской."
   },
   "aiHZVP": {
     "message": "View docs",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/Pricing.tsx", 67]],
+    "origin": [
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        67
+      ]
+    ],
     "translation": "Посмотреть документацию"
   },
   "F8DaWi": {
     "message": "View only",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 153]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        160
+      ]
+    ],
     "translation": "Только просмотр"
   },
   "fSf2ee": {
     "message": "View our roadmap.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 154]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        154
+      ]
+    ],
     "translation": "Посмотреть наш роадмап"
   },
   "U5dMR6": {
     "message": "View workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/public/board/index.tsx", 187]],
+    "origin": [
+      [
+        "src/views/public/board/index.tsx",
+        194
+      ]
+    ],
     "translation": "Просмотреть рабочее пространство"
   },
   "2q/Q7x": {
     "message": "Visibility",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/board/components/VisibilityButton.tsx", 103]],
+    "origin": [
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        103
+      ]
+    ],
     "translation": "Видимость"
   },
   "BJbLe4": {
     "message": "We are using the <0>AGPL-3.0 license</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 94]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        94
+      ]
+    ],
     "translation": "Мы используем <0>лицензию AGPL-3.0</0>."
   },
   "+EkBs0": {
     "message": "We couldn't update your preferences. Please try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 63]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        63
+      ]
+    ],
     "translation": "Не удалось обновить ваши настройки. Пожалуйста, попробуйте ещё раз."
   },
   "9y1RcT": {
     "message": "We're just getting started. ",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Features.tsx", 152]],
+    "origin": [
+      [
+        "src/views/home/components/Features.tsx",
+        152
+      ]
+    ],
     "translation": "Мы только начинаем."
   },
   "an6ayw": {
     "message": "Webhook created",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 110]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        110
+      ]
+    ],
     "translation": "Вебхук создан"
   },
   "GdWB+V": {
     "message": "Webhook created successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 111]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        111
+      ]
+    ],
     "translation": "Вебхук успешно создан"
   },
   "LnaC5y": {
@@ -6569,7 +11295,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Вебхук удалён"
   },
@@ -6578,7 +11307,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWebhookConfirmation.tsx", 29]
+      [
+        "src/views/settings/components/DeleteWebhookConfirmation.tsx",
+        29
+      ]
     ],
     "translation": "Вебхук успешно удалён"
   },
@@ -6586,14 +11318,24 @@
     "message": "Webhook name cannot exceed 255 characters",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 20]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        20
+      ]
+    ],
     "translation": "Название вебхука не может превышать 255 символов"
   },
   "U2+rn0": {
     "message": "Webhook name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 19]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        19
+      ]
+    ],
     "translation": "Название вебхука обязательно"
   },
   "8iP9oQ": {
@@ -6601,8 +11343,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/NewWebhookModal.tsx", 155],
-      ["src/views/settings/components/WebhookList.tsx", 178]
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        155
+      ],
+      [
+        "src/views/settings/components/WebhookList.tsx",
+        178
+      ]
     ],
     "translation": "Не удалось выполнить тест вебхука"
   },
@@ -6610,21 +11358,36 @@
     "message": "Webhook updated",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 129]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        129
+      ]
+    ],
     "translation": "Вебхук обновлён"
   },
   "3d54Wj": {
     "message": "Webhook updated successfully",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 130]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        130
+      ]
+    ],
     "translation": "Вебхук успешно обновлён"
   },
   "Hf1cEZ": {
     "message": "Webhook URL is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/NewWebhookModal.tsx", 23]],
+    "origin": [
+      [
+        "src/views/settings/components/NewWebhookModal.tsx",
+        23
+      ]
+    ],
     "translation": "URL вебхука обязателен"
   },
   "v1kQyJ": {
@@ -6632,8 +11395,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 71],
-      ["src/views/settings/WebhookSettings.tsx", 28]
+      [
+        "src/components/SettingsLayout.tsx",
+        71
+      ],
+      [
+        "src/views/settings/WebhookSettings.tsx",
+        28
+      ]
     ],
     "translation": "Вебхуки"
   },
@@ -6641,42 +11410,72 @@
     "message": "Week start day",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        91
+      ]
+    ],
     "translation": "День начала недели"
   },
   "9eF5oV": {
     "message": "Welcome back",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/auth/login/index.tsx", 43]],
+    "origin": [
+      [
+        "src/views/auth/login/index.tsx",
+        43
+      ]
+    ],
     "translation": "С возвращением"
   },
   "xEbBrW": {
     "message": "What license are you using?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 91]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        91
+      ]
+    ],
     "translation": "Какую лицензию вы используете?"
   },
   "H5G+qG": {
     "message": "What's the difference between Kan and Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 30]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        30
+      ]
+    ],
     "translation": "В чём разница между Kan и Trello?"
   },
   "mVZH9V": {
     "message": "When Trello launched in 2011, it blew everyone away with its carefully designed simplicity, but over the years it lost its magic and grew into something closer to \"Jira Lite\". This project is our attempt to recapture the original magic of Trello's simplicity, in open source.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 25]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        25
+      ]
+    ],
     "translation": "Когда Trello появился в 2011 году, он поразил всех своей продуманной простотой, но со временем утратил свою магию и стал чем-то вроде \"Jira Lite\". Этот проект — наша попытка вернуть ту самую магию простоты Trello, но в формате open source."
   },
   "SFnH1j": {
     "message": "Why make an open source Trello?",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 22]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        22
+      ]
+    ],
     "translation": "Зачем делать open source Trello?"
   },
   "pmUArF": {
@@ -6684,12 +11483,30 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/SettingsLayout.tsx", 47],
-      ["src/views/board/index.tsx", 530],
-      ["src/views/boards/index.tsx", 48],
-      ["src/views/members/index.tsx", 258],
-      ["src/views/public/board/index.tsx", 125],
-      ["src/views/public/boards/index.tsx", 75]
+      [
+        "src/components/SettingsLayout.tsx",
+        47
+      ],
+      [
+        "src/views/board/index.tsx",
+        536
+      ],
+      [
+        "src/views/boards/index.tsx",
+        48
+      ],
+      [
+        "src/views/members/index.tsx",
+        258
+      ],
+      [
+        "src/views/public/board/index.tsx",
+        132
+      ],
+      [
+        "src/views/public/boards/index.tsx",
+        75
+      ]
     ],
     "translation": "Рабочее пространство"
   },
@@ -6697,7 +11514,12 @@
     "message": "Workspace created successfully. You can upgrade later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 147]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        147
+      ]
+    ],
     "translation": "Рабочее пространство успешно создано. Вы сможете обновить его позже в настройках.",
     "obsolete": true
   },
@@ -6706,7 +11528,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 26]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        26
+      ]
     ],
     "translation": "Рабочее пространство удалено"
   },
@@ -6715,8 +11540,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 254],
-      ["src/views/settings/WorkspaceSettings.tsx", 82]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        254
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        82
+      ]
     ],
     "translation": "Описание рабочего пространства"
   },
@@ -6725,7 +11556,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 30]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        30
+      ]
     ],
     "translation": "Описание рабочего пространства не может превышать 280 символов"
   },
@@ -6734,7 +11568,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 27]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        27
+      ]
     ],
     "translation": "Описание рабочего пространства должно содержать не менее 3 символов"
   },
@@ -6743,7 +11580,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 50]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        50
+      ]
     ],
     "translation": "Описание рабочего пространства обновлено"
   },
@@ -6752,9 +11592,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/home/components/Features.tsx", 90],
-      ["src/views/pricing/components/Pricing.tsx", 54],
-      ["src/views/pricing/components/PricingTiers.tsx", 57]
+      [
+        "src/views/home/components/Features.tsx",
+        90
+      ],
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        54
+      ],
+      [
+        "src/views/pricing/components/PricingTiers.tsx",
+        57
+      ]
     ],
     "translation": "Участники рабочего пространства"
   },
@@ -6763,9 +11612,18 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 164],
-      ["src/views/onboarding/workspace-details/index.tsx", 189],
-      ["src/views/settings/WorkspaceSettings.tsx", 63]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        164
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        189
+      ],
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        63
+      ]
     ],
     "translation": "Название рабочего пространства"
   },
@@ -6774,8 +11632,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/components/NewWorkspaceForm.tsx", 23],
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 15]
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        23
+      ],
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        15
+      ]
     ],
     "translation": "Название рабочего пространства не может превышать 64 символа"
   },
@@ -6783,7 +11647,12 @@
     "message": "Workspace name is required",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 22]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        22
+      ]
+    ],
     "translation": "Требуется указать название рабочего пространства"
   },
   "jZBHkN": {
@@ -6791,7 +11660,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 14]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        14
+      ]
     ],
     "translation": "Название рабочего пространства должно содержать не менее 3 символов"
   },
@@ -6800,7 +11672,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 45]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        45
+      ]
     ],
     "translation": "Название рабочего пространства обновлено"
   },
@@ -6808,7 +11683,12 @@
     "message": "Workspace permissions",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 53]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        53
+      ]
+    ],
     "translation": "Права доступа рабочего пространства"
   },
   "MN6YzG": {
@@ -6816,7 +11696,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 62]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        62
+      ]
     ],
     "translation": "Слаг рабочего пространства обновлён"
   },
@@ -6824,28 +11707,48 @@
     "message": "Workspace URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/WorkspaceSettings.tsx", 72]],
+    "origin": [
+      [
+        "src/views/settings/WorkspaceSettings.tsx",
+        72
+      ]
+    ],
     "translation": "URL рабочего пространства"
   },
   "DSGzV+": {
     "message": "Workspace username",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/pricing/components/FeatureComparisonTable.tsx", 97]],
+    "origin": [
+      [
+        "src/views/pricing/components/FeatureComparisonTable.tsx",
+        97
+      ]
+    ],
     "translation": "Имя пользователя рабочего пространства"
   },
   "/8pTF/": {
     "message": "workspace-url",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/NewWorkspaceForm.tsx", 178]],
+    "origin": [
+      [
+        "src/components/NewWorkspaceForm.tsx",
+        178
+      ]
+    ],
     "translation": "workspace-url"
   },
   "4kJRen": {
     "message": "Writing",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/TemplateBoards.tsx", 43]],
+    "origin": [
+      [
+        "src/views/boards/components/TemplateBoards.tsx",
+        43
+      ]
+    ],
     "translation": "Письмо"
   },
   "zkWmBh": {
@@ -6853,8 +11756,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/pricing/components/Pricing.tsx", 19],
-      ["src/views/pricing/index.tsx", 25]
+      [
+        "src/views/pricing/components/Pricing.tsx",
+        19
+      ],
+      [
+        "src/views/pricing/index.tsx",
+        25
+      ]
     ],
     "translation": "Ежегодно"
   },
@@ -6862,42 +11771,72 @@
     "message": "Yes, we offer an forever free plan for individual use. No restrictions, no paywalls, no limits.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 86]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        86
+      ]
+    ],
     "translation": "Да, мы предлагаем бессрочный бесплатный тариф для индивидуального использования. Без ограничений, без платных функций, без лимитов."
   },
   "RtlIYB": {
     "message": "You are about to change your password.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/AccountSettings.tsx", 91]],
+    "origin": [
+      [
+        "src/views/settings/AccountSettings.tsx",
+        91
+      ]
+    ],
     "translation": "Вы собираетесь изменить свой пароль."
   },
   "3WXdoZ": {
     "message": "You can always change these later in settings.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 183]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        183
+      ]
+    ],
     "translation": "Вы всегда можете изменить это позже в настройках."
   },
   "aelko+": {
     "message": "You can get a custom workspace URL, like <0>kan.bn/kan</0>, by going into your <1>workspace settings</1> and purchasing a pro workspace subscription. All subscriptions help fund the development of the project!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 67]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        67
+      ]
+    ],
     "translation": "Вы можете получить собственный URL рабочего пространства, например <0>kan.bn/kan</0>, перейдя в <1>настройки рабочего пространства</1> и оформив подписку на pro-версию. Все подписки помогают финансировать развитие проекта!"
   },
   "kSxwQL": {
     "message": "You can invite team members by clicking the \"Invite\" button in the top right corner of the <0>members page</0> and entering their email address. They will receive an email with a link to join the workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 111]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        111
+      ]
+    ],
     "translation": "Вы можете пригласить участников команды, нажав кнопку «Пригласить» в правом верхнем углу <0>страницы участников</0> и введя их адрес электронной почты. Они получат письмо со ссылкой для присоединения к рабочему пространству."
   },
   "vAj6xG": {
     "message": "You can self-host by following the instructions in our <0>repo</0>.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/home/components/Faqs.tsx", 127]],
+    "origin": [
+      [
+        "src/views/home/components/Faqs.tsx",
+        127
+      ]
+    ],
     "translation": "Вы можете развернуть сервис самостоятельно, следуя инструкциям в нашем <0>репозитории</0>."
   },
   "h2FKMV": {
@@ -6905,14 +11844,38 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/board/components/List.tsx", 117],
-      ["src/views/board/components/UpdateBoardSlugButton.tsx", 58],
-      ["src/views/board/components/VisibilityButton.tsx", 72],
-      ["src/views/board/index.tsx", 604],
-      ["src/views/board/index.tsx", 662],
-      ["src/views/boards/components/BoardsList.tsx", 71],
-      ["src/views/boards/index.tsx", 59],
-      ["src/views/boards/index.tsx", 80]
+      [
+        "src/views/board/components/List.tsx",
+        117
+      ],
+      [
+        "src/views/board/components/UpdateBoardSlugButton.tsx",
+        58
+      ],
+      [
+        "src/views/board/components/VisibilityButton.tsx",
+        72
+      ],
+      [
+        "src/views/board/index.tsx",
+        610
+      ],
+      [
+        "src/views/board/index.tsx",
+        668
+      ],
+      [
+        "src/views/boards/components/BoardsList.tsx",
+        71
+      ],
+      [
+        "src/views/boards/index.tsx",
+        59
+      ],
+      [
+        "src/views/boards/index.tsx",
+        80
+      ]
     ],
     "translation": "У вас нет прав доступа"
   },
@@ -6920,49 +11883,84 @@
     "message": "You have been logged in successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 233]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        233
+      ]
+    ],
     "translation": "Вы успешно вошли в систему."
   },
   "mchgzf": {
     "message": "You have been signed up successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/AuthForm.tsx", 216]],
+    "origin": [
+      [
+        "src/components/AuthForm.tsx",
+        216
+      ]
+    ],
     "translation": "Вы успешно зарегистрировались."
   },
   "raHesj": {
     "message": "You have been unsubscribed!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 98]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        98
+      ]
+    ],
     "translation": "Вы отписались!"
   },
   "R275Pz": {
     "message": "You have unlimited seats with your Pro Plan. There is no additional charge for new members!",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/members/components/InviteMemberForm.tsx", 326]],
+    "origin": [
+      [
+        "src/views/members/components/InviteMemberForm.tsx",
+        326
+      ]
+    ],
     "translation": "В вашем Pro-плане неограниченное количество мест. За новых участников дополнительная плата не взимается!"
   },
   "MdN5zD": {
     "message": "You need to be an admin to manage workspace permissions.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/PermissionsSettings.tsx", 86]],
+    "origin": [
+      [
+        "src/views/settings/PermissionsSettings.tsx",
+        86
+      ]
+    ],
     "translation": "Вам нужно быть администратором, чтобы управлять правами доступа рабочего пространства."
   },
   "2SePRT": {
     "message": "You've been invited to join a workspace on kan.bn.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 134]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        134
+      ]
+    ],
     "translation": "Вас пригласили присоединиться к рабочему пространству на kan.bn."
   },
   "uOqaMC": {
     "message": "You've been invited to join a workspace.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/invite/index.tsx", 135]],
+    "origin": [
+      [
+        "src/views/invite/index.tsx",
+        135
+      ]
+    ],
     "translation": "Вас пригласили присоединиться к рабочему пространству."
   },
   "GoDLB9": {
@@ -6970,7 +11968,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteAccountConfirmation.tsx", 28]
+      [
+        "src/views/settings/components/DeleteAccountConfirmation.tsx",
+        28
+      ]
     ],
     "translation": "Ваш аккаунт был удалён."
   },
@@ -6978,49 +11979,84 @@
     "message": "Your avatar",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/select-plan/index.tsx", 229]],
+    "origin": [
+      [
+        "src/views/onboarding/select-plan/index.tsx",
+        229
+      ]
+    ],
     "translation": "Ваш аватар"
   },
   "evg7+A": {
     "message": "Your boards have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 382]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        382
+      ]
+    ],
     "translation": "Ваши доски были импортированы."
   },
   "LqWW5F": {
     "message": "Your display name has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/UpdateDisplayNameForm.tsx", 42]],
+    "origin": [
+      [
+        "src/views/settings/components/UpdateDisplayNameForm.tsx",
+        42
+      ]
+    ],
     "translation": "Ваше отображаемое имя обновлено."
   },
   "tca56/": {
     "message": "Your file has been uploaded successfully.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/card/components/AttachmentUpload.tsx", 46]],
+    "origin": [
+      [
+        "src/views/card/components/AttachmentUpload.tsx",
+        46
+      ]
+    ],
     "translation": "Ваш файл был успешно загружен."
   },
   "HcT8J4": {
     "message": "Your GitHub account has been connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 100]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        100
+      ]
+    ],
     "translation": "Ваш аккаунт GitHub был подключён."
   },
   "AdxYds": {
     "message": "Your GitHub account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 123]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        123
+      ]
+    ],
     "translation": "Ваш аккаунт GitHub был отключён."
   },
   "PELbXB": {
     "message": "Your GitHub account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 220]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        220
+      ]
+    ],
     "translation": "Ваш аккаунт GitHub подключён."
   },
   "Ozt2vv": {
@@ -7028,7 +12064,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/ChangePasswordConfirmation.tsx", 70]
+      [
+        "src/views/settings/components/ChangePasswordConfirmation.tsx",
+        70
+      ]
     ],
     "translation": "Ваш пароль был изменён."
   },
@@ -7036,49 +12075,84 @@
     "message": "Your profile image has been updated.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/components/Avatar.tsx", 190]],
+    "origin": [
+      [
+        "src/views/settings/components/Avatar.tsx",
+        190
+      ]
+    ],
     "translation": "Ваше изображение профиля было обновлено."
   },
   "+jbXzb": {
     "message": "Your projects have been imported.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/boards/components/ImportBoardsForm.tsx", 230]],
+    "origin": [
+      [
+        "src/views/boards/components/ImportBoardsForm.tsx",
+        230
+      ]
+    ],
     "translation": "Ваши проекты были импортированы."
   },
   "CJWDTP": {
     "message": "Your Trello account has been disconnected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 80]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        80
+      ]
+    ],
     "translation": "Ваш аккаунт Trello был отключён."
   },
   "WRsbHO": {
     "message": "Your Trello account is connected.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/settings/IntegrationsSettings.tsx", 171]],
+    "origin": [
+      [
+        "src/views/settings/IntegrationsSettings.tsx",
+        171
+      ]
+    ],
     "translation": "Ваш аккаунт Trello подключён."
   },
   "25fAUC": {
     "message": "Your unsubscribe link is missing a token. Please open the latest email and try again.",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/pages/unsubscribe/index.tsx", 33]],
+    "origin": [
+      [
+        "src/pages/unsubscribe/index.tsx",
+        33
+      ]
+    ],
     "translation": "В вашей ссылке для отписки отсутствует токен. Пожалуйста, откройте последнее письмо и попробуйте снова."
   },
   "GRAGsB": {
     "message": "Your workspace",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 323]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        323
+      ]
+    ],
     "translation": "Ваше рабочее пространство"
   },
   "j0o6ml": {
     "message": "Your workspace description",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/views/onboarding/workspace-details/index.tsx", 326]],
+    "origin": [
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        326
+      ]
+    ],
     "translation": "Описание вашего рабочего пространства"
   },
   "GnSSGm": {
@@ -7086,7 +12160,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx", 51]
+      [
+        "src/views/settings/components/UpdateWorkspaceDescriptionForm.tsx",
+        51
+      ]
     ],
     "translation": "Описание вашего рабочего пространства было обновлено."
   },
@@ -7095,7 +12172,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/DeleteWorkspaceConfirmation.tsx", 27]
+      [
+        "src/views/settings/components/DeleteWorkspaceConfirmation.tsx",
+        27
+      ]
     ],
     "translation": "Ваше рабочее пространство было удалено."
   },
@@ -7104,7 +12184,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceNameForm.tsx", 46]
+      [
+        "src/views/settings/components/UpdateWorkspaceNameForm.tsx",
+        46
+      ]
     ],
     "translation": "Название вашего рабочего пространства было обновлено."
   },
@@ -7113,7 +12196,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/settings/components/UpdateWorkspaceUrlForm.tsx", 63]
+      [
+        "src/views/settings/components/UpdateWorkspaceUrlForm.tsx",
+        63
+      ]
     ],
     "translation": "Слаг вашего рабочего пространства был обновлён."
   },
@@ -7122,8 +12208,14 @@
     "placeholders": {},
     "comments": [],
     "origin": [
-      ["src/views/onboarding/workspace-details/index.tsx", 198],
-      ["src/views/onboarding/workspace-details/index.tsx", 199]
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        198
+      ],
+      [
+        "src/views/onboarding/workspace-details/index.tsx",
+        199
+      ]
     ],
     "translation": "your-workspace"
   },
@@ -7131,7 +12223,12 @@
     "message": "YouTube URL",
     "placeholders": {},
     "comments": [],
-    "origin": [["src/components/YouTubeEmbed/EditYouTubeModal.tsx", 147]],
+    "origin": [
+      [
+        "src/components/YouTubeEmbed/EditYouTubeModal.tsx",
+        147
+      ]
+    ],
     "translation": "YouTube URL"
   }
 }

--- a/apps/web/src/views/board/components/Card.tsx
+++ b/apps/web/src/views/board/components/Card.tsx
@@ -7,8 +7,11 @@ import {
 } from "react-icons/hi2";
 import { twMerge } from "tailwind-merge";
 
+import type { CardType } from "@kan/shared/constants";
+
 import Avatar from "~/components/Avatar";
 import Badge from "~/components/Badge";
+import CardTypeBadge from "~/components/CardTypeBadge";
 import CircularProgress from "~/components/CircularProgress";
 import LabelIcon from "~/components/LabelIcon";
 import { useLocalisation } from "~/hooks/useLocalisation";
@@ -17,6 +20,7 @@ import { getAvatarUrl } from "~/utils/helpers";
 const Card = ({
   title,
   ticketNumber,
+  type,
   labels,
   members,
   checklists,
@@ -27,6 +31,7 @@ const Card = ({
 }: {
   title: string;
   ticketNumber?: string | null;
+  type: CardType;
   labels: { name: string; colourCode: string | null }[];
   members: {
     publicId: string;
@@ -62,21 +67,27 @@ const Card = ({
   const progress =
     totalItems > 0 ? Math.round((completedItems / totalItems) * 100) : 0;
 
-  const hasDescription =
-    description && description.replace(/<[^>]*>/g, "").trim().length > 0;
-  const hasAttachments = attachments && attachments.length > 0;
+  const hasDescription = Boolean(
+    description && description.replace(/<[^>]*>/g, "").trim().length > 0,
+  );
+  const hasAttachments = Boolean(attachments?.length);
   const hasDueDate = !!dueDate;
 
   return (
     <div className="flex flex-col overflow-hidden rounded-md border border-light-200 bg-light-50 px-3 py-2 text-sm text-neutral-900 dark:border-dark-200 dark:bg-dark-200 dark:text-dark-1000 dark:hover:bg-dark-300">
-      {ticketNumber && (
-        <span className="mb-1 text-xs text-light-700 dark:text-dark-800">
-          {ticketNumber}
-        </span>
-      )}
+      <div className="mb-1 flex items-center justify-between gap-2">
+        {ticketNumber ? (
+          <span className="min-w-0 truncate text-xs text-light-700 dark:text-dark-800">
+            {ticketNumber}
+          </span>
+        ) : (
+          <span />
+        )}
+        <CardTypeBadge type={type} size="sm" />
+      </div>
       <span className="break-words">{title}</span>
-      {labels.length ||
-      members.length ||
+      {labels.length > 0 ||
+      members.length > 0 ||
       checklists.length > 0 ||
       hasDescription ||
       comments.length > 0 ||
@@ -98,7 +109,7 @@ const Card = ({
                   <HiBars3BottomLeft className="h-4 w-4" />
                 </div>
               )}
-              {hasDueDate && dueDate && (
+              {dueDate ? (
                 <div
                   className={twMerge(
                     "flex items-center gap-1",
@@ -114,7 +125,7 @@ const Card = ({
                     })}
                   </span>
                 </div>
-              )}
+              ) : null}
               {comments.length > 0 && (
                 <div className="flex items-center gap-1 text-light-700 dark:text-dark-800">
                   <HiChatBubbleLeft className="h-4 w-4" />

--- a/apps/web/src/views/board/components/Filters.tsx
+++ b/apps/web/src/views/board/components/Filters.tsx
@@ -3,14 +3,18 @@ import { t } from "@lingui/core/macro";
 import {
   HiMiniXMark,
   HiOutlineClock,
+  HiOutlineRectangleStack,
   HiOutlineSquare3Stack3D,
   HiOutlineTag,
   HiOutlineUserCircle,
 } from "react-icons/hi2";
 import { IoFilterOutline } from "react-icons/io5";
 
+import { cardTypes } from "@kan/shared/constants";
+
 import Avatar from "~/components/Avatar";
 import Button from "~/components/Button";
+import { CardTypeIcon, getCardTypeLabel } from "~/components/CardTypeBadge";
 import CheckboxDropdown from "~/components/CheckboxDropdown";
 import LabelIcon from "~/components/LabelIcon";
 import {
@@ -67,6 +71,7 @@ const Filters = ({
           labels: [],
           lists: [],
           dueDate: [],
+          types: [],
         },
       });
     } catch (error) {
@@ -104,6 +109,14 @@ const Filters = ({
     key: list.publicId,
     value: list.name,
     selected: !!router.query.lists?.includes(list.publicId),
+  }));
+
+  const selectedTypes = formatToArray(router.query.types);
+  const formattedTypes = cardTypes.map((cardType) => ({
+    key: cardType,
+    value: getCardTypeLabel(cardType),
+    selected: selectedTypes.includes(cardType),
+    leftIcon: <CardTypeIcon type={cardType} />,
   }));
 
   const dueDateItems = [
@@ -167,6 +180,12 @@ const Filters = ({
         ]
       : []),
     {
+      key: "types",
+      label: t`Types`,
+      icon: <HiOutlineRectangleStack size={16} />,
+      items: formattedTypes,
+    },
+    {
       key: "dueDate",
       label: t`Due date`,
       icon: <HiOutlineClock size={16} />,
@@ -202,6 +221,7 @@ const Filters = ({
     ...formatToArray(router.query.members),
     ...formatToArray(router.query.labels),
     ...formatToArray(router.query.lists),
+    ...formatToArray(router.query.types),
     ...formatToArray(router.query.dueDate),
   ].length;
 

--- a/apps/web/src/views/board/components/NewCardForm.tsx
+++ b/apps/web/src/views/board/components/NewCardForm.tsx
@@ -10,11 +10,14 @@ import {
 } from "react-icons/hi2";
 
 import type { NewCardInput } from "@kan/api/types";
+import type { CardType } from "@kan/shared/constants";
+import { defaultCardType } from "@kan/shared/constants";
 import { generateUID } from "@kan/shared/utils";
 
 import type { WorkspaceMember } from "~/components/Editor";
 import Avatar from "~/components/Avatar";
 import Button from "~/components/Button";
+import CardTypeSelector from "~/components/CardTypeSelector";
 import CheckboxDropdown from "~/components/CheckboxDropdown";
 import DateSelector from "~/components/DateSelector";
 import Editor from "~/components/Editor";
@@ -38,6 +41,16 @@ interface QueryParams {
   members: string[];
   labels: string[];
   lists: string[];
+  types: CardType[];
+  dueDateFilters?: (
+    | "overdue"
+    | "today"
+    | "tomorrow"
+    | "next-week"
+    | "next-month"
+    | "no-due-date"
+  )[];
+  type: "regular" | "template";
 }
 
 interface NewCardFormProps {
@@ -70,6 +83,7 @@ export function NewCardForm({
       memberPublicIds: [],
       isCreateAnotherEnabled: false,
       position: "start",
+      type: defaultCardType,
       dueDate: null,
     },
     resetOnClose: true,
@@ -86,6 +100,7 @@ export function NewCardForm({
   const position = watch("position");
   const title = watch("title");
   const description = watch("description");
+  const cardType = watch("type") ?? defaultCardType;
   const dueDate = watch("dueDate");
   const [isDateSelectorOpen, setIsDateSelectorOpen] = useState(false);
 
@@ -143,6 +158,7 @@ export function NewCardForm({
             const newCard = {
               publicId: `PLACEHOLDER_${generateUID()}`,
               title: args.title,
+              type: args.type ?? defaultCardType,
               listId: 2,
               description: "",
               dueDate: args.dueDate ?? null,
@@ -162,9 +178,6 @@ export function NewCardForm({
                     ...member,
                     deletedAt: null,
                   })) ?? [],
-              comments: [],
-              checklists: [],
-              attachments: [],
               _filteredLabels: labelPublicIds.map((id) => ({ publicId: id })),
               _filteredMembers: memberPublicIds.map((id) => ({ publicId: id })),
               index: position === "start" ? 0 : list.cards.length,
@@ -209,6 +222,7 @@ export function NewCardForm({
           memberPublicIds: [],
           isCreateAnotherEnabled,
           position,
+          type: defaultCardType,
           dueDate: null,
         };
         reset(newFormState);
@@ -267,6 +281,7 @@ export function NewCardForm({
       labelPublicIds: data.labelPublicIds,
       memberPublicIds: data.memberPublicIds,
       position: data.position,
+      type: data.type ?? defaultCardType,
       dueDate: data.dueDate ?? null,
     });
   };
@@ -363,6 +378,12 @@ export function NewCardForm({
           </div>
         </div>
         <div className="mt-2 flex space-x-1">
+          <div className="w-fit min-w-[104px]">
+            <CardTypeSelector
+              type={cardType}
+              onChange={(type) => setValue("type", type)}
+            />
+          </div>
           <div className="w-fit">
             <CheckboxDropdown
               items={formattedLists}

--- a/apps/web/src/views/board/index.tsx
+++ b/apps/web/src/views/board/index.tsx
@@ -15,6 +15,8 @@ import {
 } from "react-icons/hi2";
 
 import type { UpdateBoardInput } from "@kan/api/types";
+import type { CardType } from "@kan/shared/constants";
+import { cardTypes } from "@kan/shared/constants";
 
 import type { CardContextMenuAction } from "./components/CardContextMenu";
 import Button from "~/components/Button";
@@ -123,6 +125,9 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
     | "next-month"
     | "no-due-date"
   )[];
+  const typeFilters = formatToArray(router.query.types).filter(
+    (type): type is CardType => cardTypes.includes(type as CardType),
+  );
 
   const boardType: "regular" | "template" = isTemplate ? "template" : "regular";
 
@@ -131,6 +136,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
     members: formatToArray(router.query.members),
     labels: formatToArray(router.query.labels),
     lists: formatToArray(router.query.lists),
+    types: typeFilters,
     ...(semanticFilters.length > 0 && {
       dueDateFilters: semanticFilters,
     }),
@@ -762,6 +768,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
                                                 ? `${boardData.workspace.cardPrefix}-${card.cardNumber}`
                                                 : null
                                             }
+                                            type={card.type}
                                             labels={card.labels}
                                             members={card.members}
                                             checklists={card.checklists ?? []}

--- a/apps/web/src/views/card/components/ActivityList.tsx
+++ b/apps/web/src/views/card/components/ActivityList.tsx
@@ -11,6 +11,7 @@ import {
   HiOutlinePaperClip,
   HiOutlinePencil,
   HiOutlinePlus,
+  HiOutlineRectangleStack,
   HiOutlineTag,
   HiOutlineTrash,
   HiOutlineUserMinus,
@@ -24,6 +25,7 @@ import type {
 import { authClient } from "@kan/auth/client";
 
 import Avatar from "~/components/Avatar";
+import { getCardTypeLabel } from "~/components/CardTypeBadge";
 import { useLocalisation } from "~/hooks/useLocalisation";
 import { api } from "~/utils/api";
 import { getAvatarUrl } from "~/utils/helpers";
@@ -66,6 +68,7 @@ const getActivityText = ({
   label,
   fromTitle,
   toDueDate,
+  toCardType,
   dateLocale,
   mergedLabels,
   attachmentName,
@@ -81,6 +84,7 @@ const getActivityText = ({
   fromTitle?: string | null;
   fromDueDate?: Date | null;
   toDueDate?: Date | null;
+  toCardType?: GetCardActivitiesOutput["activities"][number]["toCardType"];
   dateLocale: DateFnsLocale;
   mergedLabels?: string[];
   attachmentName?: string | null;
@@ -124,6 +128,7 @@ const getActivityText = ({
     "card.created": t`created the card`,
     "card.updated.title": t`updated the title`,
     "card.updated.description": t`updated the description`,
+    "card.updated.type": t`updated the type`,
     "card.updated.list": t`moved the card to another list`,
     "card.updated.label.added": t`added a label to the card`,
     "card.updated.label.removed": t`removed a label from the card`,
@@ -151,6 +156,15 @@ const getActivityText = ({
     return (
       <Trans>
         updated the title to <TextHighlight>{truncate(toTitle)}</TextHighlight>
+      </Trans>
+    );
+  }
+
+  if (type === "card.updated.type" && toCardType) {
+    return (
+      <Trans>
+        changed the type to{" "}
+        <TextHighlight>{getCardTypeLabel(toCardType)}</TextHighlight>
       </Trans>
     );
   }
@@ -332,6 +346,7 @@ const ACTIVITY_ICON_MAP: Partial<Record<ActivityType, React.ReactNode | null>> =
     "card.created": <HiOutlinePlus />,
     "card.updated.title": <HiOutlinePencil />,
     "card.updated.description": <HiOutlinePencil />,
+    "card.updated.type": <HiOutlineRectangleStack />,
     "card.updated.label.added": <HiOutlineTag />,
     "card.updated.label.removed": <HiOutlineTag />,
     "card.updated.member.added": <HiOutlineUserPlus />,
@@ -371,7 +386,7 @@ const ACTIVITIES_PAGE_SIZE = 20;
 const ActivityList = ({
   cardPublicId,
   isLoading: cardIsLoading,
-  isAdmin,
+  isAdmin: _isAdmin,
   isViewOnly,
 }: {
   cardPublicId: string;
@@ -504,11 +519,12 @@ const ActivityList = ({
           fromTitle: activity.fromTitle ?? null,
           fromDueDate: activity.fromDueDate ?? null,
           toDueDate: activity.toDueDate ?? null,
+          toCardType: activity.toCardType ?? null,
           dateLocale: dateLocale,
           mergedLabels: (activity as ActivityWithMergedLabels).mergedLabels,
           attachmentName:
-            (activity as ActivityWithMergedLabels).attachment?.originalFilename ??
-            null,
+            (activity as ActivityWithMergedLabels).attachment
+              ?.originalFilename ?? null,
         });
 
         if (activity.type === "card.updated.comment.added")
@@ -541,7 +557,9 @@ const ActivityList = ({
                 size="sm"
                 name={activity.user?.name ?? ""}
                 email={activity.user?.email ?? ""}
-                imageUrl={getAvatarUrl(activity.user?.image ?? null) || undefined}
+                imageUrl={
+                  getAvatarUrl(activity.user?.image ?? null) || undefined
+                }
                 icon={getActivityIcon(
                   activity.type,
                   activity.fromList?.index,

--- a/apps/web/src/views/card/index.tsx
+++ b/apps/web/src/views/card/index.tsx
@@ -9,6 +9,7 @@ import { IoChevronForwardSharp } from "react-icons/io5";
 import { authClient } from "@kan/auth/client";
 
 import Avatar from "~/components/Avatar";
+import CardTypeSelector from "~/components/CardTypeSelector";
 import Editor from "~/components/Editor";
 import FeedbackModal from "~/components/FeedbackModal";
 import { LabelForm } from "~/components/LabelForm";
@@ -121,6 +122,15 @@ export function CardRightPanel({ isTemplate }: { isTemplate?: boolean }) {
   return (
     <div className="h-full w-[360px] border-l-[1px] border-light-300 bg-light-50 p-8 text-light-900 dark:border-dark-300 dark:bg-dark-50 dark:text-dark-900">
       <div className="mb-4 flex w-full flex-row pt-[18px]">
+        <p className="my-2 mb-2 w-[100px] text-sm font-medium">{t`Type`}</p>
+        <CardTypeSelector
+          cardPublicId={cardId ?? ""}
+          type={card?.type}
+          isLoading={!card}
+          disabled={!canEdit}
+        />
+      </div>
+      <div className="mb-4 flex w-full flex-row">
         <p className="my-2 mb-2 w-[100px] text-sm font-medium">{t`List`}</p>
         <ListSelector
           cardPublicId={cardId ?? ""}
@@ -185,7 +195,11 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
     ? router.query.cardId[0]
     : router.query.cardId;
 
-  const { data: card, isLoading, error } = api.card.byId.useQuery(
+  const {
+    data: card,
+    isLoading,
+    error,
+  } = api.card.byId.useQuery(
     { cardPublicId: cardId ?? "" },
     { enabled: !!cardId && cardId.length >= 12 },
   );
@@ -340,14 +354,15 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
                 >
                   {board?.name}
                 </Link>
-                {card.cardNumber != null && card.list.board.workspace.cardPrefix && (
-                  <>
-                    <IoChevronForwardSharp className="h-[10px] w-[10px] text-light-900 dark:text-dark-900" />
-                    <span className="whitespace-nowrap text-sm font-bold leading-[1.5rem] text-light-700 dark:text-dark-800">
-                      {card.list.board.workspace.cardPrefix}-{card.cardNumber}
-                    </span>
-                  </>
-                )}
+                {card.cardNumber != null &&
+                  card.list.board.workspace.cardPrefix && (
+                    <>
+                      <IoChevronForwardSharp className="h-[10px] w-[10px] text-light-900 dark:text-dark-900" />
+                      <span className="whitespace-nowrap text-sm font-bold leading-[1.5rem] text-light-700 dark:text-dark-800">
+                        {card.list.board.workspace.cardPrefix}-{card.cardNumber}
+                      </span>
+                    </>
+                  )}
               </div>
               <div className="flex items-center gap-2">
                 <Dropdown
@@ -356,7 +371,8 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
                   boardPublicId={boardId}
                   cardCreatedBy={card?.createdBy}
                   ticketNumber={
-                    card.cardNumber != null && card.list.board.workspace.cardPrefix
+                    card.cardNumber != null &&
+                    card.list.board.workspace.cardPrefix
                       ? `${card.list.board.workspace.cardPrefix}-${card.cardNumber}`
                       : null
                   }

--- a/apps/web/src/views/public/board/CardModal.tsx
+++ b/apps/web/src/views/public/board/CardModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { HiLink, HiXMark } from "react-icons/hi2";
 
 import Badge from "~/components/Badge";
+import CardTypeBadge from "~/components/CardTypeBadge";
 import Editor from "~/components/Editor";
 import LabelIcon from "~/components/LabelIcon";
 import { useModal } from "~/providers/modal";
@@ -140,17 +141,23 @@ export function CardModal({
                 </div>
               ) : (
                 <>
-                  {data?.cardNumber != null && data.list.board.workspace.cardPrefix && (
-                    <span className="mb-1 block text-xs font-medium text-light-700 dark:text-dark-800">
-                      {data.list.board.workspace.cardPrefix}-{data.cardNumber}
-                    </span>
-                  )}
+                  {data?.cardNumber != null &&
+                    data.list.board.workspace.cardPrefix && (
+                      <span className="mb-1 block text-xs font-medium text-light-700 dark:text-dark-800">
+                        {data.list.board.workspace.cardPrefix}-{data.cardNumber}
+                      </span>
+                    )}
                   <h1 className="pr-8 font-bold leading-[2.3rem] tracking-tight text-neutral-900 dark:text-dark-1000 sm:text-[1.2rem]">
                     {data?.title}
                   </h1>
                 </>
               )}
             </div>
+            {data?.type && (
+              <div className="mt-2">
+                <CardTypeBadge type={data.type} />
+              </div>
+            )}
             {labels.length > 0 && (
               <div className="mt-2">
                 {labels.map((label) => (

--- a/apps/web/src/views/public/board/index.tsx
+++ b/apps/web/src/views/public/board/index.tsx
@@ -6,6 +6,9 @@ import { env } from "next-runtime-env";
 import { useEffect, useState } from "react";
 import { HiLink, HiOutlineLockClosed } from "react-icons/hi2";
 
+import type { CardType } from "@kan/shared/constants";
+import { cardTypes } from "@kan/shared/constants";
+
 import Button from "~/components/Button";
 import Modal from "~/components/modal";
 import { PageHead } from "~/components/PageHead";
@@ -52,6 +55,9 @@ export default function PublicBoardView() {
     | "next-month"
     | "no-due-date"
   )[];
+  const typeFilters = formatToArray(router.query.types).filter(
+    (type): type is CardType => cardTypes.includes(type as CardType),
+  );
 
   const { data, isLoading } = api.board.bySlug.useQuery(
     {
@@ -60,6 +66,7 @@ export default function PublicBoardView() {
       members: formatToArray(router.query.members),
       labels: formatToArray(router.query.labels),
       lists: formatToArray(router.query.lists),
+      types: typeFilters,
       ...(dueDateFilters.length > 0 && {
         dueDateFilters: dueDateFilters,
       }),
@@ -220,6 +227,13 @@ export default function PublicBoardView() {
                           >
                             <Card
                               title={card.title}
+                              ticketNumber={
+                                card.cardNumber != null &&
+                                data.workspace.cardPrefix
+                                  ? `${data.workspace.cardPrefix}-${card.cardNumber}`
+                                  : null
+                              }
+                              type={card.type}
                               labels={card.labels}
                               checklists={card.checklists ?? []}
                               members={[]}

--- a/packages/api/integration-tests/card-type.integration.test.ts
+++ b/packages/api/integration-tests/card-type.integration.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import * as boardRepo from "@kan/db/repository/board.repo";
+import * as cardRepo from "@kan/db/repository/card.repo";
+import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
+import { boards, cards, lists } from "@kan/db/schema";
+import { defaultCardType } from "@kan/shared/constants";
+
+import type { TestDbClient } from "./test-db";
+import { createTestDb, seedTestData } from "./test-db";
+
+describe("card type integration tests", () => {
+  let db: TestDbClient;
+  let user: Awaited<ReturnType<typeof seedTestData>>["user"];
+  let workspace: Awaited<ReturnType<typeof seedTestData>>["workspace"];
+  let board: typeof boards.$inferSelect;
+  let list: typeof lists.$inferSelect;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    ({ user, workspace } = await seedTestData(db));
+
+    const [createdBoard] = await db
+      .insert(boards)
+      .values({
+        publicId: "bdtest123456",
+        name: "Card Type Board",
+        slug: "card-type-board",
+        workspaceId: workspace.id,
+        createdBy: user.id,
+      })
+      .returning();
+
+    const [createdList] = await db
+      .insert(lists)
+      .values({
+        publicId: "litest123456",
+        name: "To Do",
+        index: 0,
+        boardId: createdBoard!.id,
+        createdBy: user.id,
+      })
+      .returning();
+
+    board = createdBoard!;
+    list = createdList!;
+  });
+
+  it("defaults created and bulk-imported cards to Coding", async () => {
+    const createdCard = await cardRepo.create(db, {
+      title: "Default card",
+      description: "",
+      createdBy: user.id,
+      listId: list.id,
+      workspaceId: workspace.id,
+      position: "end",
+    });
+
+    expect(createdCard.type).toBe(defaultCardType);
+
+    await cardRepo.bulkCreate(db, [
+      {
+        publicId: "bulkcard0001",
+        title: "Imported default card",
+        description: "",
+        createdBy: user.id,
+        listId: list.id,
+        workspaceId: workspace.id,
+        index: 0,
+      },
+    ]);
+
+    const importedCard = await db.query.cards.findFirst({
+      columns: { type: true },
+      where: (card, { eq }) => eq(card.publicId, "bulkcard0001"),
+    });
+
+    expect(importedCard?.type).toBe(defaultCardType);
+  });
+
+  it("persists, updates, filters, and activity-logs explicit card types", async () => {
+    await cardRepo.create(db, {
+      title: "Coding card",
+      description: "",
+      type: "coding",
+      createdBy: user.id,
+      listId: list.id,
+      workspaceId: workspace.id,
+      position: "end",
+    });
+
+    const bugCard = await cardRepo.create(db, {
+      title: "Bug card",
+      description: "",
+      type: "bug",
+      createdBy: user.id,
+      listId: list.id,
+      workspaceId: workspace.id,
+      position: "end",
+    });
+
+    const bugOnlyBoard = await boardRepo.getByPublicId(
+      db,
+      board.publicId,
+      user.id,
+      {
+        members: [],
+        labels: [],
+        lists: [],
+        dueDate: [],
+        types: ["bug"],
+        type: "regular",
+      },
+    );
+
+    expect(bugOnlyBoard?.lists[0]?.cards).toHaveLength(1);
+    expect(bugOnlyBoard?.lists[0]?.cards[0]?.title).toBe("Bug card");
+    expect(bugOnlyBoard?.lists[0]?.cards[0]?.type).toBe("bug");
+
+    const updatedCard = await cardRepo.update(
+      db,
+      { type: "research" },
+      { cardPublicId: bugCard.publicId },
+    );
+
+    expect(updatedCard?.type).toBe("research");
+
+    const typeActivity = await cardActivityRepo.create(db, {
+      type: "card.updated.type",
+      cardId: bugCard.id,
+      createdBy: user.id,
+      fromCardType: "bug",
+      toCardType: "research",
+    });
+
+    expect(typeActivity?.id).toBeDefined();
+
+    const activities = await cardActivityRepo.getPaginatedActivities(
+      db,
+      bugCard.id,
+    );
+    const loggedTypeActivity = activities.activities.find(
+      (activity) => activity.type === "card.updated.type",
+    );
+
+    expect(loggedTypeActivity?.fromCardType).toBe("bug");
+    expect(loggedTypeActivity?.toCardType).toBe("research");
+
+    const researchOnlyBoard = await boardRepo.getByPublicId(
+      db,
+      board.publicId,
+      user.id,
+      {
+        members: [],
+        labels: [],
+        lists: [],
+        dueDate: [],
+        types: ["research"],
+        type: "regular",
+      },
+    );
+
+    expect(researchOnlyBoard?.lists[0]?.cards).toHaveLength(1);
+    expect(researchOnlyBoard?.lists[0]?.cards[0]?.title).toBe("Bug card");
+    expect(researchOnlyBoard?.lists[0]?.cards[0]?.type).toBe("research");
+  });
+});

--- a/packages/api/src/routers/board.ts
+++ b/packages/api/src/routers/board.ts
@@ -15,15 +15,20 @@ import {
   generateUID,
 } from "@kan/shared/utils";
 
-import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import {
-  boardListItemSchema,
-  boardDetailSchema,
   boardBySlugSchema,
   boardCreateResponseSchema,
+  boardDetailSchema,
+  boardListItemSchema,
   boardUpdateResponseSchema,
+  cardTypeSchema,
 } from "../schemas";
-import { assertCanDelete, assertCanEdit, assertPermission } from "../utils/permissions";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
+import {
+  assertCanDelete,
+  assertCanEdit,
+  assertPermission,
+} from "../utils/permissions";
 
 export const boardRouter = createTRPCRouter({
   all: protectedProcedure
@@ -74,7 +79,7 @@ export const boardRouter = createTRPCRouter({
         {
           type: input.type,
           archived: input.archived ?? false,
-        }
+        },
       );
 
       return result;
@@ -96,6 +101,7 @@ export const boardRouter = createTRPCRouter({
         members: z.array(z.string().min(12)).optional(),
         labels: z.array(z.string().min(12)).optional(),
         lists: z.array(z.string().min(12)).optional(),
+        types: z.array(cardTypeSchema).optional(),
         dueDateFilters: z
           .array(
             z.enum([
@@ -148,6 +154,7 @@ export const boardRouter = createTRPCRouter({
           labels: input.labels ?? [],
           lists: input.lists ?? [],
           dueDate: dueDateFilters,
+          types: input.types ?? [],
           type: input.type,
         },
       );
@@ -160,27 +167,25 @@ export const boardRouter = createTRPCRouter({
       }
 
       // Generate presigned URLs for workspace member avatars
-      const workspaceWithAvatarUrls = result.workspace
-        ? {
-          ...result.workspace,
-          members: await Promise.all(
-            result.workspace.members.map(async (member) => {
-              if (!member.user?.image) {
-                return member;
-              }
+      const workspaceWithAvatarUrls = {
+        ...result.workspace,
+        members: await Promise.all(
+          result.workspace.members.map(async (member) => {
+            if (!member.user?.image) {
+              return member;
+            }
 
-              const avatarUrl = await generateAvatarUrl(member.user.image);
-              return {
-                ...member,
-                user: {
-                  ...member.user,
-                  image: avatarUrl,
-                },
-              };
-            }),
-          ),
-        }
-        : result.workspace;
+            const avatarUrl = await generateAvatarUrl(member.user.image);
+            return {
+              ...member,
+              user: {
+                ...member.user,
+                image: avatarUrl,
+              },
+            };
+          }),
+        ),
+      };
 
       // Generate presigned URLs for card member avatars
       const listsWithAvatarUrls = await Promise.all(
@@ -237,6 +242,7 @@ export const boardRouter = createTRPCRouter({
         members: z.array(z.string().min(12)).optional(),
         labels: z.array(z.string().min(12)).optional(),
         lists: z.array(z.string().min(12)).optional(),
+        types: z.array(cardTypeSchema).optional(),
         dueDateFilters: z
           .array(
             z.enum([
@@ -278,6 +284,7 @@ export const boardRouter = createTRPCRouter({
           labels: input.labels ?? [],
           lists: input.lists ?? [],
           dueDate: dueDateFilters,
+          types: input.types ?? [],
         },
       );
 
@@ -351,6 +358,7 @@ export const boardRouter = createTRPCRouter({
             labels: [],
             lists: [],
             dueDate: [],
+            types: [],
             type: sourceBoardInfo.type,
           },
         );
@@ -513,7 +521,11 @@ export const boardRouter = createTRPCRouter({
       }
 
       // Handle other updates (name, slug, visibility)
-      const hasOtherUpdates = input.name || input.slug || input.visibility !== undefined || input.isArchived !== undefined;
+      const hasOtherUpdates =
+        input.name !== undefined ||
+        input.slug !== undefined ||
+        input.visibility !== undefined ||
+        input.isArchived !== undefined;
 
       if (!hasOtherUpdates) {
         // Only favorite was updated, return success

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import type { CardType } from "@kan/shared/constants";
 import * as cardRepo from "@kan/db/repository/card.repo";
 import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
 import * as cardCommentRepo from "@kan/db/repository/cardComment.repo";
@@ -8,20 +9,26 @@ import * as checklistRepo from "@kan/db/repository/checklist.repo";
 import * as labelRepo from "@kan/db/repository/label.repo";
 import * as listRepo from "@kan/db/repository/list.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
+import { defaultCardType } from "@kan/shared/constants";
+import { generateAttachmentUrl, generateAvatarUrl } from "@kan/shared/utils";
 
-import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import {
-  cardCreateResponseSchema,
-  cardUpdateResponseSchema,
-  cardDetailSchema,
-  commentResponseSchema,
-  commentDeleteResponseSchema,
   activityItemSchema,
+  cardCreateResponseSchema,
+  cardDetailSchema,
+  cardTypeSchema,
+  cardUpdateResponseSchema,
+  commentDeleteResponseSchema,
+  commentResponseSchema,
 } from "../schemas";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { mergeActivities } from "../utils/activities";
 import { sendMentionEmails } from "../utils/notifications";
-import { assertCanDelete, assertCanEdit, assertPermission } from "../utils/permissions";
-import { generateAttachmentUrl, generateAvatarUrl } from "@kan/shared/utils";
+import {
+  assertCanDelete,
+  assertCanEdit,
+  assertPermission,
+} from "../utils/permissions";
 import {
   createCardWebhookPayload,
   sendWebhooksForWorkspace,
@@ -47,6 +54,7 @@ export const cardRouter = createTRPCRouter({
         labelPublicIds: z.array(z.string().min(12)),
         memberPublicIds: z.array(z.string().min(12)),
         position: z.enum(["start", "end"]),
+        type: cardTypeSchema.optional(),
         dueDate: z.date().nullable().optional(),
       }),
     )
@@ -80,6 +88,7 @@ export const cardRouter = createTRPCRouter({
         listId: list.id,
         workspaceId: list.workspaceId,
         position: input.position,
+        type: input.type ?? defaultCardType,
         dueDate: input.dueDate ?? null,
       });
 
@@ -189,6 +198,7 @@ export const cardRouter = createTRPCRouter({
             id: String(newCard.id),
             title: input.title,
             description: input.description,
+            type: input.type ?? newCard.type,
             dueDate: input.dueDate ?? null,
             listId: list.publicId,
           },
@@ -245,7 +255,12 @@ export const cardRouter = createTRPCRouter({
           code: "NOT_FOUND",
         });
 
-      await assertPermission(ctx.db, userId, card.workspaceId, "comment:create");
+      await assertPermission(
+        ctx.db,
+        userId,
+        card.workspaceId,
+        "comment:create",
+      );
 
       const newComment = await cardCommentRepo.create(ctx.db, {
         comment: input.comment,
@@ -700,27 +715,25 @@ export const cardRouter = createTRPCRouter({
       );
 
       // Generate presigned URLs for workspace member avatars
-      const workspaceWithAvatarUrls = result.list.board.workspace
-        ? {
-            ...result.list.board.workspace,
-            members: await Promise.all(
-              result.list.board.workspace.members.map(async (member) => {
-                if (!member.user?.image) {
-                  return member;
-                }
+      const workspaceWithAvatarUrls = {
+        ...result.list.board.workspace,
+        members: await Promise.all(
+          result.list.board.workspace.members.map(async (member) => {
+            if (!member.user?.image) {
+              return member;
+            }
 
-                const avatarUrl = await generateAvatarUrl(member.user.image);
-                return {
-                  ...member,
-                  user: {
-                    ...member.user,
-                    image: avatarUrl,
-                  },
-                };
-              }),
-            ),
-          }
-        : result.list.board.workspace;
+            const avatarUrl = await generateAvatarUrl(member.user.image);
+            return {
+              ...member,
+              user: {
+                ...member.user,
+                image: avatarUrl,
+              },
+            };
+          }),
+        ),
+      };
 
       return {
         ...result,
@@ -849,6 +862,7 @@ export const cardRouter = createTRPCRouter({
         cardPublicId: z.string().min(12),
         title: z.string().min(1).max(2000).optional(),
         description: z.string().optional(),
+        type: cardTypeSchema.optional(),
         index: z.number().optional(),
         listPublicId: z.string().min(12).optional(),
         dueDate: z.date().nullable().optional(),
@@ -900,10 +914,7 @@ export const cardRouter = createTRPCRouter({
         | undefined;
 
       if (input.listPublicId) {
-        newList = await listRepo.getByPublicId(
-          ctx.db,
-          input.listPublicId,
-        );
+        newList = await listRepo.getByPublicId(ctx.db, input.listPublicId);
 
         if (!newList)
           throw new TRPCError({
@@ -926,6 +937,7 @@ export const cardRouter = createTRPCRouter({
             id: number;
             title: string;
             description: string | null;
+            type: CardType;
             publicId: string;
             dueDate: Date | null;
           }
@@ -933,12 +945,18 @@ export const cardRouter = createTRPCRouter({
 
       const previousDueDate = existingCard.dueDate;
 
-      if (input.title || input.description || input.dueDate !== undefined) {
+      if (
+        input.title ||
+        input.description ||
+        input.type !== undefined ||
+        input.dueDate !== undefined
+      ) {
         result = await cardRepo.update(
           ctx.db,
           {
             ...(input.title && { title: input.title }),
             ...(input.description && { description: input.description }),
+            ...(input.type !== undefined && { type: input.type }),
             ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
           },
           { cardPublicId: input.cardPublicId },
@@ -987,6 +1005,16 @@ export const cardRouter = createTRPCRouter({
           commenterUserId: userId,
         }).catch((error) => {
           console.error("Failed to send mention emails:", error);
+        });
+      }
+
+      if (input.type !== undefined && existingCard.type !== input.type) {
+        activities.push({
+          type: "card.updated.type" as const,
+          cardId: result.id,
+          createdBy: userId,
+          fromCardType: existingCard.type,
+          toCardType: input.type,
         });
       }
 
@@ -1047,18 +1075,24 @@ export const cardRouter = createTRPCRouter({
       ) {
         webhookChanges.dueDate = { from: previousDueDate, to: input.dueDate };
       }
-      const movedToNewList = Boolean(newListId && existingCard.listId !== newListId);
-      const currentWebhookListPublicId = movedToNewList
-        ? input.listPublicId!
-        : existingCard.list.publicId;
+      if (input.type !== undefined && existingCard.type !== input.type) {
+        webhookChanges.type = { from: existingCard.type, to: input.type };
+      }
+      const movedToNewList = Boolean(
+        newListId && existingCard.listId !== newListId,
+      );
+      const currentWebhookListPublicId =
+        movedToNewList && input.listPublicId
+          ? input.listPublicId
+          : existingCard.list.publicId;
       const currentWebhookListName = movedToNewList
-        ? newList?.name ?? card.listName
+        ? (newList?.name ?? card.listName)
         : existingCard.list.name;
 
-      if (movedToNewList) {
+      if (movedToNewList && input.listPublicId) {
         webhookChanges.listId = {
           from: existingCard.list.publicId,
-          to: input.listPublicId!,
+          to: input.listPublicId,
         };
       }
 
@@ -1072,6 +1106,7 @@ export const cardRouter = createTRPCRouter({
             id: String(result.id),
             title: result.title,
             description: result.description,
+            type: result.type,
             dueDate: result.dueDate,
             listId: currentWebhookListPublicId,
           },
@@ -1167,6 +1202,7 @@ export const cardRouter = createTRPCRouter({
               id: String(fullCard.id),
               title: fullCard.title,
               description: fullCard.description,
+              type: fullCard.type,
               dueDate: fullCard.dueDate,
               listId: fullCard.list.publicId,
             },
@@ -1275,6 +1311,7 @@ export const cardRouter = createTRPCRouter({
         listId: targetList.id,
         workspaceId: targetList.workspaceId,
         position: "end",
+        type: sourceCard.type,
         dueDate: sourceCard.dueDate ?? null,
       });
 
@@ -1286,9 +1323,12 @@ export const cardRouter = createTRPCRouter({
         });
       }
 
-      if (input.copyLabels && sourceCard.labels?.length) {
+      if (input.copyLabels && sourceCard.labels.length) {
         const labelPublicIds = sourceCard.labels.map((l) => l.publicId);
-        const labels = await labelRepo.getAllByPublicIds(ctx.db, labelPublicIds);
+        const labels = await labelRepo.getAllByPublicIds(
+          ctx.db,
+          labelPublicIds,
+        );
         if (labels.length) {
           const labelsInsert = labels.map((label) => ({
             cardId: newCard.id,
@@ -1305,7 +1345,7 @@ export const cardRouter = createTRPCRouter({
         }
       }
 
-      if (input.copyMembers && sourceCard.members?.length) {
+      if (input.copyMembers && sourceCard.members.length) {
         const memberPublicIds = sourceCard.members.map((m) => m.publicId);
         const members = await workspaceRepo.getAllMembersByPublicIds(
           ctx.db,
@@ -1330,7 +1370,7 @@ export const cardRouter = createTRPCRouter({
         }
       }
 
-      if (input.copyChecklists && sourceCard.checklists?.length) {
+      if (input.copyChecklists && sourceCard.checklists.length) {
         for (const checklist of sourceCard.checklists) {
           const newChecklist = await checklistRepo.create(ctx.db, {
             cardId: newCard.id,
@@ -1338,13 +1378,13 @@ export const cardRouter = createTRPCRouter({
             createdBy: userId,
           });
           if (!newChecklist?.id) continue;
-          if (checklist.items?.length) {
+          if (checklist.items.length) {
             for (const item of checklist.items) {
               await checklistRepo.createItem(ctx.db, {
                 checklistId: newChecklist.id,
                 title: item.title,
                 createdBy: userId,
-                completed: item.completed ?? false,
+                completed: item.completed,
               });
             }
           }

--- a/packages/api/src/routers/webhook.ts
+++ b/packages/api/src/routers/webhook.ts
@@ -8,9 +8,9 @@ import { webhookEvents } from "@kan/db/schema";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { assertPermission } from "../utils/permissions";
 import {
-  webhookUrlSchema,
-  sendWebhookToUrl,
   createCardWebhookPayload,
+  sendWebhookToUrl,
+  webhookUrlSchema,
 } from "../utils/webhook";
 
 const webhookEventSchema = z.enum(webhookEvents);
@@ -332,21 +332,26 @@ export const webhookRouter = createTRPCRouter({
           code: "NOT_FOUND",
         });
 
-      const testPayload = createCardWebhookPayload("card.created", {
-        id: "test-card-id",
-        title: "Test Card",
-        description: "This is a test webhook payload",
-        dueDate: null,
-        listId: "test-list-id",
-      }, {
-        boardId: "test-board-id",
-        boardName: "Test Board",
-        listName: "Test List",
-        user: {
-          id: userId,
-          name: ctx.user?.name ?? "Test User",
+      const testPayload = createCardWebhookPayload(
+        "card.created",
+        {
+          id: "test-card-id",
+          title: "Test Card",
+          description: "This is a test webhook payload",
+          type: "coding",
+          dueDate: null,
+          listId: "test-list-id",
         },
-      });
+        {
+          boardId: "test-board-id",
+          boardName: "Test Board",
+          listName: "Test List",
+          user: {
+            id: userId,
+            name: ctx.user?.name ?? "Test User",
+          },
+        },
+      );
 
       const result = await sendWebhookToUrl(
         webhook.url,

--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -6,15 +6,15 @@ import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import * as workspaceSlugRepo from "@kan/db/repository/workspaceSlug.repo";
 import { generateAvatarUrl, generateUID } from "@kan/shared/utils";
 
-import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import {
-  workspaceListItemSchema,
-  workspaceDetailSchema,
-  workspaceWithBoardsSchema,
   workspaceCreateResponseSchema,
-  workspaceUpdateResponseSchema,
   workspaceDeleteResponseSchema,
+  workspaceDetailSchema,
+  workspaceListItemSchema,
+  workspaceUpdateResponseSchema,
+  workspaceWithBoardsSchema,
 } from "../schemas";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { assertPermission } from "../utils/permissions";
 
 export const workspaceRouter = createTRPCRouter({
@@ -264,7 +264,13 @@ export const workspaceRouter = createTRPCRouter({
         ...(input.description && { description: input.description }),
       });
 
-      if (!result.publicId)
+      if (
+        !result.publicId ||
+        !result.name ||
+        !result.slug ||
+        !result.plan ||
+        !result.cardPrefix
+      )
         throw new TRPCError({
           message: `Unable to create workspace`,
           code: "INTERNAL_SERVER_ERROR",
@@ -272,10 +278,11 @@ export const workspaceRouter = createTRPCRouter({
 
       return {
         publicId: result.publicId,
-        name: result.name!,
-        slug: result.slug!,
+        name: result.name,
+        slug: result.slug,
         description: result.description ?? null,
-        plan: result.plan!,
+        plan: result.plan,
+        cardPrefix: result.cardPrefix,
       };
     }),
   update: protectedProcedure
@@ -411,10 +418,7 @@ export const workspaceRouter = createTRPCRouter({
         });
       await assertPermission(ctx.db, userId, workspace.id, "workspace:delete");
 
-      await workspaceRepo.hardDelete(
-        ctx.db,
-        input.workspacePublicId,
-      );
+      await workspaceRepo.hardDelete(ctx.db, input.workspacePublicId);
 
       return { success: true };
     }),

--- a/packages/api/src/schemas/board.ts
+++ b/packages/api/src/schemas/board.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 
 import {
+  cardTypeSchema,
   checklistResponseSchema,
   labelSchema,
   workspaceMemberSchema,
 } from "./common";
+
+const boardVisibilitySchema = z.enum(["private", "public"]);
 
 // ─── board.all ───────────────────────────────────────────────
 export const boardListItemSchema = z.object({
@@ -38,7 +41,9 @@ const boardDetailCardSchema = z.object({
   publicId: z.string(),
   title: z.string(),
   description: z.string().nullable(),
+  type: cardTypeSchema,
   index: z.number(),
+  cardNumber: z.number().nullable(),
   dueDate: z.date().nullable(),
   labels: z.array(labelSchema),
   members: z.array(boardCardMemberSchema),
@@ -52,11 +57,12 @@ export const boardDetailSchema = z.object({
   publicId: z.string(),
   name: z.string(),
   slug: z.string(),
-  visibility: z.string(),
+  visibility: boardVisibilitySchema,
   isArchived: z.boolean(),
   favorite: z.boolean(),
   workspace: z.object({
     publicId: z.string(),
+    cardPrefix: z.string(),
     members: z.array(workspaceMemberSchema),
   }),
   labels: z.array(labelSchema),
@@ -81,7 +87,9 @@ const boardSlugCardSchema = z.object({
   publicId: z.string(),
   title: z.string(),
   description: z.string().nullable(),
+  type: cardTypeSchema,
   index: z.number(),
+  cardNumber: z.number().nullable(),
   dueDate: z.date().nullable(),
   labels: z.array(labelSchema),
   attachments: z.array(z.object({ publicId: z.string() })),
@@ -94,11 +102,12 @@ export const boardBySlugSchema = z.object({
   publicId: z.string(),
   name: z.string(),
   slug: z.string(),
-  visibility: z.string(),
+  visibility: boardVisibilitySchema,
   workspace: z.object({
     publicId: z.string(),
     name: z.string(),
     slug: z.string(),
+    cardPrefix: z.string(),
   }),
   labels: z.array(labelSchema),
   lists: z.array(

--- a/packages/api/src/schemas/card.ts
+++ b/packages/api/src/schemas/card.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  cardTypeSchema,
   checklistResponseSchema,
   labelSchema,
   workspaceMemberSchema,
@@ -16,6 +17,7 @@ export const cardUpdateResponseSchema = z.object({
   publicId: z.string(),
   title: z.string(),
   description: z.string().nullable(),
+  type: cardTypeSchema,
   dueDate: z.date().nullable(),
 });
 
@@ -46,8 +48,10 @@ export const cardDetailSchema = z.object({
   publicId: z.string(),
   title: z.string(),
   description: z.string().nullable(),
+  type: cardTypeSchema,
   dueDate: z.date().nullable(),
   createdBy: z.string().nullable(),
+  cardNumber: z.number().nullable(),
   labels: z.array(labelSchema),
   attachments: z.array(
     z.object({
@@ -75,6 +79,7 @@ export const cardDetailSchema = z.object({
       ),
       workspace: z.object({
         publicId: z.string(),
+        cardPrefix: z.string(),
         members: z.array(workspaceMemberSchema),
       }),
     }),
@@ -91,6 +96,8 @@ export const cardDetailSchema = z.object({
       toTitle: z.string().nullable(),
       fromDescription: z.string().nullable(),
       toDescription: z.string().nullable(),
+      fromCardType: cardTypeSchema.nullable(),
+      toCardType: cardTypeSchema.nullable(),
       fromDueDate: z.date().nullable(),
       toDueDate: z.date().nullable(),
       fromList: z
@@ -154,6 +161,8 @@ export const activityItemSchema = z.object({
   toTitle: z.string().nullable(),
   fromDescription: z.string().nullable(),
   toDescription: z.string().nullable(),
+  fromCardType: cardTypeSchema.nullable(),
+  toCardType: cardTypeSchema.nullable(),
   fromDueDate: z.date().nullable(),
   toDueDate: z.date().nullable(),
   fromList: z

--- a/packages/api/src/schemas/common.ts
+++ b/packages/api/src/schemas/common.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+import { cardTypes } from "@kan/shared/constants";
+
+export const cardTypeSchema = z.enum(cardTypes);
+
 // Shared label schema used across board and card responses
 export const labelSchema = z.object({
   publicId: z.string(),

--- a/packages/api/src/schemas/index.ts
+++ b/packages/api/src/schemas/index.ts
@@ -17,6 +17,7 @@ export {
 
 export {
   labelSchema,
+  cardTypeSchema,
   checklistItemResponseSchema,
   checklistResponseSchema,
   userSchema,

--- a/packages/api/src/schemas/workspace.ts
+++ b/packages/api/src/schemas/workspace.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
-import { userSchema } from "./common";
+const workspaceRoleSchema = z.enum(["admin", "member", "guest"]);
 
 // ─── workspace.all ───────────────────────────────────────────
 export const workspaceListItemSchema = z.object({
-  role: z.string(),
+  role: workspaceRoleSchema,
   workspace: z.object({
     publicId: z.string(),
     name: z.string(),
@@ -12,6 +12,7 @@ export const workspaceListItemSchema = z.object({
     slug: z.string(),
     plan: z.enum(["free", "team", "pro", "enterprise"]),
     weekStartDay: z.number().nullable(),
+    cardPrefix: z.string(),
     deletedAt: z.date().nullable(),
   }),
 });
@@ -74,6 +75,7 @@ export const workspaceCreateResponseSchema = z.object({
   slug: z.string(),
   description: z.string().nullable(),
   plan: z.enum(["free", "team", "pro", "enterprise"]),
+  cardPrefix: z.string(),
 });
 
 // ─── workspace.update ────────────────────────────────────────

--- a/packages/api/src/utils/webhook.test.ts
+++ b/packages/api/src/utils/webhook.test.ts
@@ -1,4 +1,14 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as webhookRepo from "@kan/db/repository/webhook.repo";
+
+import type { WebhookPayload } from "./webhook";
+import {
+  createCardWebhookPayload,
+  sendWebhooksForWorkspace,
+  sendWebhookToUrl,
+  webhookUrlSchema,
+} from "./webhook";
 
 const { mockLogger } = vi.hoisted(() => ({
   mockLogger: {
@@ -15,16 +25,8 @@ vi.mock("@kan/logger", () => ({
   createLogger: vi.fn(() => mockLogger),
 }));
 
-import * as webhookRepo from "@kan/db/repository/webhook.repo";
-import {
-  sendWebhookToUrl,
-  sendWebhooksForWorkspace,
-  createCardWebhookPayload,
-  webhookUrlSchema,
-  type WebhookPayload,
-} from "./webhook";
-
-const mockGetActiveByWorkspaceId = webhookRepo.getActiveByWorkspaceId as ReturnType<typeof vi.fn>;
+const mockGetActiveByWorkspaceId =
+  webhookRepo.getActiveByWorkspaceId as ReturnType<typeof vi.fn>;
 
 describe("webhook utilities", () => {
   beforeEach(() => {
@@ -57,6 +59,7 @@ describe("webhook utilities", () => {
         id: "card-123",
         title: "Test Card",
         description: undefined,
+        type: undefined,
         dueDate: null,
         listId: "list-456",
         boardId: "board-789",
@@ -71,6 +74,7 @@ describe("webhook utilities", () => {
           id: "card-123",
           title: "Test Card",
           description: "A description",
+          type: "bug",
           dueDate,
           listId: "list-456",
         },
@@ -80,6 +84,7 @@ describe("webhook utilities", () => {
       );
 
       expect(payload.data.card.description).toBe("A description");
+      expect(payload.data.card.type).toBe("bug");
       expect(payload.data.card.dueDate).toBe("2024-02-01T10:00:00.000Z");
     });
 
@@ -221,48 +226,79 @@ describe("webhook utilities", () => {
 
     describe("SSRF protection", () => {
       it("blocks HTTP URLs", async () => {
-        const result = await sendWebhookToUrl("http://example.com/webhook", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "http://example.com/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(result.error).toContain("HTTPS");
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("blocks localhost", async () => {
-        const result = await sendWebhookToUrl("https://localhost/webhook", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "https://localhost/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(result.error).toContain("Localhost");
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("blocks 127.0.0.1", async () => {
-        const result = await sendWebhookToUrl("https://127.0.0.1/webhook", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "https://127.0.0.1/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("blocks cloud metadata endpoint", async () => {
-        const result = await sendWebhookToUrl("https://169.254.169.254/latest/meta-data/", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "https://169.254.169.254/latest/meta-data/",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(result.error).toContain("metadata");
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("blocks private 10.x.x.x IPs", async () => {
-        const result = await sendWebhookToUrl("https://10.0.0.1/webhook", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "https://10.0.0.1/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(result.error).toContain("Private");
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("blocks private 192.168.x.x IPs", async () => {
-        const result = await sendWebhookToUrl("https://192.168.1.1/webhook", undefined, mockPayload);
+        const result = await sendWebhookToUrl(
+          "https://192.168.1.1/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(false);
         expect(global.fetch).not.toHaveBeenCalled();
       });
 
       it("allows valid HTTPS URLs", async () => {
-        (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, status: 200 });
-        const result = await sendWebhookToUrl("https://example.com/webhook", undefined, mockPayload);
+        (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+        });
+        const result = await sendWebhookToUrl(
+          "https://example.com/webhook",
+          undefined,
+          mockPayload,
+        );
         expect(result.success).toBe(true);
         expect(global.fetch).toHaveBeenCalled();
       });
@@ -274,7 +310,11 @@ describe("webhook utilities", () => {
         status: 200,
       });
 
-      await sendWebhookToUrl("https://example.com/webhook", undefined, mockPayload);
+      await sendWebhookToUrl(
+        "https://example.com/webhook",
+        undefined,
+        mockPayload,
+      );
 
       expect(global.fetch).toHaveBeenCalledWith(
         "https://example.com/webhook",
@@ -296,7 +336,11 @@ describe("webhook utilities", () => {
         status: 200,
       });
 
-      await sendWebhookToUrl("https://example.com/webhook", "my-secret", mockPayload);
+      await sendWebhookToUrl(
+        "https://example.com/webhook",
+        "my-secret",
+        mockPayload,
+      );
 
       expect(global.fetch).toHaveBeenCalledWith(
         "https://example.com/webhook",
@@ -443,10 +487,7 @@ describe("webhook utilities", () => {
       await sendWebhooksForWorkspace(mockDb, 1, mockPayload);
 
       // getActiveByWorkspaceId fetches all active webhooks; event filtering is client-side
-      expect(mockGetActiveByWorkspaceId).toHaveBeenCalledWith(
-        mockDb,
-        1,
-      );
+      expect(mockGetActiveByWorkspaceId).toHaveBeenCalledWith(mockDb, 1);
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(global.fetch).toHaveBeenCalledWith(
         "https://example.com/webhook1",
@@ -464,10 +505,7 @@ describe("webhook utilities", () => {
 
       await sendWebhooksForWorkspace(mockDb, 1, mockPayload);
 
-      expect(mockGetActiveByWorkspaceId).toHaveBeenCalledWith(
-        mockDb,
-        1,
-      );
+      expect(mockGetActiveByWorkspaceId).toHaveBeenCalledWith(mockDb, 1);
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
@@ -539,7 +577,9 @@ describe("webhook utilities", () => {
 
   describe("webhookUrlSchema", () => {
     it("accepts valid HTTPS URLs", () => {
-      expect(webhookUrlSchema.safeParse("https://example.com/webhook").success).toBe(true);
+      expect(
+        webhookUrlSchema.safeParse("https://example.com/webhook").success,
+      ).toBe(true);
     });
 
     it("rejects HTTP URLs", () => {
@@ -553,12 +593,18 @@ describe("webhook utilities", () => {
     });
 
     it("rejects private IPs", () => {
-      expect(webhookUrlSchema.safeParse("https://10.0.0.1/webhook").success).toBe(false);
-      expect(webhookUrlSchema.safeParse("https://192.168.1.1/webhook").success).toBe(false);
+      expect(
+        webhookUrlSchema.safeParse("https://10.0.0.1/webhook").success,
+      ).toBe(false);
+      expect(
+        webhookUrlSchema.safeParse("https://192.168.1.1/webhook").success,
+      ).toBe(false);
     });
 
     it("rejects cloud metadata endpoints", () => {
-      expect(webhookUrlSchema.safeParse("https://169.254.169.254/latest").success).toBe(false);
+      expect(
+        webhookUrlSchema.safeParse("https://169.254.169.254/latest").success,
+      ).toBe(false);
     });
   });
 });

--- a/packages/api/src/utils/webhook.ts
+++ b/packages/api/src/utils/webhook.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import type { dbClient } from "@kan/db/client";
 import type { WebhookEvent } from "@kan/db/schema";
+import type { CardType } from "@kan/shared/constants";
 import * as webhookRepo from "@kan/db/repository/webhook.repo";
 import { createLogger } from "@kan/logger";
 
@@ -18,6 +19,7 @@ export interface WebhookPayload {
       id: string;
       title: string;
       description?: string | null;
+      type?: CardType;
       dueDate?: string | null; // ISO string after JSON serialization
       listId: string;
       boardId: string;
@@ -97,10 +99,11 @@ export const webhookUrlSchema = z
         const hostname = new URL(url).hostname.toLowerCase();
         const ipv4Match = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(hostname);
         if (ipv4Match) {
-          const [, a, b] = ipv4Match.map(Number);
+          const a = Number(ipv4Match[1] ?? -1);
+          const b = Number(ipv4Match[2] ?? -1);
           if (
             a === 10 ||
-            (a === 172 && b! >= 16 && b! <= 31) ||
+            (a === 172 && b >= 16 && b <= 31) ||
             (a === 192 && b === 168)
           ) {
             return false;
@@ -202,9 +205,24 @@ export async function sendWebhooksForWorkspace(
       sendWebhookToUrl(webhook.url, webhook.secret ?? undefined, payload).then(
         (result) => {
           if (!result.success) {
-            log.error({ url: webhook.url, event: payload.event, error: result.error, statusCode: result.statusCode }, "Webhook delivery failed");
+            log.error(
+              {
+                url: webhook.url,
+                event: payload.event,
+                error: result.error,
+                statusCode: result.statusCode,
+              },
+              "Webhook delivery failed",
+            );
           } else {
-            log.info({ url: webhook.url, event: payload.event, statusCode: result.statusCode }, "Webhook delivered");
+            log.info(
+              {
+                url: webhook.url,
+                event: payload.event,
+                statusCode: result.statusCode,
+              },
+              "Webhook delivered",
+            );
           }
         },
       ),
@@ -213,7 +231,10 @@ export async function sendWebhooksForWorkspace(
     // Wait for all to complete but don't block on failures
     await Promise.allSettled(promises);
   } catch (error) {
-    log.error({ err: error, workspaceId }, "Failed to send webhooks for workspace");
+    log.error(
+      { err: error, workspaceId },
+      "Failed to send webhooks for workspace",
+    );
   }
 }
 
@@ -223,6 +244,7 @@ export function createCardWebhookPayload(
     id: string;
     title: string;
     description?: string | null;
+    type?: CardType;
     dueDate?: Date | null;
     listId: string;
   },
@@ -245,6 +267,7 @@ export function createCardWebhookPayload(
         id: card.id,
         title: card.title,
         description: card.description,
+        type: card.type,
         dueDate: card.dueDate?.toISOString() ?? null,
         listId: card.listId,
         boardId: context.boardId,

--- a/packages/db/migrations/20260503093959_AddCardType.sql
+++ b/packages/db/migrations/20260503093959_AddCardType.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."card_type" AS ENUM('spike', 'research', 'coding', 'analyze', 'bug', 'feedback', 'suggestion');--> statement-breakpoint
+ALTER TYPE "public"."card_activity_type" ADD VALUE 'card.updated.type' BEFORE 'card.updated.index';--> statement-breakpoint
+ALTER TABLE "card_activity" ADD COLUMN "fromCardType" "card_type";--> statement-breakpoint
+ALTER TABLE "card_activity" ADD COLUMN "toCardType" "card_type";--> statement-breakpoint
+ALTER TABLE "card" ADD COLUMN "type" "card_type" DEFAULT 'coding' NOT NULL;

--- a/packages/db/migrations/meta/20260503093959_snapshot.json
+++ b/packages/db/migrations/meta/20260503093959_snapshot.json
@@ -1,0 +1,3963 @@
+{
+  "id": "774b23ce-54fb-4366-be7f-9a78807f9a89",
+  "prevId": "061f5a3b-83c3-4274-a0c5-723d4acf8b11",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.apiKey": {
+      "name": "apiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apiKey_userId_user_id_fk": {
+          "name": "apiKey_userId_user_id_fk",
+          "tableFrom": "apiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.board": {
+      "name": "board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importId": {
+          "name": "importId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "board_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "type": {
+          "name": "type",
+          "type": "board_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sourceBoardId": {
+          "name": "sourceBoardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "board_is_archived_idx": {
+          "name": "board_is_archived_idx",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_visibility_idx": {
+          "name": "board_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_type_idx": {
+          "name": "board_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "board_source_idx": {
+          "name": "board_source_idx",
+          "columns": [
+            {
+              "expression": "sourceBoardId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_slug_per_workspace": {
+          "name": "unique_slug_per_workspace",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"board\".\"deletedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "board_createdBy_user_id_fk": {
+          "name": "board_createdBy_user_id_fk",
+          "tableFrom": "board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_deletedBy_user_id_fk": {
+          "name": "board_deletedBy_user_id_fk",
+          "tableFrom": "board",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "board_importId_import_id_fk": {
+          "name": "board_importId_import_id_fk",
+          "tableFrom": "board",
+          "tableTo": "import",
+          "columnsFrom": [
+            "importId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "board_workspaceId_workspace_id_fk": {
+          "name": "board_workspaceId_workspace_id_fk",
+          "tableFrom": "board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "board_publicId_unique": {
+          "name": "board_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_board_favorites": {
+      "name": "user_board_favorites",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_board_favorite_user_idx": {
+          "name": "user_board_favorite_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_board_favorite_board_idx": {
+          "name": "user_board_favorite_board_idx",
+          "columns": [
+            {
+              "expression": "boardId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_board_favorites_userId_user_id_fk": {
+          "name": "user_board_favorites_userId_user_id_fk",
+          "tableFrom": "user_board_favorites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_board_favorites_boardId_board_id_fk": {
+          "name": "user_board_favorites_boardId_board_id_fk",
+          "tableFrom": "user_board_favorites",
+          "tableTo": "board",
+          "columnsFrom": [
+            "boardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_board_favorites_userId_boardId_pk": {
+          "name": "user_board_favorites_userId_boardId_pk",
+          "columns": [
+            "userId",
+            "boardId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_activity": {
+      "name": "card_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "card_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromIndex": {
+          "name": "fromIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toIndex": {
+          "name": "toIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromListId": {
+          "name": "fromListId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toListId": {
+          "name": "toListId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceMemberId": {
+          "name": "workspaceMemberId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromTitle": {
+          "name": "fromTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toTitle": {
+          "name": "toTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromDescription": {
+          "name": "fromDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toDescription": {
+          "name": "toDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromCardType": {
+          "name": "fromCardType",
+          "type": "card_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toCardType": {
+          "name": "toCardType",
+          "type": "card_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromComment": {
+          "name": "fromComment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toComment": {
+          "name": "toComment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromDueDate": {
+          "name": "fromDueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toDueDate": {
+          "name": "toDueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceBoardId": {
+          "name": "sourceBoardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentId": {
+          "name": "attachmentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_activity_cardId_card_id_fk": {
+          "name": "card_activity_cardId_card_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_activity_fromListId_list_id_fk": {
+          "name": "card_activity_fromListId_list_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "list",
+          "columnsFrom": [
+            "fromListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_activity_toListId_list_id_fk": {
+          "name": "card_activity_toListId_list_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "list",
+          "columnsFrom": [
+            "toListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_activity_labelId_label_id_fk": {
+          "name": "card_activity_labelId_label_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "label",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_activity_workspaceMemberId_workspace_members_id_fk": {
+          "name": "card_activity_workspaceMemberId_workspace_members_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "workspace_members",
+          "columnsFrom": [
+            "workspaceMemberId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_activity_createdBy_user_id_fk": {
+          "name": "card_activity_createdBy_user_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_activity_commentId_card_comments_id_fk": {
+          "name": "card_activity_commentId_card_comments_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "card_comments",
+          "columnsFrom": [
+            "commentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_activity_sourceBoardId_board_id_fk": {
+          "name": "card_activity_sourceBoardId_board_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "board",
+          "columnsFrom": [
+            "sourceBoardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_activity_attachmentId_card_attachment_id_fk": {
+          "name": "card_activity_attachmentId_card_attachment_id_fk",
+          "tableFrom": "card_activity",
+          "tableTo": "card_attachment",
+          "columnsFrom": [
+            "attachmentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_activity_publicId_unique": {
+          "name": "card_activity_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.card_attachment": {
+      "name": "card_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalFilename": {
+          "name": "originalFilename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3Key": {
+          "name": "s3Key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_attachment_cardId_card_id_fk": {
+          "name": "card_attachment_cardId_card_id_fk",
+          "tableFrom": "card_attachment",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_attachment_createdBy_user_id_fk": {
+          "name": "card_attachment_createdBy_user_id_fk",
+          "tableFrom": "card_attachment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_attachment_publicId_unique": {
+          "name": "card_attachment_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public._card_workspace_members": {
+      "name": "_card_workspace_members",
+      "schema": "",
+      "columns": {
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceMemberId": {
+          "name": "workspaceMemberId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_card_workspace_members_cardId_card_id_fk": {
+          "name": "_card_workspace_members_cardId_card_id_fk",
+          "tableFrom": "_card_workspace_members",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_card_workspace_members_workspaceMemberId_workspace_members_id_fk": {
+          "name": "_card_workspace_members_workspaceMemberId_workspace_members_id_fk",
+          "tableFrom": "_card_workspace_members",
+          "tableTo": "workspace_members",
+          "columnsFrom": [
+            "workspaceMemberId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "_card_workspace_members_cardId_workspaceMemberId_pk": {
+          "name": "_card_workspace_members_cardId_workspaceMemberId_pk",
+          "columns": [
+            "cardId",
+            "workspaceMemberId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.card": {
+      "name": "card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "card_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'coding'"
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardNumber": {
+          "name": "cardNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listId": {
+          "name": "listId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importId": {
+          "name": "importId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "card_list_number_idx": {
+          "name": "card_list_number_idx",
+          "columns": [
+            {
+              "expression": "listId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cardNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "card_createdBy_user_id_fk": {
+          "name": "card_createdBy_user_id_fk",
+          "tableFrom": "card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_deletedBy_user_id_fk": {
+          "name": "card_deletedBy_user_id_fk",
+          "tableFrom": "card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_listId_list_id_fk": {
+          "name": "card_listId_list_id_fk",
+          "tableFrom": "card",
+          "tableTo": "list",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_importId_import_id_fk": {
+          "name": "card_importId_import_id_fk",
+          "tableFrom": "card",
+          "tableTo": "import",
+          "columnsFrom": [
+            "importId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_publicId_unique": {
+          "name": "card_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public._card_labels": {
+      "name": "_card_labels",
+      "schema": "",
+      "columns": {
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labelId": {
+          "name": "labelId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_card_labels_cardId_card_id_fk": {
+          "name": "_card_labels_cardId_card_id_fk",
+          "tableFrom": "_card_labels",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_card_labels_labelId_label_id_fk": {
+          "name": "_card_labels_labelId_label_id_fk",
+          "tableFrom": "_card_labels",
+          "tableTo": "label",
+          "columnsFrom": [
+            "labelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "_card_labels_cardId_labelId_pk": {
+          "name": "_card_labels_cardId_labelId_pk",
+          "columns": [
+            "cardId",
+            "labelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.card_comments": {
+      "name": "card_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_comments_cardId_card_id_fk": {
+          "name": "card_comments_cardId_card_id_fk",
+          "tableFrom": "card_comments",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_comments_createdBy_user_id_fk": {
+          "name": "card_comments_createdBy_user_id_fk",
+          "tableFrom": "card_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_comments_deletedBy_user_id_fk": {
+          "name": "card_comments_deletedBy_user_id_fk",
+          "tableFrom": "card_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_comments_publicId_unique": {
+          "name": "card_comments_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.card_checklist_item": {
+      "name": "card_checklist_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklistId": {
+          "name": "checklistId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_checklist_item_checklistId_card_checklist_id_fk": {
+          "name": "card_checklist_item_checklistId_card_checklist_id_fk",
+          "tableFrom": "card_checklist_item",
+          "tableTo": "card_checklist",
+          "columnsFrom": [
+            "checklistId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_checklist_item_createdBy_user_id_fk": {
+          "name": "card_checklist_item_createdBy_user_id_fk",
+          "tableFrom": "card_checklist_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_checklist_item_deletedBy_user_id_fk": {
+          "name": "card_checklist_item_deletedBy_user_id_fk",
+          "tableFrom": "card_checklist_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_checklist_item_publicId_unique": {
+          "name": "card_checklist_item_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.card_checklist": {
+      "name": "card_checklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_checklist_cardId_card_id_fk": {
+          "name": "card_checklist_cardId_card_id_fk",
+          "tableFrom": "card_checklist",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "card_checklist_createdBy_user_id_fk": {
+          "name": "card_checklist_createdBy_user_id_fk",
+          "tableFrom": "card_checklist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "card_checklist_deletedBy_user_id_fk": {
+          "name": "card_checklist_deletedBy_user_id_fk",
+          "tableFrom": "card_checklist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "card_checklist_publicId_unique": {
+          "name": "card_checklist_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_createdBy_user_id_fk": {
+          "name": "feedback_createdBy_user_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.import": {
+      "name": "import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_createdBy_user_id_fk": {
+          "name": "import_createdBy_user_id_fk",
+          "tableFrom": "import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "import_publicId_unique": {
+          "name": "import_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.label": {
+      "name": "label",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colourCode": {
+          "name": "colourCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importId": {
+          "name": "importId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "label_createdBy_user_id_fk": {
+          "name": "label_createdBy_user_id_fk",
+          "tableFrom": "label",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "label_boardId_board_id_fk": {
+          "name": "label_boardId_board_id_fk",
+          "tableFrom": "label",
+          "tableTo": "board",
+          "columnsFrom": [
+            "boardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_importId_import_id_fk": {
+          "name": "label_importId_import_id_fk",
+          "tableFrom": "label",
+          "tableTo": "import",
+          "columnsFrom": [
+            "importId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "label_deletedBy_user_id_fk": {
+          "name": "label_deletedBy_user_id_fk",
+          "tableFrom": "label",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "label_publicId_unique": {
+          "name": "label_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.list": {
+      "name": "list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boardId": {
+          "name": "boardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importId": {
+          "name": "importId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_createdBy_user_id_fk": {
+          "name": "list_createdBy_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "list_deletedBy_user_id_fk": {
+          "name": "list_deletedBy_user_id_fk",
+          "tableFrom": "list",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "list_boardId_board_id_fk": {
+          "name": "list_boardId_board_id_fk",
+          "tableFrom": "list",
+          "tableTo": "board",
+          "columnsFrom": [
+            "boardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_importId_import_id_fk": {
+          "name": "list_importId_import_id_fk",
+          "tableFrom": "list",
+          "tableTo": "import",
+          "columnsFrom": [
+            "importId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "list_publicId_unique": {
+          "name": "list_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integration_userId_user_id_fk": {
+          "name": "integration_userId_user_id_fk",
+          "tableFrom": "integration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "integration_pkey": {
+          "name": "integration_pkey",
+          "columns": [
+            "userId",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_slug_checks": {
+      "name": "workspace_slug_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved": {
+          "name": "reserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_slug_checks_workspaceId_workspace_id_fk": {
+          "name": "workspace_slug_checks_workspaceId_workspace_id_fk",
+          "tableFrom": "workspace_slug_checks",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workspace_slug_checks_createdBy_user_id_fk": {
+          "name": "workspace_slug_checks_createdBy_user_id_fk",
+          "tableFrom": "workspace_slug_checks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_slugs": {
+      "name": "workspace_slugs",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "slug_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_slugs_slug_unique": {
+          "name": "workspace_slugs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_members": {
+      "name": "workspace_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_members_userId_user_id_fk": {
+          "name": "workspace_members_userId_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_members_workspaceId_workspace_id_fk": {
+          "name": "workspace_members_workspaceId_workspace_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_members_deletedBy_user_id_fk": {
+          "name": "workspace_members_deletedBy_user_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_members_roleId_workspace_roles_id_fk": {
+          "name": "workspace_members_roleId_workspace_roles_id_fk",
+          "tableFrom": "workspace_members",
+          "tableTo": "workspace_roles",
+          "columnsFrom": [
+            "roleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_members_publicId_unique": {
+          "name": "workspace_members_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "workspace_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "showEmailsToMembers": {
+          "name": "showEmailsToMembers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekStartDay": {
+          "name": "weekStartDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cardPrefix": {
+          "name": "cardPrefix",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cardCounter": {
+          "name": "cardCounter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedBy": {
+          "name": "deletedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_card_prefix_idx": {
+          "name": "workspace_card_prefix_idx",
+          "columns": [
+            {
+              "expression": "cardPrefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_createdBy_user_id_fk": {
+          "name": "workspace_createdBy_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_deletedBy_user_id_fk": {
+          "name": "workspace_deletedBy_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deletedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_publicId_unique": {
+          "name": "workspace_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        },
+        "workspace_slug_unique": {
+          "name": "workspace_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seats": {
+          "name": "seats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimitedSeats": {
+          "name": "unlimitedSeats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trialStart": {
+          "name": "trialStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trialEnd": {
+          "name": "trialEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_referenceId_workspace_publicId_fk": {
+          "name": "subscription_referenceId_workspace_publicId_fk",
+          "tableFrom": "subscription",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "publicId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_invite_links": {
+      "name": "workspace_invite_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_link_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_invite_links_workspaceId_workspace_id_fk": {
+          "name": "workspace_invite_links_workspaceId_workspace_id_fk",
+          "tableFrom": "workspace_invite_links",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_invite_links_createdBy_user_id_fk": {
+          "name": "workspace_invite_links_createdBy_user_id_fk",
+          "tableFrom": "workspace_invite_links",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_invite_links_updatedBy_user_id_fk": {
+          "name": "workspace_invite_links_updatedBy_user_id_fk",
+          "tableFrom": "workspace_invite_links",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_invite_links_publicId_unique": {
+          "name": "workspace_invite_links_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        },
+        "workspace_invite_links_code_unique": {
+          "name": "workspace_invite_links_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_member_permissions": {
+      "name": "workspace_member_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceMemberId": {
+          "name": "workspaceMemberId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_member_permission": {
+          "name": "unique_member_permission",
+          "columns": [
+            {
+              "expression": "workspaceMemberId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permission_member_idx": {
+          "name": "permission_member_idx",
+          "columns": [
+            {
+              "expression": "workspaceMemberId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_role_permissions": {
+      "name": "workspace_role_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceRoleId": {
+          "name": "workspaceRoleId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "columns": [
+            {
+              "expression": "workspaceRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "role_permissions_role_idx": {
+          "name": "role_permissions_role_idx",
+          "columns": [
+            {
+              "expression": "workspaceRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_role_permissions_workspaceRoleId_workspace_roles_id_fk": {
+          "name": "workspace_role_permissions_workspaceRoleId_workspace_roles_id_fk",
+          "tableFrom": "workspace_role_permissions",
+          "tableTo": "workspace_roles",
+          "columnsFrom": [
+            "workspaceRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_roles": {
+      "name": "workspace_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hierarchyLevel": {
+          "name": "hierarchyLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "unique_role_per_workspace": {
+          "name": "unique_role_per_workspace",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_roles_workspace_idx": {
+          "name": "workspace_roles_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_roles_workspaceId_workspace_id_fk": {
+          "name": "workspace_roles_workspaceId_workspace_id_fk",
+          "tableFrom": "workspace_roles",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_roles_publicId_unique": {
+          "name": "workspace_roles_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cardId": {
+          "name": "cardId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_user_deleted_idx": {
+          "name": "notification_user_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_read_deleted_idx": {
+          "name": "notification_user_read_deleted_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "readAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_type_card_idx": {
+          "name": "notification_user_type_card_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cardId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_type_workspace_idx": {
+          "name": "notification_user_type_workspace_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_user_created_idx": {
+          "name": "notification_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_userId_user_id_fk": {
+          "name": "notification_userId_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_cardId_card_id_fk": {
+          "name": "notification_cardId_card_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "card",
+          "columnsFrom": [
+            "cardId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_commentId_card_comments_id_fk": {
+          "name": "notification_commentId_card_comments_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "card_comments",
+          "columnsFrom": [
+            "commentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_workspaceId_workspace_id_fk": {
+          "name": "notification_workspaceId_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_publicId_unique": {
+          "name": "notification_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.workspace_webhooks": {
+      "name": "workspace_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicId": {
+          "name": "publicId",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_webhooks_workspace_idx": {
+          "name": "workspace_webhooks_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_webhooks_workspaceId_workspace_id_fk": {
+          "name": "workspace_webhooks_workspaceId_workspace_id_fk",
+          "tableFrom": "workspace_webhooks",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_webhooks_createdBy_user_id_fk": {
+          "name": "workspace_webhooks_createdBy_user_id_fk",
+          "tableFrom": "workspace_webhooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_webhooks_publicId_unique": {
+          "name": "workspace_webhooks_publicId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.board_type": {
+      "name": "board_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "template"
+      ]
+    },
+    "public.board_visibility": {
+      "name": "board_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.card_activity_type": {
+      "name": "card_activity_type",
+      "schema": "public",
+      "values": [
+        "card.created",
+        "card.updated.title",
+        "card.updated.description",
+        "card.updated.type",
+        "card.updated.index",
+        "card.updated.list",
+        "card.updated.label.added",
+        "card.updated.label.removed",
+        "card.updated.member.added",
+        "card.updated.member.removed",
+        "card.updated.comment.added",
+        "card.updated.comment.updated",
+        "card.updated.comment.deleted",
+        "card.updated.checklist.added",
+        "card.updated.checklist.renamed",
+        "card.updated.checklist.deleted",
+        "card.updated.checklist.item.added",
+        "card.updated.checklist.item.updated",
+        "card.updated.checklist.item.completed",
+        "card.updated.checklist.item.uncompleted",
+        "card.updated.checklist.item.deleted",
+        "card.updated.attachment.added",
+        "card.updated.attachment.removed",
+        "card.updated.dueDate.added",
+        "card.updated.dueDate.updated",
+        "card.updated.dueDate.removed",
+        "card.archived"
+      ]
+    },
+    "public.card_type": {
+      "name": "card_type",
+      "schema": "public",
+      "values": [
+        "spike",
+        "research",
+        "coding",
+        "analyze",
+        "bug",
+        "feedback",
+        "suggestion"
+      ]
+    },
+    "public.source": {
+      "name": "source",
+      "schema": "public",
+      "values": [
+        "trello",
+        "github"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "started",
+        "success",
+        "failed"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member",
+        "guest"
+      ]
+    },
+    "public.member_status": {
+      "name": "member_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "active",
+        "removed",
+        "paused"
+      ]
+    },
+    "public.slug_type": {
+      "name": "slug_type",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "premium"
+      ]
+    },
+    "public.workspace_plan": {
+      "name": "workspace_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "team",
+        "pro",
+        "enterprise"
+      ]
+    },
+    "public.invite_link_status": {
+      "name": "invite_link_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "mention",
+        "workspace.member.added",
+        "workspace.member.removed",
+        "workspace.role.changed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1776809379931,
       "tag": "20260421220939_AddCardNumber",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1777801199220,
+      "tag": "20260503093959_AddCardType",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repository/board.repo.ts
+++ b/packages/db/src/repository/board.repo.ts
@@ -14,6 +14,7 @@ import {
 
 import type { dbClient } from "@kan/db/client";
 import type { BoardVisibilityStatus } from "@kan/db/schema";
+import type { CardType } from "@kan/shared/constants";
 import {
   boards,
   cardActivities,
@@ -78,7 +79,9 @@ export const getAllByWorkspaceId = async (
       eq(boards.workspaceId, workspaceId),
       isNull(boards.deletedAt),
       opts?.type ? eq(boards.type, opts.type) : undefined,
-      opts?.archived !== undefined ? eq(boards.isArchived, opts.archived) : undefined,
+      opts?.archived !== undefined
+        ? eq(boards.isArchived, opts.archived)
+        : undefined,
     ),
   });
 
@@ -153,6 +156,7 @@ export const getByPublicId = async (
     labels: string[];
     lists: string[];
     dueDate: DueDateFilter[];
+    types: CardType[];
     type: "regular" | "template" | undefined;
   },
 ) => {
@@ -253,6 +257,7 @@ export const getByPublicId = async (
               publicId: true,
               title: true,
               description: true,
+              type: true,
               listId: true,
               index: true,
               dueDate: true,
@@ -331,6 +336,9 @@ export const getByPublicId = async (
               cardIds.length > 0 ? inArray(cards.publicId, cardIds) : undefined,
               isNull(cards.deletedAt),
               buildDueDateWhere(filters.dueDate),
+              filters.types.length > 0
+                ? inArray(cards.type, filters.types)
+                : undefined,
             ),
             orderBy: [asc(cards.index)],
           },
@@ -389,6 +397,7 @@ export const getBySlug = async (
     labels: string[];
     lists: string[];
     dueDate: DueDateFilter[];
+    types: CardType[];
   },
 ) => {
   let cardIds: string[] = [];
@@ -450,6 +459,7 @@ export const getBySlug = async (
               publicId: true,
               title: true,
               description: true,
+              type: true,
               listId: true,
               index: true,
               dueDate: true,
@@ -507,6 +517,9 @@ export const getBySlug = async (
               cardIds.length > 0 ? inArray(cards.publicId, cardIds) : undefined,
               isNull(cards.deletedAt),
               buildDueDateWhere(filters.dueDate),
+              filters.types.length > 0
+                ? inArray(cards.type, filters.types)
+                : undefined,
             ),
             orderBy: [asc(cards.index)],
           },
@@ -647,7 +660,9 @@ export const update = async (
       slug: boardInput.slug,
       visibility: boardInput.visibility,
       updatedAt: new Date(),
-      ...(boardInput.isArchived !== undefined && { isArchived: boardInput.isArchived })
+      ...(boardInput.isArchived !== undefined && {
+        isArchived: boardInput.isArchived,
+      }),
     })
     .where(eq(boards.publicId, boardInput.boardPublicId))
     .returning({
@@ -756,6 +771,7 @@ export const createFromSnapshot = async (
         cards: {
           title: string;
           description: string | null;
+          type: CardType;
           index: number;
           labels: {
             publicId: string;
@@ -865,6 +881,7 @@ export const createFromSnapshot = async (
             publicId: generateUID(),
             title: card.title,
             description: card.description ?? "",
+            type: card.type,
             createdBy: args.createdBy,
             listId: newListId,
             index: card.index,
@@ -994,8 +1011,8 @@ export const removeUserFavorite = async (
     .where(
       and(
         eq(userBoardFavorites.userId, userId),
-        eq(userBoardFavorites.boardId, boardId)
-      )
+        eq(userBoardFavorites.boardId, boardId),
+      ),
     )
     .returning();
 };

--- a/packages/db/src/repository/card.repo.ts
+++ b/packages/db/src/repository/card.repo.ts
@@ -11,6 +11,7 @@ import {
 } from "drizzle-orm";
 
 import type { dbClient } from "@kan/db/client";
+import type { CardType } from "@kan/shared/constants";
 import {
   cardActivities,
   cardAttachments,
@@ -24,6 +25,7 @@ import {
   workspaceMembers,
   workspaces,
 } from "@kan/db/schema";
+import { defaultCardType } from "@kan/shared/constants";
 import { generateUID } from "@kan/shared/utils";
 
 export const getCount = async (db: dbClient) => {
@@ -40,6 +42,7 @@ export const create = async (
   cardInput: {
     title: string;
     description: string;
+    type?: CardType;
     createdBy: string;
     listId: number;
     workspaceId: number;
@@ -101,13 +104,20 @@ export const create = async (
         publicId: generateUID(),
         title: cardInput.title,
         description: cardInput.description,
+        type: cardInput.type ?? defaultCardType,
         createdBy: cardInput.createdBy,
         listId: cardInput.listId,
         index: index,
         cardNumber,
         dueDate: cardInput.dueDate ?? null,
       })
-      .returning({ id: cards.id, listId: cards.listId, publicId: cards.publicId, cardNumber: cards.cardNumber });
+      .returning({
+        id: cards.id,
+        listId: cards.listId,
+        publicId: cards.publicId,
+        type: cards.type,
+        cardNumber: cards.cardNumber,
+      });
 
     if (!result[0]) throw new Error("Unable to create card");
 
@@ -198,6 +208,7 @@ export const update = async (
   cardInput: {
     title?: string;
     description?: string;
+    type?: CardType;
     dueDate?: Date | null;
   },
   args: {
@@ -209,6 +220,7 @@ export const update = async (
     .set({
       title: cardInput.title,
       description: cardInput.description,
+      type: cardInput.type,
       dueDate: cardInput.dueDate !== undefined ? cardInput.dueDate : undefined,
       updatedAt: new Date(),
     })
@@ -218,6 +230,7 @@ export const update = async (
       publicId: cards.publicId,
       title: cards.title,
       description: cards.description,
+      type: cards.type,
       dueDate: cards.dueDate,
     });
 
@@ -252,6 +265,7 @@ export const getByPublicId = (db: dbClient, cardPublicId: string) => {
       publicId: true,
       title: true,
       description: true,
+      type: true,
       listId: true,
       dueDate: true,
     },
@@ -285,6 +299,7 @@ export const bulkCreate = async (
     publicId: string;
     title: string;
     description: string;
+    type?: CardType;
     createdBy: string;
     listId: number;
     workspaceId: number;
@@ -321,8 +336,7 @@ export const bulkCreate = async (
         .where(eq(workspaces.id, workspaceId))
         .returning({ cardCounter: workspaces.cardCounter });
 
-      if (!counterResult)
-        throw new Error(`Workspace ${workspaceId} not found`);
+      if (!counterResult) throw new Error(`Workspace ${workspaceId} not found`);
 
       const last = counterResult.cardCounter;
       const start = last - count + 1;
@@ -335,6 +349,7 @@ export const bulkCreate = async (
       publicId: string;
       title: string;
       description: string;
+      type: CardType;
       createdBy: string;
       listId: number;
       index: number;
@@ -363,6 +378,7 @@ export const bulkCreate = async (
           publicId: it.publicId,
           title: it.title,
           description: it.description,
+          type: it.type ?? defaultCardType,
           createdBy: it.createdBy,
           listId: it.listId,
           index: nextIndex++,
@@ -483,6 +499,7 @@ export const getWithListAndMembersByPublicId = async (
       publicId: true,
       title: true,
       description: true,
+      type: true,
       dueDate: true,
       createdBy: true,
       cardNumber: true,
@@ -622,6 +639,8 @@ export const getWithListAndMembersByPublicId = async (
           toTitle: true,
           fromDescription: true,
           toDescription: true,
+          fromCardType: true,
+          toCardType: true,
           fromDueDate: true,
           toDueDate: true,
         },
@@ -873,6 +892,7 @@ export const reorder = async (
         publicId: true,
         title: true,
         description: true,
+        type: true,
         dueDate: true,
       },
       where: eq(cards.id, card.id),

--- a/packages/db/src/repository/cardActivity.repo.ts
+++ b/packages/db/src/repository/cardActivity.repo.ts
@@ -2,6 +2,7 @@ import { and, asc, count, eq, gt, inArray, isNull, or } from "drizzle-orm";
 
 import type { dbClient } from "@kan/db/client";
 import type { ActivityType } from "@kan/db/schema";
+import type { CardType } from "@kan/shared/constants";
 import { cardActivities, comments } from "@kan/db/schema";
 import { generateUID } from "@kan/shared/utils";
 
@@ -26,6 +27,8 @@ export const create = async (
     toTitle?: string;
     fromDescription?: string;
     toDescription?: string;
+    fromCardType?: CardType;
+    toCardType?: CardType;
     createdBy: string;
     commentId?: number;
     fromComment?: string;
@@ -52,6 +55,8 @@ export const create = async (
       toTitle: activityInput.toTitle,
       fromDescription: activityInput.fromDescription,
       toDescription: activityInput.toDescription,
+      fromCardType: activityInput.fromCardType,
+      toCardType: activityInput.toCardType,
       createdBy: activityInput.createdBy,
       commentId: activityInput.commentId,
       fromComment: activityInput.fromComment,
@@ -81,6 +86,8 @@ export const bulkCreate = async (
     toTitle?: string;
     fromDescription?: string;
     toDescription?: string;
+    fromCardType?: CardType;
+    toCardType?: CardType;
     createdBy: string;
     fromDueDate?: Date;
     toDueDate?: Date;
@@ -130,6 +137,8 @@ export const getPaginatedActivities = async (
       toTitle: true,
       fromDescription: true,
       toDescription: true,
+      fromCardType: true,
+      toCardType: true,
       fromDueDate: true,
       toDueDate: true,
     },

--- a/packages/db/src/repository/workspace.repo.ts
+++ b/packages/db/src/repository/workspace.repo.ts
@@ -93,6 +93,7 @@ export const create = async (
       slug: workspaces.slug,
       description: workspaces.description,
       plan: workspaces.plan,
+      cardPrefix: workspaces.cardPrefix,
     });
 
   if (workspace) {
@@ -383,7 +384,11 @@ const parseTicketId = (
 ): { prefix: string; number: number } | null => {
   const match = /^([A-Za-z0-9]{1,10})-(\d+)$/.exec(query);
   if (!match) return null;
-  return { prefix: match[1]!.toUpperCase(), number: parseInt(match[2]!, 10) };
+
+  const [, prefix, number] = match;
+  if (!prefix || !number) return null;
+
+  return { prefix: prefix.toUpperCase(), number: parseInt(number, 10) };
 };
 
 export const searchBoardsAndCards = async (

--- a/packages/db/src/schema/cards.ts
+++ b/packages/db/src/schema/cards.ts
@@ -13,6 +13,8 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
+import { cardTypes, defaultCardType } from "@kan/shared/constants";
+
 import { boards } from "./boards";
 import { checklists } from "./checklists";
 import { imports } from "./imports";
@@ -25,6 +27,7 @@ export const activityTypes = [
   "card.created",
   "card.updated.title",
   "card.updated.description",
+  "card.updated.type",
   "card.updated.index",
   "card.updated.list",
   "card.updated.label.added",
@@ -54,6 +57,7 @@ export const activityTypes = [
 export type ActivityType = (typeof activityTypes)[number];
 
 export const activityTypeEnum = pgEnum("card_activity_type", activityTypes);
+export const cardTypeEnum = pgEnum("card_type", cardTypes);
 
 export const cards = pgTable(
   "card",
@@ -62,6 +66,7 @@ export const cards = pgTable(
     publicId: varchar("publicId", { length: 12 }).notNull().unique(),
     title: text("title").notNull(),
     description: text("description"),
+    type: cardTypeEnum("type").default(defaultCardType).notNull(),
     index: integer("index").notNull(),
     cardNumber: integer("cardNumber"),
     createdBy: uuid("createdBy").references(() => users.id, {
@@ -81,9 +86,7 @@ export const cards = pgTable(
     ),
     dueDate: timestamp("dueDate"),
   },
-  (table) => [
-    index("card_list_number_idx").on(table.listId, table.cardNumber),
-  ],
+  (table) => [index("card_list_number_idx").on(table.listId, table.cardNumber)],
 ).enableRLS();
 
 export const cardsRelations = relations(cards, ({ one, many }) => ({
@@ -141,6 +144,8 @@ export const cardActivities = pgTable("card_activity", {
   toTitle: text("toTitle"),
   fromDescription: text("fromDescription"),
   toDescription: text("toDescription"),
+  fromCardType: cardTypeEnum("fromCardType"),
+  toCardType: cardTypeEnum("toCardType"),
   createdBy: uuid("createdBy").references(() => users.id, {
     onDelete: "set null",
   }),

--- a/packages/shared/src/constants/card-types.ts
+++ b/packages/shared/src/constants/card-types.ts
@@ -1,0 +1,13 @@
+export const cardTypes = [
+  "spike",
+  "research",
+  "coding",
+  "analyze",
+  "bug",
+  "feedback",
+  "suggestion",
+] as const;
+
+export type CardType = (typeof cardTypes)[number];
+
+export const defaultCardType: CardType = "coding";

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,1 +1,2 @@
+export * from "./card-types";
 export * from "./colours";


### PR DESCRIPTION
Add fixed card ticket types across the database, API, board filtering, card UI, activity feed, webhook payloads, and tests.