### PR TITLE
fix: encode attachment filename header to support non-ASCII characters

### DIFF
--- a/apps/web/src/pages/api/upload/attachment.ts
+++ b/apps/web/src/pages/api/upload/attachment.ts
@@ -67,8 +67,15 @@ export default withRateLimit(
         return res.status(400).json({ error: "File too large" });
       }
 
-      const originalFilenameHeader =
+      const rawFilenameHeader =
         (req.headers["x-original-filename"] as string | undefined) ?? "file";
+      const originalFilenameHeader = (() => {
+        try {
+          return decodeURIComponent(rawFilenameHeader);
+        } catch {
+          return rawFilenameHeader;
+        }
+      })();
 
       const sanitizedFilename = originalFilenameHeader
         .replace(/[^a-zA-Z0-9._-]/g, "_")

--- a/apps/web/src/pages/api/upload/avatar.ts
+++ b/apps/web/src/pages/api/upload/avatar.ts
@@ -64,8 +64,15 @@ export default withRateLimit(
         return res.status(400).json({ error: "File too large" });
       }
 
-      const originalFilenameHeader =
+      const rawFilenameHeader =
         (req.headers["x-original-filename"] as string | undefined) ?? "file";
+      const originalFilenameHeader = (() => {
+        try {
+          return decodeURIComponent(rawFilenameHeader);
+        } catch {
+          return rawFilenameHeader;
+        }
+      })();
 
       const sanitizedFilename = originalFilenameHeader
         .replace(/[^a-zA-Z0-9._-]/g, "_")

--- a/apps/web/src/views/card/components/AttachmentUpload.tsx
+++ b/apps/web/src/views/card/components/AttachmentUpload.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/core/macro";
+import { env } from "next-runtime-env";
 import { useRef, useState } from "react";
 import { HiOutlinePaperClip } from "react-icons/hi";
 import { HiCheckBadge } from "react-icons/hi2";
@@ -7,7 +8,6 @@ import { twMerge } from "tailwind-merge";
 import Button from "~/components/Button";
 import { useModal } from "~/providers/modal";
 import { usePopup } from "~/providers/popup";
-import { env } from "next-runtime-env";
 import { api } from "~/utils/api";
 import { invalidateCard } from "~/utils/cardInvalidation";
 
@@ -30,7 +30,7 @@ export function AttachmentUpload({ cardPublicId }: { cardPublicId: string }) {
           method: "POST",
           headers: {
             "Content-Type": file.type,
-            "x-original-filename": file.name,
+            "x-original-filename": encodeURIComponent(file.name),
           },
           body: file,
         },

--- a/apps/web/src/views/settings/components/Avatar.tsx
+++ b/apps/web/src/views/settings/components/Avatar.tsx
@@ -172,7 +172,7 @@ export default function Avatar({
           method: "POST",
           headers: {
             "Content-Type": blob.type,
-            "x-original-filename": fileName,
+            "x-original-filename": encodeURIComponent(fileName),
           },
           body: blob,
         },


### PR DESCRIPTION
- Non-ASCII filenames caused fetch to throw before the request fired - showing a silent upload error with nothing in server logs
- Fix: encodeURIComponent the filename on the client before setting the header and decode on the server
- Applied to both attachment and avatar upload endpoints