### PR TITLE
perf: deduplicate avatar URL generation in API responses

### DIFF
--- a/packages/api/src/routers/avatar-urls.test.ts
+++ b/packages/api/src/routers/avatar-urls.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as cardRepo from "@kan/db/repository/card.repo";
+import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
+import * as workspaceRepo from "@kan/db/repository/workspace.repo";
+import { generateAvatarUrl } from "@kan/shared/utils";
+
+import { assertPermission } from "../utils/permissions";
+
+vi.mock("@kan/db/repository/card.repo", () => ({
+  getWorkspaceAndCardIdByCardPublicId: vi.fn(),
+  getWithListAndMembersByPublicId: vi.fn(),
+}));
+vi.mock("@kan/db/repository/cardActivity.repo", () => ({
+  getPaginatedActivities: vi.fn(),
+}));
+vi.mock("@kan/db/repository/cardComment.repo", () => ({}));
+vi.mock("@kan/db/repository/checklist.repo", () => ({}));
+vi.mock("@kan/db/repository/label.repo", () => ({}));
+vi.mock("@kan/db/repository/list.repo", () => ({}));
+vi.mock("@kan/db/repository/subscription.repo", () => ({}));
+vi.mock("@kan/db/repository/workspace.repo", () => ({
+  getByPublicIdWithMembers: vi.fn(),
+}));
+vi.mock("@kan/db/repository/workspaceSlug.repo", () => ({}));
+vi.mock("@kan/db/client", () => ({
+  createDrizzleClient: vi.fn(() => ({})),
+}));
+vi.mock("@kan/auth/server", () => ({
+  initAuth: vi.fn(() => ({ api: {} })),
+}));
+vi.mock("@kan/shared/utils", () => ({
+  generateAttachmentUrl: vi.fn(),
+  generateAvatarUrl: vi.fn(),
+  generateUID: vi.fn(),
+}));
+vi.mock("../utils/notifications", () => ({
+  sendMentionEmails: vi.fn(),
+}));
+vi.mock("../utils/permissions", () => ({
+  assertCanDelete: vi.fn(),
+  assertCanEdit: vi.fn(),
+  assertPermission: vi.fn(),
+}));
+vi.mock("../utils/webhook", () => ({
+  createCardWebhookPayload: vi.fn(() => ({})),
+  sendWebhooksForWorkspace: vi.fn(() => Promise.resolve()),
+}));
+
+const mockGetCard = vi.mocked(cardRepo.getWorkspaceAndCardIdByCardPublicId);
+const mockGetCardWithMembers = vi.mocked(
+  cardRepo.getWithListAndMembersByPublicId,
+);
+const mockGetActivities = vi.mocked(cardActivityRepo.getPaginatedActivities);
+const mockGetWorkspace = vi.mocked(workspaceRepo.getByPublicIdWithMembers);
+const mockGenerateAvatarUrl = vi.mocked(generateAvatarUrl);
+const mockAssertPermission = vi.mocked(assertPermission);
+
+const avatarKey = "avatars/shared.png";
+const signedAvatarUrl = "https://example.com/avatars/shared.png";
+const now = new Date("2026-09-04T12:00:00.000Z");
+const ctx = {
+  db: {} as never,
+  user: {
+    id: "user-1",
+    name: "Test User",
+    email: "test@example.com",
+  },
+} as never;
+
+const createWorkspaceMember = (publicId: string, userId: string) => ({
+  publicId,
+  email: `${userId}@example.com`,
+  role: userId === "user-1" ? "admin" : "member",
+  status: "active",
+  createdAt: now,
+  user: {
+    id: userId,
+    name: `User ${userId}`,
+    email: `${userId}@example.com`,
+    image: avatarKey,
+  },
+});
+
+const createActivity = (publicId: string, withMember: boolean) => ({
+  publicId,
+  type: withMember ? "card.updated.member.added" : "card.created",
+  createdAt: now,
+  fromIndex: null,
+  toIndex: null,
+  fromTitle: null,
+  toTitle: null,
+  fromDescription: null,
+  toDescription: null,
+  fromDueDate: null,
+  toDueDate: null,
+  fromList: null,
+  toList: null,
+  label: null,
+  member: withMember
+    ? {
+        publicId: "member-2",
+        user: {
+          id: "user-2",
+          name: "Member User",
+          email: "member@example.com",
+          image: avatarKey,
+        },
+      }
+    : null,
+  user: {
+    id: "user-1",
+    name: "Activity User",
+    email: "activity@example.com",
+    image: avatarKey,
+  },
+  comment: null,
+  attachment: null,
+});
+
+describe("avatar URL resolution in routers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAssertPermission.mockResolvedValue(undefined);
+    mockGenerateAvatarUrl.mockResolvedValue(signedAvatarUrl);
+  });
+
+  it("reuses avatar URLs for duplicate workspace member image keys", async () => {
+    mockGetWorkspace.mockResolvedValue({
+      id: 7,
+      publicId: "workspace-12",
+      name: "Workspace",
+      slug: "workspace",
+      showEmailsToMembers: true,
+      weekStartDay: null,
+      members: [
+        createWorkspaceMember("member-1", "user-1"),
+        createWorkspaceMember("member-2", "user-2"),
+      ],
+      subscriptions: [],
+    } as never);
+
+    const { workspaceRouter } = await import("./workspace");
+    const result = await workspaceRouter.createCaller(ctx).byId({
+      workspacePublicId: "workspace-12",
+    });
+
+    expect(result.members.map((member) => member.user?.image)).toEqual([
+      signedAvatarUrl,
+      signedAvatarUrl,
+    ]);
+    expect(mockGenerateAvatarUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses avatar URLs for duplicate card workspace member image keys", async () => {
+    mockGetCard.mockResolvedValue({
+      id: 17,
+      workspaceId: 7,
+      workspaceVisibility: "public",
+    } as never);
+    mockGetCardWithMembers.mockResolvedValue({
+      publicId: "card-12345678",
+      title: "Card",
+      description: null,
+      cardNumber: 1,
+      index: 1,
+      dueDate: null,
+      createdBy: "user-1",
+      labels: [],
+      attachments: [],
+      checklists: [],
+      list: {
+        publicId: "list-12345678",
+        name: "List",
+        board: {
+          publicId: "board-1234567",
+          name: "Board",
+          labels: [],
+          lists: [],
+          workspace: {
+            publicId: "workspace-12",
+            cardPrefix: "KAN",
+            members: [
+              createWorkspaceMember("member-1", "user-1"),
+              createWorkspaceMember("member-2", "user-2"),
+            ],
+          },
+        },
+      },
+      members: [],
+      activities: [],
+    } as never);
+
+    const { cardRouter } = await import("./card");
+    const result = await cardRouter.createCaller(ctx).byId({
+      cardPublicId: "card-12345678",
+    });
+
+    expect(
+      result.list.board.workspace.members.map((member) => member.user?.image),
+    ).toEqual([signedAvatarUrl, signedAvatarUrl]);
+    expect(mockGenerateAvatarUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one resolver across activity users and member users", async () => {
+    mockGetCard.mockResolvedValue({
+      id: 17,
+      workspaceId: 7,
+      workspaceVisibility: "public",
+    } as never);
+    mockGetActivities.mockResolvedValue({
+      activities: [
+        createActivity("activity-01", false),
+        createActivity("activity-02", true),
+      ],
+      hasMore: false,
+      nextCursor: undefined,
+    } as never);
+
+    const { cardRouter } = await import("./card");
+    const result = await cardRouter.createCaller(ctx).getActivities({
+      cardPublicId: "card-12345678",
+      limit: 100,
+    });
+
+    expect(result.activities[0]?.user?.image).toBe(signedAvatarUrl);
+    expect(result.activities[1]?.user?.image).toBe(signedAvatarUrl);
+    expect(result.activities[1]?.member?.user?.image).toBe(signedAvatarUrl);
+    expect(mockGenerateAvatarUrl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routers/board.ts
+++ b/packages/api/src/routers/board.ts
@@ -10,7 +10,6 @@ import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import { colours } from "@kan/shared/constants";
 import {
   convertDueDateFiltersToRanges,
-  generateAvatarUrl,
   generateSlug,
   generateUID,
 } from "@kan/shared/utils";
@@ -23,6 +22,7 @@ import {
   boardCreateResponseSchema,
   boardUpdateResponseSchema,
 } from "../schemas";
+import { createAvatarUrlResolver } from "../utils/avatarUrls";
 import { assertCanDelete, assertCanEdit, assertPermission } from "../utils/permissions";
 
 export const boardRouter = createTRPCRouter({
@@ -159,6 +159,8 @@ export const boardRouter = createTRPCRouter({
         });
       }
 
+      const resolveAvatarUrl = createAvatarUrlResolver();
+
       // Generate presigned URLs for workspace member avatars
       const workspaceWithAvatarUrls = result.workspace
         ? {
@@ -169,7 +171,7 @@ export const boardRouter = createTRPCRouter({
                 return member;
               }
 
-              const avatarUrl = await generateAvatarUrl(member.user.image);
+              const avatarUrl = await resolveAvatarUrl(member.user.image);
               return {
                 ...member,
                 user: {
@@ -192,7 +194,7 @@ export const boardRouter = createTRPCRouter({
               members: await Promise.all(
                 card.members.map(async (member) => {
                   if (!member.user?.image) return member;
-                  const avatarUrl = await generateAvatarUrl(member.user.image);
+                  const avatarUrl = await resolveAvatarUrl(member.user.image);
                   return {
                     ...member,
                     user: { ...member.user, image: avatarUrl },

--- a/packages/api/src/routers/card-members.test.ts
+++ b/packages/api/src/routers/card-members.test.ts
@@ -44,6 +44,7 @@ vi.mock("@kan/auth/server", () => ({
 vi.mock("@kan/shared/utils", () => ({
   generateAttachmentUrl: vi.fn(),
   generateAvatarUrl: vi.fn(),
+  normalizeDescription: vi.fn((description: string) => description),
 }));
 vi.mock("../utils/notifications", () => ({
   sendMentionEmails: vi.fn(),

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -10,7 +10,6 @@ import * as listRepo from "@kan/db/repository/list.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import {
   generateAttachmentUrl,
-  generateAvatarUrl,
   normalizeDescription,
 } from "@kan/shared/utils";
 
@@ -24,6 +23,7 @@ import {
 } from "../schemas";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
 import { mergeActivities } from "../utils/activities";
+import { createAvatarUrlResolver } from "../utils/avatarUrls";
 import { sendMentionEmails } from "../utils/notifications";
 import {
   assertCanDelete,
@@ -715,6 +715,7 @@ export const cardRouter = createTRPCRouter({
       );
 
       // Generate presigned URLs for workspace member avatars
+      const resolveAvatarUrl = createAvatarUrlResolver();
       const workspaceWithAvatarUrls = result.list.board.workspace
         ? {
             ...result.list.board.workspace,
@@ -724,7 +725,7 @@ export const cardRouter = createTRPCRouter({
                   return member;
                 }
 
-                const avatarUrl = await generateAvatarUrl(member.user.image);
+                const avatarUrl = await resolveAvatarUrl(member.user.image);
                 return {
                   ...member,
                   user: {
@@ -809,13 +810,14 @@ export const cardRouter = createTRPCRouter({
       );
 
       // Generate presigned URLs for user avatars in activities
+      const resolveAvatarUrl = createAvatarUrlResolver();
       const activitiesWithAvatarUrls = await Promise.all(
         result.activities.map(async (activity) => {
           const updatedActivity = { ...activity };
 
           // Generate presigned URL for activity user avatar
           if (activity.user?.image) {
-            const userAvatarUrl = await generateAvatarUrl(activity.user.image);
+            const userAvatarUrl = await resolveAvatarUrl(activity.user.image);
             updatedActivity.user = {
               ...activity.user,
               image: userAvatarUrl,
@@ -824,7 +826,7 @@ export const cardRouter = createTRPCRouter({
 
           // Generate presigned URL for member user avatar (if exists)
           if (activity.member?.user?.image) {
-            const memberAvatarUrl = await generateAvatarUrl(
+            const memberAvatarUrl = await resolveAvatarUrl(
               activity.member.user.image,
             );
             updatedActivity.member = {

--- a/packages/api/src/routers/workspace.ts
+++ b/packages/api/src/routers/workspace.ts
@@ -6,7 +6,7 @@ import type { WorkspacePlan } from "@kan/db/schema";
 import * as subscriptionRepo from "@kan/db/repository/subscription.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import * as workspaceSlugRepo from "@kan/db/repository/workspaceSlug.repo";
-import { generateAvatarUrl, generateUID } from "@kan/shared/utils";
+import { generateUID } from "@kan/shared/utils";
 
 import {
   workspaceCreateResponseSchema,
@@ -17,6 +17,7 @@ import {
   workspaceWithBoardsSchema,
 } from "../schemas";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
+import { createAvatarUrlResolver } from "../utils/avatarUrls";
 import { assertPermission } from "../utils/permissions";
 
 export const workspaceRouter = createTRPCRouter({
@@ -90,13 +91,14 @@ export const workspaceRouter = createTRPCRouter({
       const shouldShowEmails = isAdmin || result.showEmailsToMembers === true;
 
       // Generate presigned URLs for member avatars
+      const resolveAvatarUrl = createAvatarUrlResolver();
       const membersWithAvatarUrls = await Promise.all(
         result.members.map(async (member) => {
           if (!member.user?.image) {
             return member;
           }
 
-          const avatarUrl = await generateAvatarUrl(member.user.image);
+          const avatarUrl = await resolveAvatarUrl(member.user.image);
           return {
             ...member,
             user: {

--- a/packages/api/src/utils/avatarUrls.test.ts
+++ b/packages/api/src/utils/avatarUrls.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateAvatarUrl } from "@kan/shared/utils";
+
+import { createAvatarUrlResolver } from "./avatarUrls";
+
+vi.mock("@kan/shared/utils", () => ({
+  generateAvatarUrl: vi.fn(),
+}));
+
+const mockGenerateAvatarUrl = vi.mocked(generateAvatarUrl);
+
+describe("createAvatarUrlResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateAvatarUrl.mockImplementation((imageKey) =>
+      Promise.resolve(`https://example.com/${imageKey}`),
+    );
+  });
+
+  it("reuses one generated URL for duplicate image keys", async () => {
+    const resolveAvatarUrl = createAvatarUrlResolver();
+
+    const urls = await Promise.all([
+      resolveAvatarUrl("avatars/alice.png"),
+      resolveAvatarUrl("avatars/alice.png"),
+      resolveAvatarUrl("avatars/bob.png"),
+    ]);
+
+    expect(urls).toEqual([
+      "https://example.com/avatars/alice.png",
+      "https://example.com/avatars/alice.png",
+      "https://example.com/avatars/bob.png",
+    ]);
+    expect(mockGenerateAvatarUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not share cached URLs between requests", async () => {
+    await createAvatarUrlResolver()("avatars/alice.png");
+    await createAvatarUrlResolver()("avatars/alice.png");
+
+    expect(mockGenerateAvatarUrl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api/src/utils/avatarUrls.ts
+++ b/packages/api/src/utils/avatarUrls.ts
@@ -1,0 +1,16 @@
+import { generateAvatarUrl } from "@kan/shared/utils";
+
+export const createAvatarUrlResolver = () => {
+  const urlsByImageKey = new Map<string, Promise<string | null>>();
+
+  return (imageKey: string) => {
+    const cachedUrl = urlsByImageKey.get(imageKey);
+
+    if (cachedUrl) return cachedUrl;
+
+    const url = generateAvatarUrl(imageKey);
+    urlsByImageKey.set(imageKey, url);
+
+    return url;
+  };
+};


### PR DESCRIPTION
## Description

`board.byId` generated a presigned avatar URL for every workspace member and
every card-member occurrence. The same image key can appear on hundreds or
thousands of cards, so one board request repeatedly created S3 clients and
signed identical URLs.

This change adds a procedure-scoped resolver that caches the promise for each
image key. Concurrent duplicates share the same work. Resolver instances are
not shared between procedures or requests, so URL expiry and access behaviour
remain unchanged.

Following review feedback, the same pattern is now used by `workspace.byId`,
`card.byId`, and `card.getActivities`. The activity feed shares one resolver
between activity actors and member users. The two user endpoints are left as
direct calls because each resolves only one avatar and cannot contain duplicate
keys.

## Production reference

On a migrated board with 1,890 cards and 4,600 card-member assignments, 4,196
avatar-bearing occurrences referenced only 33 unique image keys. Populating
those avatars changed `board.byId` from roughly sub-second responses to a 4–12
second range and delayed unrelated procedures in the same tRPC batch. With this
change, that procedure performs at most one signing operation per unique key.

The review follow-up was also A/B tested using two isolated builds against the
same production data:

- an activity feed with 46 avatar occurrences and 3 unique keys reduced its
  median server duration from 90.5 ms to 25 ms;
- a second feed with 31 raw avatar occurrences, including member-user avatars,
  and 3 unique keys reduced its median from 73.5 ms to 25 ms;
- the tested workspace and card detail contained 108 avatar occurrences and
  105 unique keys, so they showed no material timing change, as expected.

Normalized responses were identical and payload sizes did not change.

## Tests

The tests cover:

- concurrent reuse of duplicate image keys;
- isolation between resolver instances;
- duplicate workspace-member avatars in workspace and card responses;
- reuse across activity actors and member users.

Tested with:

- `pnpm --filter @kan/api test -- src/routers/card-members.test.ts src/routers/avatar-urls.test.ts src/utils/avatarUrls.test.ts`
- `pnpm --filter @kan/api typecheck`
- ESLint and Prettier checks for the changed files

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below — not required for this bug fix
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes — no UI changes

## Linked issue

Not required for this bug fix.
