### PR TITLE
fix: use public base URL for login redirects

### DIFF
--- a/apps/web/src/middleware.test.ts
+++ b/apps/web/src/middleware.test.ts
@@ -45,4 +45,18 @@ describe("middleware", () => {
       );
     },
   );
+
+  it("falls back to the request URL when the public URL is malformed", () => {
+    mockedEnv.mockImplementation((key) => {
+      if (key === "NEXT_PUBLIC_BASE_URL") return "kan.example.com";
+      if (key === "NEXT_PUBLIC_KAN_ENV") return "self-hosted";
+    });
+
+    const response = middleware(new NextRequest("http://localhost:3000/"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/login",
+    );
+  });
 });

--- a/apps/web/src/middleware.test.ts
+++ b/apps/web/src/middleware.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from "next/server";
+import { env } from "next-runtime-env";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { middleware } from "./middleware";
+
+vi.mock("next-runtime-env", () => ({
+  env: vi.fn(),
+}));
+
+const mockedEnv = vi.mocked(env);
+
+describe("middleware", () => {
+  beforeEach(() => {
+    mockedEnv.mockReset();
+  });
+
+  it("uses the configured public URL for self-hosted login redirects", () => {
+    mockedEnv.mockImplementation((key) => {
+      if (key === "NEXT_PUBLIC_BASE_URL") return "https://kan.example.com";
+      if (key === "NEXT_PUBLIC_KAN_ENV") return "self-hosted";
+    });
+
+    const response = middleware(new NextRequest("http://localhost:3000/"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://kan.example.com/login",
+    );
+  });
+
+  it.each([undefined, ""])(
+    "falls back to the request URL when the public URL is %s",
+    (publicBaseUrl) => {
+      mockedEnv.mockImplementation((key) => {
+        if (key === "NEXT_PUBLIC_BASE_URL") return publicBaseUrl;
+        if (key === "NEXT_PUBLIC_KAN_ENV") return "self-hosted";
+      });
+
+      const response = middleware(new NextRequest("http://localhost:3000/"));
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe(
+        "http://localhost:3000/login",
+      );
+    },
+  );
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -5,7 +5,11 @@ import { env } from "next-runtime-env";
 export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname === "/") {
     if (env("NEXT_PUBLIC_KAN_ENV") !== "cloud") {
-      const loginUrl = new URL("/login", request.url);
+      const publicBaseUrl = env("NEXT_PUBLIC_BASE_URL");
+      const loginUrl = new URL(
+        "/login",
+        publicBaseUrl?.length ? publicBaseUrl : request.url,
+      );
       return NextResponse.redirect(loginUrl);
     }
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,15 +2,24 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { env } from "next-runtime-env";
 
+function resolveLoginUrl(request: NextRequest) {
+  const publicBaseUrl = env("NEXT_PUBLIC_BASE_URL");
+
+  if (publicBaseUrl?.length) {
+    try {
+      return new URL("/login", publicBaseUrl);
+    } catch {
+      // Runtime-injected values may bypass the build-time environment schema.
+    }
+  }
+
+  return new URL("/login", request.url);
+}
+
 export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname === "/") {
     if (env("NEXT_PUBLIC_KAN_ENV") !== "cloud") {
-      const publicBaseUrl = env("NEXT_PUBLIC_BASE_URL");
-      const loginUrl = new URL(
-        "/login",
-        publicBaseUrl?.length ? publicBaseUrl : request.url,
-      );
-      return NextResponse.redirect(loginUrl);
+      return NextResponse.redirect(resolveLoginUrl(request));
     }
   }
 


### PR DESCRIPTION
## Description

In a self-hosted standalone deployment behind a reverse proxy, Next.js constructs the middleware request URL from the internal listener address. As a result, visiting `/` could redirect users to an internal URL such as `https://localhost:3000/login`, even when the proxy forwards the public host and protocol correctly.

Use the configured `NEXT_PUBLIC_BASE_URL` as the origin for the self-hosted login redirect. This is already Kan's canonical installation URL and is also used by the authentication setup and other absolute links. The request URL remains the fallback when the public base URL is missing, empty, or malformed at runtime.

This deliberately does not derive the redirect target from `Host` or `X-Forwarded-Host`, which would require an explicit trusted-proxy boundary and could otherwise allow host-header-driven redirects.

## Reproduction

Run the standalone server behind a TLS-terminating reverse proxy and request `/` with a public host:

`curl -I -H 'Host: kan.example.com' -H 'X-Forwarded-Proto: https' http://127.0.0.1:3000/`

Before this change, the response points to the internal listener:

`Location: https://localhost:3000/login`

After this change, with `NEXT_PUBLIC_BASE_URL=https://kan.example.com`:

`Location: https://kan.example.com/login`

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [ ] I have included screenshots for any UI changes

## Testing

- `pnpm --filter @kan/web test` — 12 tests passed
- Prettier check for the changed files
- ESLint check for the changed files
- `git diff --check upstream/main...HEAD`
- reproduced against an unmodified standalone build behind forwarded host/protocol headers
- regression coverage for a runtime `NEXT_PUBLIC_BASE_URL` without a URL scheme

## Linked issue

Not applicable: this is a self-hosting bug fix and does not change intended product behavior.
