### PR TITLE
fix: sync Editor editable state with readOnly prop

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -457,6 +457,17 @@ export default function Editor({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // useEditor is created once (empty deps below), so keep the latest callbacks
+  // in refs to avoid the editor capturing stale closures on re-render.
+  const onChangeRef = useRef(onChange);
+  const onBlurRef = useRef(onBlur);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+  useEffect(() => {
+    onBlurRef.current = onBlur;
+  }, [onBlur]);
+
   const editor = useEditor(
     {
       extensions: [
@@ -553,7 +564,7 @@ export default function Editor({
         ...(enableYouTubeEmbed ? [YouTubeNode] : []),
       ],
       content,
-      onUpdate: ({ editor }) => onChange?.(editor.getHTML()),
+      onUpdate: ({ editor }) => onChangeRef.current?.(editor.getHTML()),
       onBlur: ({ event }) => {
         if (
           document
@@ -563,7 +574,7 @@ export default function Editor({
           return;
         // Only trigger onBlur if the click was outside both the editor and menu
         if (!containerRef.current?.contains(event.relatedTarget as Node)) {
-          onBlur?.();
+          onBlurRef.current?.();
         }
       },
       editorProps: {
@@ -586,6 +597,16 @@ export default function Editor({
       editor.commands.setContent(safeContent, false);
     }
   }, [content, editor]);
+
+  // useEditor captures `readOnly` once at creation time (empty deps above), so
+  // explicitly sync `editable` when the prop changes. Without this the editor
+  // gets stuck read-only when `readOnly` flips from true to false after mount
+  // (e.g. card permissions resolving slower than the card data on first load).
+  useEffect(() => {
+    if (!editor) return;
+    if (editor.isEditable === !readOnly) return;
+    editor.setEditable(!readOnly);
+  }, [editor, readOnly]);
 
   return (
     <div ref={containerRef}>


### PR DESCRIPTION
## Description

The rich-text `Editor` component (used for card descriptions) creates its Tiptap instance once via `useEditor` with an empty dependency array. This means:

1. `editable: !readOnly` is captured at mount time and never updated.
2. `onChange` / `onBlur` are frozen as the first-render closures.

In `CardPage`, the description `Editor` mounts as soon as the card query resolves — but the permissions query is usually still in-flight at that point. So on first render `readOnly={true}` and the handlers are `undefined`. When permissions resolve a moment later and `canEdit` flips to `true`, the `Editor` never becomes editable — leaving the description permanently stuck read-only, even for workspace admins.

Refreshing the page sometimes "fixes" it because cached permission state resolves faster on subsequent loads. This explains why the issue is intermittent and hard to reproduce on a fast connection with a warm cache.

### Why this is a real oversight

The existing `PlainTextEditor.tsx` already uses the exact pattern this PR applies:
- Refs for callbacks (`onChangeRef`, `onBlurRef`, etc.)
- `useEffect` syncing `editor.setEditable(!readOnly)` when the prop changes

It just never got ported to `Editor.tsx`. `Comment.tsx` sidesteps the issue by mounting two separate `<Editor>` instances behind an `isEditing` ternary, so `readOnly` never mutates on a live instance — but `CardPage` mounts a single `Editor` whose `readOnly` prop flips from `true` → `false`, which is where this bites.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes (no UI changes)

## Verification

- `Editor.tsx` typechecks clean (no new TS errors vs. HEAD)
- Diff is minimal: 1 file, +23 / -2
- Fix mirrors the proven pattern in `PlainTextEditor.tsx`

## Linked issue

Closes https://github.com/kanbn/kan/issues/522

## Notes for reviewer

- Did not re-run prettier on the whole file (it would have produced ~80 lines of unrelated formatting noise from pre-existing issues in `Editor.tsx`). Only the fix lines are touched.
- The `Placeholder` plugin config also captures `readOnly` at creation time and won't show its hint text after `setEditable(true)`. Not addressed here — it's cosmetic and would require extension reconfiguration. Happy to follow up if desired.
