### PR TITLE
feat: refine card activity feed controls by separating notes/comments

### DIFF
--- a/apps/web/src/views/card/components/ActivityList.tsx
+++ b/apps/web/src/views/card/components/ActivityList.tsx
@@ -2,7 +2,7 @@ import type { Locale as DateFnsLocale } from "date-fns";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { format, formatDistanceToNow, isSameYear } from "date-fns";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   HiOutlineArrowLeft,
   HiOutlineArrowRight,
@@ -368,16 +368,23 @@ const getActivityIcon = (
 
 const ACTIVITIES_PAGE_SIZE = 20;
 
+export type ActivityFeedFilter = "all" | "activity" | "comments";
+export type ActivityFeedSortOrder = "desc" | "asc";
+
 const ActivityList = ({
   cardPublicId,
   isLoading: cardIsLoading,
   isAdmin,
   isViewOnly,
+  filter = "all",
+  sortOrder = "desc",
 }: {
   cardPublicId: string;
   isLoading: boolean;
   isAdmin?: boolean;
   isViewOnly?: boolean;
+  filter?: ActivityFeedFilter;
+  sortOrder?: ActivityFeedSortOrder;
 }) => {
   const { dateLocale } = useLocalisation();
   const { data: sessionData } = authClient.useSession();
@@ -489,9 +496,31 @@ const ActivityList = ({
   const isLoading =
     cardIsLoading || (isFetchingFirst && allActivities.length === 0);
 
+  const filteredActivities = useMemo(
+    () =>
+      allActivities.filter((activity) => {
+        if (filter === "all") return true;
+        if (filter === "comments") {
+          return activity.type === "card.updated.comment.added";
+        }
+        return activity.type !== "card.updated.comment.added";
+      }),
+    [allActivities, filter],
+  );
+
+  const sortedActivities = useMemo(() => {
+    const newestFirst = [...filteredActivities].sort((a, b) => {
+      const timeA = new Date(a.createdAt).getTime();
+      const timeB = new Date(b.createdAt).getTime();
+      return timeB - timeA;
+    });
+
+    return sortOrder === "desc" ? newestFirst : [...newestFirst].reverse();
+  }, [filteredActivities, sortOrder]);
+
   return (
     <div className="flex flex-col space-y-4 pt-4">
-      {allActivities.map((activity, index) => {
+      {sortedActivities.map((activity, index) => {
         const activityText = getActivityText({
           type: activity.type,
           toTitle: activity.toTitle,
@@ -549,7 +578,7 @@ const ActivityList = ({
                 )}
                 isLoading={isLoading}
               />
-              {index !== allActivities.length - 1 && (
+              {index !== sortedActivities.length - 1 && (
                 <div className="absolute bottom-[-14px] left-1/2 top-[30px] w-0.5 -translate-x-1/2 bg-light-600 dark:bg-dark-600" />
               )}
             </div>

--- a/apps/web/src/views/card/components/ActivityList.tsx
+++ b/apps/web/src/views/card/components/ActivityList.tsx
@@ -2,7 +2,7 @@ import type { Locale as DateFnsLocale } from "date-fns";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { format, formatDistanceToNow, isSameYear } from "date-fns";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   HiOutlineArrowLeft,
   HiOutlineArrowRight,
@@ -398,6 +398,14 @@ const ActivityList = ({
   const isFullyExpandedRef = useRef(false);
   const lastDataUpdatedAtRef = useRef<number | null>(null);
 
+  // Reset accumulated activities when filter or sortOrder changes
+  useEffect(() => {
+    setAllActivities([]);
+    setHasMore(true);
+    isFullyExpandedRef.current = false;
+    lastDataUpdatedAtRef.current = null;
+  }, [filter, sortOrder]);
+
   const {
     data: firstPageData,
     isFetching: isFetchingFirst,
@@ -406,6 +414,8 @@ const ActivityList = ({
     {
       cardPublicId,
       limit: ACTIVITIES_PAGE_SIZE,
+      filter,
+      sortOrder,
     },
     {
       enabled: !!cardPublicId && cardPublicId.length >= 12,
@@ -434,6 +444,8 @@ const ActivityList = ({
               cardPublicId,
               limit: ACTIVITIES_PAGE_SIZE,
               cursor: nextCursor,
+              filter,
+              sortOrder,
             });
 
             const existingIds = new Set(
@@ -460,7 +472,7 @@ const ActivityList = ({
         }
       }
     }
-  }, [firstPageData, dataUpdatedAt, cardPublicId, utils.card.getActivities]);
+  }, [firstPageData, dataUpdatedAt, cardPublicId, filter, sortOrder, utils.card.getActivities]);
 
   const handleLoadMore = async () => {
     if (isLoadingMore || !hasMore || allActivities.length === 0) return;
@@ -475,6 +487,8 @@ const ActivityList = ({
         cardPublicId,
         limit: ACTIVITIES_PAGE_SIZE,
         cursor: nextCursor,
+        filter,
+        sortOrder,
       });
 
       const existingIds = new Set(allActivities.map((a) => a.publicId));
@@ -496,31 +510,9 @@ const ActivityList = ({
   const isLoading =
     cardIsLoading || (isFetchingFirst && allActivities.length === 0);
 
-  const filteredActivities = useMemo(
-    () =>
-      allActivities.filter((activity) => {
-        if (filter === "all") return true;
-        if (filter === "comments") {
-          return activity.type === "card.updated.comment.added";
-        }
-        return activity.type !== "card.updated.comment.added";
-      }),
-    [allActivities, filter],
-  );
-
-  const sortedActivities = useMemo(() => {
-    const newestFirst = [...filteredActivities].sort((a, b) => {
-      const timeA = new Date(a.createdAt).getTime();
-      const timeB = new Date(b.createdAt).getTime();
-      return timeB - timeA;
-    });
-
-    return sortOrder === "desc" ? newestFirst : [...newestFirst].reverse();
-  }, [filteredActivities, sortOrder]);
-
   return (
     <div className="flex flex-col space-y-4 pt-4">
-      {sortedActivities.map((activity, index) => {
+      {allActivities.map((activity, index) => {
         const activityText = getActivityText({
           type: activity.type,
           toTitle: activity.toTitle,
@@ -578,7 +570,7 @@ const ActivityList = ({
                 )}
                 isLoading={isLoading}
               />
-              {index !== sortedActivities.length - 1 && (
+              {index !== allActivities.length - 1 && (
                 <div className="absolute bottom-[-14px] left-1/2 top-[30px] w-0.5 -translate-x-1/2 bg-light-600 dark:bg-dark-600" />
               )}
             </div>

--- a/apps/web/src/views/card/index.tsx
+++ b/apps/web/src/views/card/index.tsx
@@ -3,11 +3,12 @@ import { useRouter } from "next/router";
 import { t } from "@lingui/core/macro";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { HiXMark } from "react-icons/hi2";
+import { HiMiniBarsArrowDown, HiMiniBarsArrowUp, HiXMark } from "react-icons/hi2";
 import { IoChevronForwardSharp } from "react-icons/io5";
 
 import { authClient } from "@kan/auth/client";
 
+import type { ActivityFeedFilter } from "./components/ActivityList";
 import Avatar from "~/components/Avatar";
 import Editor from "~/components/Editor";
 import FeedbackModal from "~/components/FeedbackModal";
@@ -45,6 +46,8 @@ interface FormValues {
   title: string;
   description: string;
 }
+
+type ActivityFeedSortOrderLocal = "desc" | "asc";
 
 export function CardRightPanel({ isTemplate }: { isTemplate?: boolean }) {
   const router = useRouter();
@@ -180,6 +183,10 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
   const [activeChecklistForm, setActiveChecklistForm] = useState<string | null>(
     null,
   );
+  const [activityFeedFilter, setActivityFeedFilter] =
+    useState<ActivityFeedFilter>("all");
+  const [activityFeedSortOrder, setActivityFeedSortOrder] =
+    useState<ActivityFeedSortOrderLocal>("desc");
 
   const cardId = Array.isArray(router.query.cardId)
     ? router.query.cardId[0]
@@ -472,17 +479,92 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
                     </>
                   )}
                   <div className="border-t-[1px] border-light-300 pt-12 dark:border-dark-300">
-                    <h2 className="text-md pb-4 font-medium text-light-1000 dark:text-dark-1000">
-                      {t`Activity`}
-                    </h2>
+                    <div className="mb-4 flex items-center justify-between border-b border-light-300 dark:border-dark-300">
+                      <nav
+                        aria-label={t`Activity tabs`}
+                        className="-mb-px flex items-center gap-5"
+                      >
+                        {(
+                          [
+                            { key: "all", label: t`All` },
+                            { key: "activity", label: t`Activity` },
+                            { key: "comments", label: t`Comments` },
+                          ] as const
+                        ).map((tab) => {
+                          const isActive = activityFeedFilter === tab.key;
+                          return (
+                            <button
+                              key={tab.key}
+                              type="button"
+                              role="tab"
+                              aria-selected={isActive}
+                              onClick={() => setActivityFeedFilter(tab.key)}
+                              className={`whitespace-nowrap border-b-2 pb-2 text-sm font-semibold transition-colors focus:outline-none ${
+                                isActive
+                                  ? "border-light-1000 text-light-1000 dark:border-dark-1000 dark:text-dark-1000"
+                                  : "border-transparent text-light-900 hover:border-light-950 hover:text-light-950 dark:text-dark-900 dark:hover:border-white/20 dark:hover:text-dark-950"
+                              }`}
+                            >
+                              {tab.label}
+                            </button>
+                          );
+                        })}
+                      </nav>
+                      <div className="mb-2 inline-flex items-center gap-2">
+                        <span className="text-xs font-medium text-light-900 dark:text-dark-700">
+                          {t`Sort`}
+                        </span>
+                        <div className="inline-flex items-center gap-1 rounded-md border border-light-400 p-0.5 dark:border-dark-300">
+                          {(
+                            [
+                              {
+                                key: "asc",
+                                label: t`Sort oldest to newest`,
+                                icon: HiMiniBarsArrowUp,
+                              },
+                              {
+                                key: "desc",
+                                label: t`Sort newest to oldest`,
+                                icon: HiMiniBarsArrowDown,
+                              },
+                            ] as const
+                          ).map((sortOption) => {
+                            const isActive =
+                              activityFeedSortOrder === sortOption.key;
+                            const Icon = sortOption.icon;
+
+                            return (
+                              <button
+                                key={sortOption.key}
+                                type="button"
+                                aria-label={sortOption.label}
+                                aria-pressed={isActive}
+                                onClick={() =>
+                                  setActivityFeedSortOrder(sortOption.key)
+                                }
+                                className={`rounded p-1.5 transition-colors ${
+                                  isActive
+                                    ? "bg-light-300 text-light-1000 dark:bg-dark-300 dark:text-dark-1000"
+                                    : "text-light-800 hover:bg-light-200 dark:text-dark-700 dark:hover:bg-dark-200"
+                                }`}
+                              >
+                                <Icon className="h-3.5 w-3.5" />
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    </div>
                     <div>
                       <ActivityList
                         cardPublicId={cardId}
                         isLoading={!card}
                         isAdmin={workspace.role === "admin"}
+                        filter={activityFeedFilter}
+                        sortOrder={activityFeedSortOrder}
                       />
                     </div>
-                    {!isTemplate && (
+                    {!isTemplate && activityFeedFilter !== "activity" && (
                       <div className="mt-6">
                         <NewCommentForm
                           cardPublicId={cardId}

--- a/apps/web/src/views/card/index.tsx
+++ b/apps/web/src/views/card/index.tsx
@@ -479,7 +479,7 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
                     </>
                   )}
                   <div className="border-t-[1px] border-light-300 pt-12 dark:border-dark-300">
-                    <div className="mb-4 flex items-center justify-between border-b border-light-300 dark:border-dark-300">
+                    <div className="mb-4 flex items-center justify-between">
                       <nav
                         aria-label={t`Activity tabs`}
                         className="-mb-px flex items-center gap-5"
@@ -511,9 +511,6 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
                         })}
                       </nav>
                       <div className="mb-2 inline-flex items-center gap-2">
-                        <span className="text-xs font-medium text-light-900 dark:text-dark-700">
-                          {t`Sort`}
-                        </span>
                         <div className="inline-flex items-center gap-1 rounded-md border border-light-400 p-0.5 dark:border-dark-300">
                           {(
                             [

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -751,6 +751,8 @@ export const cardRouter = createTRPCRouter({
         cardPublicId: z.string().min(12),
         limit: z.number().min(1).max(100).optional().default(10),
         cursor: z.string().datetime().optional(), // ISO datetime string
+        filter: z.enum(["all", "activity", "comments"]).optional().default("all"),
+        sortOrder: z.enum(["asc", "desc"]).optional().default("desc"),
       }),
     )
     .output(
@@ -791,6 +793,7 @@ export const cardRouter = createTRPCRouter({
         {
           limit: input.limit,
           cursor,
+          filter: input.filter,
         },
       );
 
@@ -828,8 +831,13 @@ export const cardRouter = createTRPCRouter({
 
       const mergedActivities = mergeActivities(activitiesWithAvatarUrls);
 
+      const sortedActivities =
+        input.sortOrder === "asc"
+          ? mergedActivities
+          : [...mergedActivities].reverse();
+
       return {
-        activities: mergedActivities,
+        activities: sortedActivities,
         hasMore: result.hasMore,
         nextCursor: result.nextCursor?.toISOString() ?? null,
       };

--- a/packages/db/src/repository/cardActivity.repo.ts
+++ b/packages/db/src/repository/cardActivity.repo.ts
@@ -1,4 +1,14 @@
-import { and, asc, count, eq, gt, inArray, isNull, or } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  notInArray,
+  or,
+} from "drizzle-orm";
 
 import type { dbClient } from "@kan/db/client";
 import type { ActivityType } from "@kan/db/schema";
@@ -101,16 +111,24 @@ export const bulkCreate = async (
   return results;
 };
 
+const COMMENT_TYPES = [
+  "card.updated.comment.added",
+  "card.updated.comment.updated",
+  "card.updated.comment.deleted",
+] as const;
+
 export const getPaginatedActivities = async (
   db: dbClient,
   cardId: number,
   options?: {
     limit?: number;
     cursor?: Date; // createdAt cursor for pagination
+    filter?: "all" | "activity" | "comments";
   },
 ) => {
   const limit = options?.limit ?? 20;
   const cursor = options?.cursor;
+  const filter = options?.filter ?? "all";
 
   const validComments = await db
     .select({ id: comments.id })
@@ -118,6 +136,13 @@ export const getPaginatedActivities = async (
     .where(and(eq(comments.cardId, cardId), isNull(comments.deletedAt)));
 
   const validCommentIds = validComments.map((comment) => comment.id);
+
+  const filterCondition =
+    filter === "comments"
+      ? inArray(cardActivities.type, [...COMMENT_TYPES])
+      : filter === "activity"
+        ? notInArray(cardActivities.type, [...COMMENT_TYPES])
+        : undefined;
 
   const activities = await db.query.cardActivities.findMany({
     columns: {
@@ -140,6 +165,7 @@ export const getPaginatedActivities = async (
         isNull(cardActivities.commentId),
         inArray(cardActivities.commentId, validCommentIds),
       ),
+      filterCondition,
     ),
     with: {
       fromList: {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->
Separates activity from comments/notes for better organization and sorting. This improves the card view by giving users a dedicated activity feed that's distinct from user comments and notes, making it easier to track changes and updates. Additionally the activies can be sorted.

## Type of change

- [ ] Bug fix
- [x] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes

## Linked issue

Closes #525 <!-- issue number -->

## Screenshots

[Short Video of functionality](https://app.screencast.com/03xNLiOZNVGSb)



> **Feature PRs without a linked, approved issue will be closed without review.**
> Open or comment on a [feature request](https://github.com/kanbn/kan/issues/new?template=feature_request.md) first and wait for maintainer approval before building.
