### PR TITLE
Add cardPublicId to card webhook payloads

### DIFF
--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -187,7 +187,7 @@ export const cardRouter = createTRPCRouter({
           "card.created",
           {
             id: String(newCard.id),
-            cardPublicId: String(newCard.publicId),
+            publicId: newCard.publicId,
             title: input.title,
             description: input.description,
             dueDate: input.dueDate ?? null,
@@ -1071,7 +1071,7 @@ export const cardRouter = createTRPCRouter({
           movedToNewList ? "card.moved" : "card.updated",
           {
             id: String(result.id),
-            cardPublicId: String(newCard.publicId),
+            publicId: result.publicId,
             title: result.title,
             description: result.description,
             dueDate: result.dueDate,
@@ -1167,6 +1167,7 @@ export const cardRouter = createTRPCRouter({
             "card.deleted",
             {
               id: String(fullCard.id),
+              publicId: fullCard.publicId,
               title: fullCard.title,
               description: fullCard.description,
               dueDate: fullCard.dueDate,

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -187,6 +187,7 @@ export const cardRouter = createTRPCRouter({
           "card.created",
           {
             id: String(newCard.id),
+            cardPublicId: String(newCard.publicId),
             title: input.title,
             description: input.description,
             dueDate: input.dueDate ?? null,
@@ -1070,6 +1071,7 @@ export const cardRouter = createTRPCRouter({
           movedToNewList ? "card.moved" : "card.updated",
           {
             id: String(result.id),
+            cardPublicId: String(newCard.publicId),
             title: result.title,
             description: result.description,
             dueDate: result.dueDate,

--- a/packages/api/src/routers/webhook.ts
+++ b/packages/api/src/routers/webhook.ts
@@ -334,6 +334,7 @@ export const webhookRouter = createTRPCRouter({
 
       const testPayload = createCardWebhookPayload("card.created", {
         id: "test-card-id",
+        publicId: "test-card-public-id",
         title: "Test Card",
         description: "This is a test webhook payload",
         dueDate: null,

--- a/packages/api/src/utils/webhook.test.ts
+++ b/packages/api/src/utils/webhook.test.ts
@@ -43,6 +43,7 @@ describe("webhook utilities", () => {
         "card.created",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
         },
@@ -55,12 +56,14 @@ describe("webhook utilities", () => {
       expect(payload.timestamp).toBe("2024-01-15T12:00:00.000Z");
       expect(payload.data.card).toEqual({
         id: "card-123",
+        publicId: "card-pub-123",
         title: "Test Card",
         description: undefined,
         dueDate: null,
         listId: "list-456",
         boardId: "board-789",
       });
+      expect(payload.data.card.publicId).toBe("card-pub-123");
     });
 
     it("includes optional card fields when provided", () => {
@@ -69,6 +72,7 @@ describe("webhook utilities", () => {
         "card.updated",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           description: "A description",
           dueDate,
@@ -88,6 +92,7 @@ describe("webhook utilities", () => {
         "card.created",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
         },
@@ -108,6 +113,7 @@ describe("webhook utilities", () => {
         "card.created",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
         },
@@ -128,6 +134,7 @@ describe("webhook utilities", () => {
         "card.created",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
         },
@@ -151,6 +158,7 @@ describe("webhook utilities", () => {
         "card.updated",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Updated Title",
           listId: "list-456",
         },
@@ -172,6 +180,7 @@ describe("webhook utilities", () => {
         "card.moved",
         {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Moved Card",
           listId: "list-public-done",
         },
@@ -212,6 +221,7 @@ describe("webhook utilities", () => {
       data: {
         card: {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
           boardId: "board-789",
@@ -408,6 +418,7 @@ describe("webhook utilities", () => {
       data: {
         card: {
           id: "card-123",
+          publicId: "card-pub-123",
           title: "Test Card",
           listId: "list-456",
           boardId: "board-789",

--- a/packages/api/src/utils/webhook.ts
+++ b/packages/api/src/utils/webhook.ts
@@ -16,6 +16,7 @@ export interface WebhookPayload {
   data: {
     card: {
       id: string;
+      publicId: string;
       title: string;
       description?: string | null;
       dueDate?: string | null; // ISO string after JSON serialization
@@ -221,6 +222,7 @@ export function createCardWebhookPayload(
   event: WebhookEventType,
   card: {
     id: string;
+    publicId: string;
     title: string;
     description?: string | null;
     dueDate?: Date | null;
@@ -243,6 +245,7 @@ export function createCardWebhookPayload(
     data: {
       card: {
         id: card.id,
+        publicId: card.publicId,
         title: card.title,
         description: card.description,
         dueDate: card.dueDate?.toISOString() ?? null,


### PR DESCRIPTION
I would like to suggest the inclusion of the card public id on the fired events of the webhooks.

I would like to partially automate label tagging and for that I would require to know the public id of the card in order to manipulate it. 