### PR TITLE
fix(editor): don't throw in suggestion onExit when no popup was created

### DIFF
--- a/apps/web/src/components/Editor.tsx
+++ b/apps/web/src/components/Editor.tsx
@@ -180,13 +180,13 @@ const RenderSuggestions = () => {
 
       if (!props.clientRect) return;
 
-      popup[0]?.setProps({
+      popup?.[0]?.setProps({
         getReferenceClientRect: props.clientRect,
       });
     },
     onKeyDown(props: SuggestionKeyDownProps): boolean {
       if (props.event.key === "Escape") {
-        popup[0]?.hide();
+        popup?.[0]?.hide();
         return true;
       }
 
@@ -199,7 +199,7 @@ const RenderSuggestions = () => {
       );
     },
     onExit() {
-      popup[0]?.destroy();
+      popup?.[0]?.destroy();
       reactRenderer.destroy();
     },
   };
@@ -308,11 +308,11 @@ const renderMentionSuggestions = () => {
     onUpdate(props: any) {
       reactRenderer.updateProps(props);
       if (!props.clientRect) return;
-      popup[0]?.setProps({ getReferenceClientRect: props.clientRect });
+      popup?.[0]?.setProps({ getReferenceClientRect: props.clientRect });
     },
     onKeyDown(props: SuggestionKeyDownProps) {
       if (props.event.key === "Escape") {
-        popup[0]?.hide();
+        popup?.[0]?.hide();
         return true;
       }
       return (
@@ -324,7 +324,7 @@ const renderMentionSuggestions = () => {
       );
     },
     onExit() {
-      popup[0]?.destroy();
+      popup?.[0]?.destroy();
       reactRenderer.destroy();
     },
   };


### PR DESCRIPTION
## Description

Opening a card can take the whole page down with `Application error: a client-side exception has occurred`. Console:

```
TypeError: Cannot read properties of undefined (reading '0')
    at Object.onExit
    at Object.destroy
    at rk.destroyPluginViews
    at rk.updatePluginViews
    at rk.updateStateInner
    at rk.updateState
    at ow.registerPlugin
```

In `RenderSuggestions` and `renderMentionSuggestions`, `popup` is declared but only assigned at the very end of `onStart`, after the `if (!props.clientRect) return` bail-out. If that early return happens, `popup` is still `undefined` when `onExit` runs, and `popup[0]?.destroy()` throws — the optional chaining sits on the tippy instance, not on the array.

How I ran into it: a card whose description ends with something that looks like a mention (my last line was `… · автор @anatoly.r`). The read-only editor leaves the caret at the end of the doc, so the suggestion plugin is active on mount, `onStart` runs without a client rect and skips creating the popup. Then the bubble menu mounts, `registerPlugin` rebuilds the plugin views, `onExit` fires on the empty `popup` and the page dies. Same for a document whose last line starts with `/`. Moving the mention away from the end of the text is enough to avoid it, which is what I did as a stopgap on my instance (0.6.0, code identical to main).

The fix moves the optional chaining onto the array in all six places (`onUpdate`, `onKeyDown`, `onExit` of both renderers), so the handlers quietly do nothing when there is no popup instead of throwing. `reactRenderer` is always assigned before the early return, so it is left as is.

I have not spun up the full stack against this branch — the repro needs a card with the right trailing text — but the change is a null guard on an already-optional call.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [ ] I have tested my changes locally
- [ ] I have included screenshots for any UI changes

## Linked issue

No issue — bug fix, no visual change.
