### PR TITLE
Fix: boards page heading and tabs are not translated

### DIFF
--- a/apps/web/src/views/boards/index.tsx
+++ b/apps/web/src/views/boards/index.tsx
@@ -5,6 +5,7 @@ import {
   ListboxOptions,
 } from "@headlessui/react";
 import { t } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
 import { useMemo, useState } from "react";
 import {
   HiArrowDownTray,
@@ -26,12 +27,12 @@ import { BoardsList } from "./components/BoardsList";
 import { ImportBoardsForm } from "./components/ImportBoardsForm";
 import { NewBoardForm } from "./components/NewBoardForm";
 
-const boardsTabs = [
-  { key: "boards" as const, label: t`Active` },
-  { key: "archived" as const, label: t`Archived` },
-];
-
 export default function BoardsPage({ isTemplate }: { isTemplate?: boolean }) {
+  useLingui();
+  const boardsTabs = [
+    { key: "boards" as const, label: t`Active` },
+    { key: "archived" as const, label: t`Archived` },
+  ];
   const { openModal, modalContentType, isOpen } = useModal();
   const { workspace } = useWorkspace();
   const [activeTab, setActiveTab] = useState<"boards" | "archived">("boards");
@@ -54,12 +55,12 @@ export default function BoardsPage({ isTemplate }: { isTemplate?: boolean }) {
   return (
     <>
       <PageHead
-        title={t`${isTemplate ? "Templates" : "Boards"} | ${workspace.name ?? t`Workspace`}`}
+        title={t`${isTemplate ? t`Templates` : t`Boards`} | ${workspace.name ?? t`Workspace`}`}
       />
       <div className="m-auto h-full max-w-[1100px] p-8 px-5 md:px-28 md:py-12">
         <div className="relative z-10 mb-8 flex w-full items-center justify-between">
           <h1 className="font-bold tracking-tight text-neutral-900 dark:text-dark-1000 sm:text-[1.2rem]">
-            {t`${isTemplate ? "Templates" : "Boards"}`}
+            {isTemplate ? t`Templates` : t`Boards`}
           </h1>
           <div className="flex gap-2">
             {!isTemplate && (


### PR DESCRIPTION
## Problem

On the boards page, the "Active" / "Archived" tabs and the "Boards" / "Templates" heading always render in English, even when the user selects another language. Translations for all four strings exist in the catalogs.

## Cause

Two separate issues in `views/boards/index.tsx`:

1. The tabs array was a module-level constant. The `t` macro values were computed once at module load, before any locale activates.
2. The heading used `t`${isTemplate ? "Templates" : "Boards"}`` — the ternary passes a raw English string into a placeholder, so the catalog translation never applies.

## Fix

- Move the tabs array into the component and subscribe with `useLingui()`, so the labels re-render after locale activation.
- Translate the heading words directly: `isTemplate ? t`Templates` : t`Boards``. The page title uses the same approach.

No catalog changes are needed — all message ids already exist.

Same bug class as #563, found while testing the Ukrainian translation from #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)