### PR TITLE
feat(webhooks): expose granular card_activity events as webhook subsc…

### DIFF
--- a/packages/api/src/routers/attachment.ts
+++ b/packages/api/src/routers/attachment.ts
@@ -2,13 +2,13 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import * as cardRepo from "@kan/db/repository/card.repo";
-import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
 import * as cardAttachmentRepo from "@kan/db/repository/cardAttachment.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import { generateUID } from "@kan/shared/utils";
 
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { attachmentConfirmResponseSchema } from "../schemas";
+import { createWithWebhook as createCardActivity } from "../utils/cardActivityHook";
 import { assertPermission } from "../utils/permissions";
 import { deleteObject, generateUploadUrl } from "@kan/shared/utils";
 
@@ -150,7 +150,7 @@ export const attachmentRouter = createTRPCRouter({
         });
       }
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.attachment.added",
         cardId: card.id,
         attachmentId: attachment.id,
@@ -213,7 +213,7 @@ export const attachmentRouter = createTRPCRouter({
         deletedAt: new Date(),
       });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.attachment.removed",
         cardId: attachment.cardId,
         attachmentId: attachment.id,

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -19,6 +19,10 @@ import {
   activityItemSchema,
 } from "../schemas";
 import { mergeActivities } from "../utils/activities";
+import {
+  bulkCreateWithWebhook as bulkCreateCardActivity,
+  createWithWebhook as createCardActivity,
+} from "../utils/cardActivityHook";
 import { sendMentionEmails } from "../utils/notifications";
 import { assertCanDelete, assertCanEdit, assertPermission } from "../utils/permissions";
 import { generateAttachmentUrl, generateAvatarUrl } from "@kan/shared/utils";
@@ -126,7 +130,7 @@ export const cardRouter = createTRPCRouter({
           createdBy: userId,
         }));
 
-        await cardActivityRepo.bulkCreate(ctx.db, cardActivitesInsert);
+        await bulkCreateCardActivity(ctx.db, cardActivitesInsert);
       }
 
       if (newCardId && input.memberPublicIds.length) {
@@ -165,7 +169,7 @@ export const cardRouter = createTRPCRouter({
           createdBy: userId,
         }));
 
-        await cardActivityRepo.bulkCreate(ctx.db, cardActivitesInsert);
+        await bulkCreateCardActivity(ctx.db, cardActivitesInsert);
       }
 
       if (input.description) {
@@ -260,7 +264,7 @@ export const cardRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.comment.added" as const,
         cardId: card.id,
         commentId: newComment.id,
@@ -349,7 +353,7 @@ export const cardRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.comment.updated" as const,
         cardId: card.id,
         commentId: updatedComment.id,
@@ -438,7 +442,7 @@ export const cardRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.comment.deleted" as const,
         cardId: card.id,
         commentId: existingComment.id,
@@ -512,7 +516,7 @@ export const cardRouter = createTRPCRouter({
             code: "INTERNAL_SERVER_ERROR",
           });
 
-        await cardActivityRepo.create(ctx.db, {
+        await createCardActivity(ctx.db, {
           type: "card.updated.label.removed" as const,
           cardId: card.id,
           labelId: label.id,
@@ -531,7 +535,7 @@ export const cardRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.label.added" as const,
         cardId: card.id,
         labelId: label.id,
@@ -610,7 +614,7 @@ export const cardRouter = createTRPCRouter({
             code: "INTERNAL_SERVER_ERROR",
           });
 
-        await cardActivityRepo.create(ctx.db, {
+        await createCardActivity(ctx.db, {
           type: "card.updated.member.removed" as const,
           cardId: card.id,
           workspaceMemberId: member.id,
@@ -629,7 +633,7 @@ export const cardRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.member.added" as const,
         cardId: card.id,
         workspaceMemberId: member.id,
@@ -1028,7 +1032,7 @@ export const cardRouter = createTRPCRouter({
       }
 
       if (activities.length > 0) {
-        await cardActivityRepo.bulkCreate(ctx.db, activities);
+        await bulkCreateCardActivity(ctx.db, activities);
       }
 
       // Build changes object for webhook
@@ -1152,7 +1156,7 @@ export const cardRouter = createTRPCRouter({
         deletedBy: userId,
       });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.archived",
         cardId: card.id,
         createdBy: userId,
@@ -1304,7 +1308,7 @@ export const cardRouter = createTRPCRouter({
             labelId: cardLabel.id,
             createdBy: userId,
           }));
-          await cardActivityRepo.bulkCreate(ctx.db, cardActivitesInsert);
+          await bulkCreateCardActivity(ctx.db, cardActivitesInsert);
         }
       }
 
@@ -1329,7 +1333,7 @@ export const cardRouter = createTRPCRouter({
             workspaceMemberId: member.id,
             createdBy: userId,
           }));
-          await cardActivityRepo.bulkCreate(ctx.db, cardActivitesInsert);
+          await bulkCreateCardActivity(ctx.db, cardActivitesInsert);
         }
       }
 
@@ -1351,7 +1355,7 @@ export const cardRouter = createTRPCRouter({
               });
             }
           }
-          await cardActivityRepo.create(ctx.db, {
+          await createCardActivity(ctx.db, {
             type: "card.updated.checklist.added",
             cardId: newCard.id,
             toTitle: newChecklist.name,

--- a/packages/api/src/routers/checklist.ts
+++ b/packages/api/src/routers/checklist.ts
@@ -2,11 +2,11 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import * as cardRepo from "@kan/db/repository/card.repo";
-import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
 import * as checklistRepo from "@kan/db/repository/checklist.repo";
 import { stripHtml } from "@kan/shared/utils";
 
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { createWithWebhook as createCardActivity } from "../utils/cardActivityHook";
 import { assertPermission } from "../utils/permissions";
 
 const checklistSchema = z.object({
@@ -72,7 +72,7 @@ export const checklistRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.checklist.added",
         cardId: card.id,
         toTitle: newChecklist.name,
@@ -136,7 +136,7 @@ export const checklistRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.checklist.renamed",
         cardId: checklist.cardId,
         fromTitle: previousName,
@@ -201,7 +201,7 @@ export const checklistRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.checklist.deleted",
         cardId: checklist.cardId,
         fromTitle: checklist.name,
@@ -266,7 +266,7 @@ export const checklistRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.checklist.item.added",
         cardId: checklist.cardId,
         toTitle: newChecklistItem.title,
@@ -349,7 +349,7 @@ export const checklistRouter = createTRPCRouter({
 
       // Log completion toggle
       if (input.completed !== undefined) {
-        await cardActivityRepo.create(ctx.db, {
+        await createCardActivity(ctx.db, {
           type: input.completed
             ? "card.updated.checklist.item.completed"
             : "card.updated.checklist.item.uncompleted",
@@ -361,7 +361,7 @@ export const checklistRouter = createTRPCRouter({
 
       // Log title change
       if (input.title !== undefined && input.title !== previousTitle) {
-        await cardActivityRepo.create(ctx.db, {
+        await createCardActivity(ctx.db, {
           type: "card.updated.checklist.item.updated",
           cardId: item.checklist.cardId,
           fromTitle: previousTitle,
@@ -421,7 +421,7 @@ export const checklistRouter = createTRPCRouter({
           code: "INTERNAL_SERVER_ERROR",
         });
 
-      await cardActivityRepo.create(ctx.db, {
+      await createCardActivity(ctx.db, {
         type: "card.updated.checklist.item.deleted",
         cardId: item.checklist.cardId,
         fromTitle: item.title,

--- a/packages/api/src/utils/cardActivityHook.ts
+++ b/packages/api/src/utils/cardActivityHook.ts
@@ -1,0 +1,263 @@
+import { and, eq, isNull } from "drizzle-orm";
+
+import type { dbClient } from "@kan/db/client";
+import type { ActivityType } from "@kan/db/schema";
+import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
+import {
+  cardAttachments,
+  cards,
+  comments,
+  labels,
+  lists,
+  workspaceMembers,
+} from "@kan/db/schema";
+import { createLogger } from "@kan/logger";
+
+import type { WebhookPayload } from "./webhook";
+import { sendWebhooksForWorkspace } from "./webhook";
+
+const log = createLogger("card-activity-hook");
+
+type ActivityInput = Parameters<typeof cardActivityRepo.create>[1];
+type BulkActivityInput = Parameters<typeof cardActivityRepo.bulkCreate>[1][number];
+
+/**
+ * Wraps cardActivityRepo.create with fire-and-forget webhook fan-out.
+ *
+ * Every card_activity row inserted produces a webhook event of the same
+ * granular type (e.g. "card.updated.label.added"). Subscribers configured
+ * for that exact event in workspace_webhooks receive the payload.
+ *
+ * "card.created" is intentionally skipped — the card router already fires
+ * a coarse "card.created" webhook explicitly at the creation call site, so
+ * routing it through here would deliver duplicates. Coarse "card.updated",
+ * "card.moved" and "card.deleted" events are likewise still fired from
+ * their original explicit dispatch sites for backward compatibility; this
+ * hook only adds the granular events on top.
+ *
+ * Webhook delivery is fire-and-forget and never blocks the activity insert
+ * or surfaces errors to callers — failures are logged.
+ */
+export const createWithWebhook = async (
+  db: dbClient,
+  input: ActivityInput,
+): ReturnType<typeof cardActivityRepo.create> => {
+  const result = await cardActivityRepo.create(db, input);
+
+  if (input.type !== "card.created") {
+    void deliverGranularWebhook(db, input).catch((err) => {
+      log.error(
+        { err, type: input.type, cardId: input.cardId },
+        "Granular webhook fan-out failed",
+      );
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Wraps cardActivityRepo.bulkCreate with fire-and-forget webhook fan-out.
+ *
+ * One webhook per inserted activity row, same dispatch rules as
+ * createWithWebhook (skips "card.created").
+ */
+export const bulkCreateWithWebhook = async (
+  db: dbClient,
+  inputs: BulkActivityInput[],
+): ReturnType<typeof cardActivityRepo.bulkCreate> => {
+  const results = await cardActivityRepo.bulkCreate(db, inputs);
+
+  for (const input of inputs) {
+    if (input.type === "card.created") continue;
+    void deliverGranularWebhook(db, input as ActivityInput).catch((err) => {
+      log.error(
+        { err, type: input.type, cardId: input.cardId },
+        "Granular webhook fan-out failed",
+      );
+    });
+  }
+
+  return results;
+};
+
+async function deliverGranularWebhook(
+  db: dbClient,
+  input: ActivityInput,
+): Promise<void> {
+  const card = await db.query.cards.findFirst({
+    columns: {
+      id: true,
+      publicId: true,
+      title: true,
+      description: true,
+      dueDate: true,
+      listId: true,
+    },
+    with: {
+      list: {
+        columns: { publicId: true, name: true, boardId: true },
+        with: {
+          board: {
+            columns: { publicId: true, name: true, workspaceId: true },
+          },
+        },
+      },
+    },
+    where: and(eq(cards.id, input.cardId), isNull(cards.deletedAt)),
+  });
+
+  if (!card?.list?.board) return;
+
+  const workspaceId = card.list.board.workspaceId;
+
+  const payload: WebhookPayload = {
+    event: input.type as ActivityType,
+    timestamp: new Date().toISOString(),
+    data: {
+      card: {
+        id: String(card.id),
+        publicId: card.publicId,
+        title: card.title,
+        description: card.description,
+        dueDate: card.dueDate?.toISOString() ?? null,
+        listId: card.list.publicId,
+        boardId: card.list.board.publicId,
+      },
+      board: { id: card.list.board.publicId, name: card.list.board.name },
+      list: { id: card.list.publicId, name: card.list.name },
+    },
+  };
+
+  await hydrateActivityContext(db, input, payload);
+
+  await sendWebhooksForWorkspace(db, workspaceId, payload);
+}
+
+async function hydrateActivityContext(
+  db: dbClient,
+  input: ActivityInput,
+  payload: WebhookPayload,
+): Promise<void> {
+  const lookups: Promise<void>[] = [];
+
+  if (input.labelId !== undefined) {
+    lookups.push(
+      db.query.labels
+        .findFirst({
+          columns: { publicId: true, name: true },
+          where: eq(labels.id, input.labelId),
+        })
+        .then((row) => {
+          if (row) payload.data.label = { id: row.publicId, name: row.name };
+        }),
+    );
+  }
+
+  if (input.workspaceMemberId !== undefined) {
+    lookups.push(
+      db.query.workspaceMembers
+        .findFirst({
+          columns: { publicId: true },
+          with: { user: { columns: { name: true } } },
+          where: eq(workspaceMembers.id, input.workspaceMemberId),
+        })
+        .then((row) => {
+          if (row)
+            payload.data.member = {
+              id: row.publicId,
+              name: row.user?.name ?? null,
+            };
+        }),
+    );
+  }
+
+  if (input.commentId !== undefined) {
+    lookups.push(
+      db.query.comments
+        .findFirst({
+          columns: { publicId: true, comment: true },
+          where: eq(comments.id, input.commentId),
+        })
+        .then((row) => {
+          if (row)
+            payload.data.comment = {
+              id: row.publicId,
+              body: row.comment ?? null,
+            };
+        }),
+    );
+  }
+
+  if (input.attachmentId !== undefined) {
+    lookups.push(
+      db.query.cardAttachments
+        .findFirst({
+          columns: { publicId: true, filename: true },
+          where: eq(cardAttachments.id, input.attachmentId),
+        })
+        .then((row) => {
+          if (row)
+            payload.data.attachment = {
+              id: row.publicId,
+              filename: row.filename,
+            };
+        }),
+    );
+  }
+
+  if (input.fromListId !== undefined) {
+    lookups.push(
+      db.query.lists
+        .findFirst({
+          columns: { publicId: true, name: true },
+          where: eq(lists.id, input.fromListId),
+        })
+        .then((row) => {
+          if (row) payload.data.fromList = { id: row.publicId, name: row.name };
+        }),
+    );
+  }
+
+  if (input.toListId !== undefined) {
+    lookups.push(
+      db.query.lists
+        .findFirst({
+          columns: { publicId: true, name: true },
+          where: eq(lists.id, input.toListId),
+        })
+        .then((row) => {
+          if (row) payload.data.toList = { id: row.publicId, name: row.name };
+        }),
+    );
+  }
+
+  if (input.fromDueDate !== undefined || input.toDueDate !== undefined) {
+    payload.data.changes = {
+      ...(payload.data.changes ?? {}),
+      dueDate: {
+        from: input.fromDueDate?.toISOString() ?? null,
+        to: input.toDueDate?.toISOString() ?? null,
+      },
+    };
+  }
+
+  if (input.fromTitle !== undefined || input.toTitle !== undefined) {
+    payload.data.changes = {
+      ...(payload.data.changes ?? {}),
+      title: { from: input.fromTitle ?? null, to: input.toTitle ?? null },
+    };
+  }
+
+  if (input.fromDescription !== undefined || input.toDescription !== undefined) {
+    payload.data.changes = {
+      ...(payload.data.changes ?? {}),
+      description: {
+        from: input.fromDescription ?? null,
+        to: input.toDescription ?? null,
+      },
+    };
+  }
+
+  await Promise.all(lookups);
+}

--- a/packages/api/src/utils/webhook.ts
+++ b/packages/api/src/utils/webhook.ts
@@ -31,9 +31,44 @@ export interface WebhookPayload {
       id: string;
       name: string;
     };
+    fromList?: {
+      id: string;
+      name: string;
+    };
+    toList?: {
+      id: string;
+      name: string;
+    };
     user?: {
       id: string;
       name: string | null;
+    };
+    // Granular event context — populated based on the activity row that
+    // triggered the webhook. Only the fields relevant to event are set.
+    label?: {
+      id: string;
+      name: string;
+    };
+    member?: {
+      id: string;
+      name: string | null;
+    };
+    comment?: {
+      id: string;
+      body: string | null;
+    };
+    attachment?: {
+      id: string;
+      filename: string;
+    };
+    checklist?: {
+      id: string;
+      name: string;
+    };
+    checklistItem?: {
+      id: string;
+      title: string;
+      completed: boolean;
     };
     changes?: Record<string, { from: unknown; to: unknown }>;
   };

--- a/packages/db/src/schema/webhooks.ts
+++ b/packages/db/src/schema/webhooks.ts
@@ -11,14 +11,20 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
+import { activityTypes } from "./cards";
 import { users } from "./users";
 import { workspaces } from "./workspaces";
 
+// Coarse-grained events fired once per card mutation, kept for backward
+// compatibility with existing subscribers. Granular events come from
+// activityTypes (cards.ts) — every distinct card_activity_type produces a
+// webhook of the same name. New types added to activityTypes upstream
+// automatically become available as webhook subscriptions.
+const coarseWebhookEvents = ["card.updated", "card.moved", "card.deleted"] as const;
+
 export const webhookEvents = [
-  "card.created",
-  "card.updated",
-  "card.moved",
-  "card.deleted",
+  ...activityTypes,
+  ...coarseWebhookEvents,
 ] as const;
 export type WebhookEvent = (typeof webhookEvents)[number];
 


### PR DESCRIPTION
…riptions

Every card_activity_type (26 variants like card.updated.label.added, card.updated.dueDate.updated, card.archived, etc.) is now selectable in the webhook settings UI and fires its own webhook on the matching change. The existing coarse card.created / card.updated / card.moved / card.deleted events continue to fire from their original dispatch sites, so existing subscribers are unaffected.

- webhookEvents is now derived from activityTypes (cards.ts) plus the legacy coarse set, so new activity types added upstream automatically become available as webhook subscriptions.
- New cardActivityHook util wraps cardActivityRepo.create and bulkCreate with fire-and-forget webhook fan-out, looking up workspaceId and hydrating type-specific context (label, member, comment, attachment, fromList, toList, changes) for the payload.
- card.ts / checklist.ts / attachment.ts routers route through the new hook. import.ts intentionally keeps the raw bulkCreate to avoid flooding subscribers during data imports.
- WebhookPayload.data extended with optional label / member / comment / attachment / fromList / toList fields.
- card.created is skipped by the hook because the card router already fires it explicitly; routing it through the hook would deliver duplicates.