### PR TITLE
fix: create empty boards through MCP

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc --noEmit false --declaration false --emitDeclarationOnly false --outDir dist",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@kan/tsconfig": "workspace:*",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/mcp/src/tools/board.test.ts
+++ b/packages/mcp/src/tools/board.test.ts
@@ -1,0 +1,42 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { kanRequest } from "../client.js";
+import { registerBoardTools } from "./board.js";
+
+vi.mock("../client.js", () => ({
+  kanRequest: vi.fn(),
+}));
+
+describe("create_board", () => {
+  it("forwards documented input with the backend-required empty arrays", async () => {
+    const tools = new Map<string, (...args: unknown[]) => unknown>();
+    const server = {
+      tool: (name: string, ...args: unknown[]) => {
+        tools.set(name, args.at(-1) as (...args: unknown[]) => unknown);
+      },
+    } as unknown as McpServer;
+    const request = vi.mocked(kanRequest);
+    request.mockResolvedValueOnce({ publicId: "board-123456" });
+
+    registerBoardTools(server);
+
+    await tools.get("create_board")?.({
+      workspacePublicId: "workspace-123456",
+      name: "Private board",
+      visibility: "private",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "POST",
+      "/workspaces/workspace-123456/boards",
+      {
+        name: "Private board",
+        slug: undefined,
+        visibility: "private",
+        lists: [],
+        labels: [],
+      },
+    );
+  });
+});

--- a/packages/mcp/src/tools/board.ts
+++ b/packages/mcp/src/tools/board.ts
@@ -106,6 +106,8 @@ export function registerBoardTools(server: McpServer): void {
         name,
         slug,
         visibility,
+        lists: [],
+        labels: [],
       });
       return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
     },

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.0.0)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.1)
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary
- supply empty `lists` and `labels` arrays required by the Kan board-create API while preserving the minimal MCP tool input
- add an MCP tool contract test for the forwarded payload

Cross-references https://github.com/mikkelvalentinsorensen/MikValSor.HomeLab.Docker01/issues/259.