### PR TITLE
perf: improvements to build time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,9 @@ jobs:
   build:
     concurrency:
       group: docker-build-${{ github.ref }}
-      cancel-in-progress: true
+      # Only supersede PR builds. Branch and tag builds publish artifacts and
+      # are allowed to finish.
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,29 +43,36 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Both are required: fetch-depth alone does not pull tags, and the
+          # version step below degrades to a bare sha without them.
           fetch-depth: 0
+          fetch-tags: true
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
-        with:
-          cosign-release: "v2.2.4"
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Register binfmt handlers. Still required: the migrate image is built
+      # per-architecture and its arm64 half runs emulated.
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +82,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -87,7 +96,7 @@ jobs:
 
       - name: Extract Docker metadata (migrate)
         id: meta-migrate
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.MIGRATE_IMAGE_NAME }}
           tags: |
@@ -139,7 +148,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: apps/web/Dockerfile
@@ -149,12 +158,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped separately from the migrate build: a shared scope means each
+          # export overwrites the other's manifest and neither ever hits.
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
 
       - name: Build and push migrate Docker image
         id: build-and-push-migrate
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: apps/web/Dockerfile
@@ -165,8 +176,8 @@ jobs:
           labels: ${{ steps.meta-migrate.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=migrate
+          cache-to: type=gha,mode=max,scope=migrate
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,33 +6,30 @@ ARG DISTROLESS_NODE_IMAGE=gcr.io/distroless/nodejs${NODE_VERSION}-debian12
 # ============================================
 # Stage 1: Alpine base with pnpm and turbo
 # ============================================
-FROM node:${NODE_VERSION}-alpine AS alpine
+# Pinned to $BUILDPLATFORM so the JS toolchain never runs under QEMU. Every
+# stage derived from `alpine` (pruner, deps, builder) is therefore native, and
+# only the final per-arch stages pay emulation. See .github/docker-build-performance.md.
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION}-alpine AS alpine
+
+# Absolute path: BuildKit does not expand `~` in cache mount targets, so the
+# store dir and the mount target must both be literal for the mount to work.
+ENV PNPM_STORE=/pnpm/store
+
 RUN apk update && \
     apk add --no-cache libc6-compat && \
     rm -rf /var/cache/apk/* /tmp/* || true && \
     corepack enable && \
     corepack prepare pnpm@9.14.2 --activate && \
     npm install turbo@2.3.1 --global && \
-    pnpm config set store-dir ~/.pnpm-store
+    pnpm config set store-dir "$PNPM_STORE"
 
 # ============================================
 # Stage 2: Prune the monorepo
 # ============================================
 FROM alpine AS pruner
 
-RUN apk add --no-cache git
-
 WORKDIR /app
 COPY . .
-
-# Generate version from git (fallback if APP_VERSION not provided)
-RUN git fetch --tags --unshallow 2>/dev/null || git fetch --tags 2>/dev/null || true && \
-    AUTO_VERSION=$(git describe --tags --always --long 2>/dev/null | \
-    sed -E 's/^v?([0-9]+\.[0-9]+\.[0-9]+)-[0-9]+-g([a-f0-9]{7}).*/\1+\2/' | \
-    sed 's/^v//' || \
-    git rev-parse --short HEAD 2>/dev/null | head -c 7 || \
-    echo "unknown") && \
-    echo "$AUTO_VERSION" > /app/AUTO_VERSION
 
 RUN turbo prune --scope=@kan/web --scope=@kan/db --docker
 
@@ -47,37 +44,44 @@ COPY --from=pruner /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
 COPY --from=pruner /app/out/json/ .
 
 ENV CI=true
-RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
 
 # ============================================
 # Stage 4: Build the web application
 # ============================================
 FROM alpine AS builder
-ARG APP_VERSION
+# Empty default: an unstamped build hides the version row rather than linking
+# to a release tag that does not exist.
+ARG APP_VERSION=""
 
 WORKDIR /app
 
 COPY --from=deps /app/ ./
 COPY --from=pruner /app/out/full/ .
-COPY --from=pruner /app/AUTO_VERSION /tmp/AUTO_VERSION
 
 # Force standalone output for production Docker image
 ENV NEXT_PUBLIC_USE_STANDALONE_OUTPUT=true
 ENV CI=true
 
-RUN VERSION="${APP_VERSION:-$(cat /tmp/AUTO_VERSION 2>/dev/null | tr -d '\n\r' || echo 'unknown')}" && \
-    NEXT_PUBLIC_APP_VERSION="$VERSION" pnpm build --filter=@kan/web
+RUN --mount=type=cache,id=next-cache,target=/app/apps/web/.next/cache,sharing=locked \
+    --mount=type=cache,id=turbo-cache,target=/app/.turbo,sharing=locked \
+    NEXT_PUBLIC_APP_VERSION="$APP_VERSION" pnpm build --filter=@kan/web
 
 # ============================================
 # Stage 5: Migration image (run-once container)
 # ============================================
+# Deliberately not pinned to $BUILDPLATFORM: drizzle-kit pulls esbuild, which
+# resolves a prebuilt binary per platform. Cross-compiling would put
+# @esbuild/linux-x64 in the arm64 image.
 FROM node:${NODE_VERSION}-alpine AS migrate
 WORKDIR /db
 
 COPY packages/db/drizzle.config.ts ./drizzle.config.ts
 COPY packages/db/migrations/ ./migrations/
 
-RUN npm init -y && \
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm,sharing=locked \
+    npm init -y && \
     npm install drizzle-kit drizzle-orm pg --save-exact && \
     # Strip unnecessary files from node_modules
     find node_modules -type f \( \
@@ -95,7 +99,7 @@ RUN npm init -y && \
       -name 'tsconfig*.json' \
     \) -delete && \
     find node_modules -type d -empty -delete && \
-    rm -rf /root/.npm /tmp/*
+    rm -rf /tmp/*
 
 CMD ["npx", "drizzle-kit", "migrate"]
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   },
   "prettier": "@kan/prettier-config",
   "pnpm": {
+    "supportedArchitectures": {
+      "os": ["linux", "current"],
+      "cpu": ["x64", "arm64", "current"],
+      "libc": ["glibc", "musl", "current"]
+    },
     "overrides": {
       "@types/minimatch": "npm:minimatch@*",
       "@types/glob": "npm:@types/glob@^8.1.0"


### PR DESCRIPTION
The Docker workflow was slow for two reasons, and both of them are easy to miss unless you read the build log properly. The arm64 half of the web image was getting built under QEMU emulation, and the layer cache never hit anything, so every run rebuilt from scratch.

The arm64 Next build went from `14m01.956s` to `1m36.583s` on the same machine, same output, still two multi-arch images signed with cosign.

---

**What was actually wrong**

- BuildKit only advertises x86 platforms, so every arm64 stage went through the host binfmt handlers. `pnpm install` was 5.5x slower, `turbo run build` 6.2x slower.
- Both build steps wrote to the same gha cache scope, so each one overwrote the other's manifest. A cache got imported every run and then everything rebuilt anyway, zero `CACHED` steps.
- The pnpm store mount pointed at `~/.pnpm-store`. BuildKit doesn't expand `~` in mount targets but pnpm does, so the two never pointed at the same directory and the mount did nothing. Every run logged `resolved 0, reused 0, downloaded 111`.

---

**The fix**

The base stage is pinned to `$BUILDPLATFORM` now, so `pruner`, `deps` and `builder` all run native no matter the target arch. Only the final distroless stage is per arch and that one just copies plain JS, which is already how the image worked, it builds on musl and runs on glibc.

`migrate` is left per arch on purpose. drizzle-kit pulls esbuild, which has a per platform binary, so cross compiling it would drop `@esbuild/linux-x64` into the arm64 image. It stays emulated at about 71s, which is worth it.

Everything else is cache and cleanup:

- pnpm store mount fixed with an absolute path, plus new cache mounts for `.next/cache`, `.turbo` and npm.
- gha cache split into `scope=web` and `scope=migrate` so the two builds stop fighting over the same key.
- QEMU action gets called explicitly now. It only worked before cause the runner happened to have binfmt set up, and `migrate` still needs arm64 for real.
- Actions bumped to current SHA pinned releases, which drops the `cosign-release: "v2.2.4"` pin since v4 picks its own default.
- Git version logic taken out of `pruner`. `.dockerignore` excludes `.git`, so every git call was already doing nothing and the version comes in as a build arg anyway. `fetch-tags: true` added on checkout, without it the version falls back to a bare sha and the version link in the user menu points at a release tag that doesn't exist.
- Only PR builds get cancelled by the concurrency group now, branch and tag builds publish things so they get to finish.

---

**The trade-off**

Cross compiling broke sharp, which is what the `supportedArchitectures` change in `package.json` is for. sharp picks a prebuilt binary per platform, so building `deps` on amd64 put x64 binaries into the arm64 image, and Next has image optimization on, so that would have died at runtime. The emulated build only got it right by accident.

Installing every Linux variant fixes it but adds about 51MB to the image. If that's too much, the other option is a small per arch stage that installs only sharp, but the Dockerfile gets messier. Any future dep with a native addon needs the same treatment, that's just what you get with cross compiling.

---

**Checked**

`docker build --check` is clean on both targets. The arm64 image reports `linux/arm64` and sharp loads in it, the migrate image has `@esbuild/linux-arm64`, and `pnpm install --frozen-lockfile` still passes with the lockfile unchanged.

Timings were on an 8 core machine and `ubuntu-latest` has 4, so the absolute numbers will differ but the ratios shouldn't. Splitting web and migrate into parallel jobs would save another couple of minutes, but that's not in this PR.