### PR TITLE
fix(mcp): map comment content field for Kan API compatibility

### DIFF
--- a/packages/mcp/src/tools/card.ts
+++ b/packages/mcp/src/tools/card.ts
@@ -119,7 +119,7 @@ export function registerCardTools(server: McpServer): void {
       content: z.string().describe("Comment text"),
     },
     async ({ cardPublicId, content }) => {
-      const data = await kanRequest("POST", `/cards/${cardPublicId}/comments`, { content });
+      const data = await kanRequest("POST", `/cards/${cardPublicId}/comments`, { comment: content });
       return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
     },
   );
@@ -136,7 +136,7 @@ export function registerCardTools(server: McpServer): void {
       const data = await kanRequest(
         "PUT",
         `/cards/${cardPublicId}/comments/${commentPublicId}`,
-        { content },
+        { comment: content },
       );
       return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
     },


### PR DESCRIPTION
## Description

The MCP tools `add_card_comment` and `update_card_comment` send `{ content }` to the Kan API, but the API expects `{ comment }`. This causes a **400 Bad Request** with `"comment": ["Required"]` on every comment create/update attempt.

## Changes

- `packages/mcp/src/tools/card.ts`: Changed `{ content }` → `{ comment: content }` in both:
  - `add_card_comment` (POST `/cards/:id/comments`)
  - `update_card_comment` (PUT `/cards/:id/comments/:commentId`)

The `delete_card_comment` tool was already correct (no body).

## Testing

Tested against a live Kan instance:
- `add_card_comment` — ✅ comment created successfully
- `update_card_comment` — ✅ comment updated (field mapping applied, not tested via MCP tool before fix but same pattern)
- `update_card` (description) — ✅ works fine, unrelated field

Co-Authored-By: Craft Agent <agents-noreply@craft.do>