### PR TITLE
fix(editor): convert pasted markdown to formatted content

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -474,7 +474,7 @@ export default function Editor({
           autolink: true,
           linkOnPaste: true,
         }),
-        Markdown,
+        Markdown.configure({ transformPastedText: true }),
         Placeholder.configure({
           placeholder: readOnly
             ? ""


### PR DESCRIPTION
## What

Enables `transformPastedText: true` on the `tiptap-markdown` extension in `apps/web/src/components/Editor.tsx`.

## Why

When pasting markdown text into a card description, the literal characters appeared (e.g. `# Heading` rendered as the text `# Heading` inside a paragraph) rather than being parsed as formatting.

This was surprising because:
- Typing markdown shortcuts in the editor (e.g. `## ` followed by space) **already works** — that goes through TipTap's input rules.
- Programmatic writes via the REST API **already work** — the description field stores whatever string is sent and the editor renders markdown source on read.
- Only **paste** was broken, because `tiptap-markdown`'s paste handler is gated by the `transformPastedText` option, which defaults to `false`.

This one-line change brings the paste UX in line with the typed and API-written behaviors.

## How tested

- Cloned, built, smoke-tested manually with the dev server: pasting markdown into a card description now renders correctly.
- Behavior unchanged for non-markdown paste (rich text from other sources still pastes as-is).

## Reference

- tiptap-markdown docs: https://github.com/aguingand/tiptap-markdown#configuration — `transformPastedText: false  // Allow to paste markdown text in the editor`

Happy to add tests or adjust as needed.