### PR TITLE
fix: correct German gender for "Neues Board"

### DIFF
--- a/apps/web/src/locales/de/messages.json
+++ b/apps/web/src/locales/de/messages.json
@@ -1875,7 +1875,7 @@
       ["src/views/boards/components/BoardsList.tsx", 80],
       ["src/views/boards/index.tsx", 41]
     ],
-    "translation": "Neue {0} erstellen"
+    "translation": "Neues {0} erstellen"
   },
   "okpxfB": {
     "message": "Create new key",
@@ -4059,7 +4059,7 @@
     },
     "comments": [],
     "origin": [["src/views/boards/components/NewBoardForm.tsx", 120]],
-    "translation": "Neue {0}"
+    "translation": "Neues {0}"
   },
   "TjREUS": {
     "message": "New API key",


### PR DESCRIPTION
"Board" is neuter in German, so "Neue Board" should be "Neues Board".