### PR TITLE
fix: accept empty slug in workspace.create

### DIFF
--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -205,12 +205,18 @@ export const workspaceRouter = createTRPCRouter({
       z.object({
         name: z.string().min(1).max(64),
         description: z.string().max(280).optional(),
+        // NewWorkspaceForm submits slug as "" when the user leaves the URL
+        // field empty (its own schema allows .or(z.literal(""))), so the
+        // server must accept the empty string too and fall back to the
+        // generated public id below — otherwise self-hosted workspace
+        // creation fails validation whenever the slug is left blank.
         slug: z
           .string()
           .min(3)
           .max(64)
           .regex(/^(?![-]+$)[a-zA-Z0-9-]+$/)
-          .optional(),
+          .optional()
+          .or(z.literal("")),
       }),
     )
     .output(workspaceCreateResponseSchema)
@@ -233,7 +239,9 @@ export const workspaceRouter = createTRPCRouter({
       }
 
       const workspacePublicId = generateUID();
-      const workspaceSlug = input.slug ?? workspacePublicId;
+      // `||` (not `??`): an empty-string slug must also fall back to the
+      // generated public id.
+      const workspaceSlug = input.slug || workspacePublicId;
 
       if (input.slug) {
         const reservedOrPremiumWorkspaceSlug =


### PR DESCRIPTION
## Problem
`NewWorkspaceForm` submits `slug: ""` when the URL field is left blank — its client-side schema explicitly allows this (`.optional().or(z.literal("")))`. The server-side input schema of `workspace.create` however only allows `undefined` or a valid 3–64 char slug, so the mutation always fails validation with `too_small` + regex errors on `path: ["slug"]`.

On self-hosted instances this means **workspace creation is broken whenever the URL field is left empty** (reproducible on current main; observed on a self-hosted instance pinned to the latest ghcr image).

## Fix
- Mirror the client schema on the server: `.optional().or(z.literal(""))`.
- Fall back to the generated public id with `input.slug || workspacePublicId` (`??` keeps the empty string).

The existing `if (input.slug)` guards (cloud check, availability/reserved checks) already treat `""` as absent, so no further changes are needed.