### PR TITLE
perf: reduce board payload with compact card summaries

### DIFF
--- a/apps/web/src/views/board/components/Card.tsx
+++ b/apps/web/src/views/board/components/Card.tsx
@@ -19,6 +19,7 @@ const Card = ({
   ticketNumber,
   labels,
   members,
+  summary,
   checklists,
   description,
   comments,
@@ -33,6 +34,13 @@ const Card = ({
     email: string;
     user: { name: string | null; email: string; image: string | null } | null;
   }[];
+  summary?: {
+    hasDescription: boolean;
+    attachmentCount: number;
+    hasComments: boolean;
+    checklistItemCount: number;
+    completedChecklistItemCount: number;
+  };
   checklists: {
     publicId: string;
     name: string;
@@ -45,26 +53,35 @@ const Card = ({
   }[];
   description: string | null;
   comments: { publicId: string }[];
-  attachments?: { publicId: string }[];
+  attachments: { publicId: string }[];
   dueDate?: Date | null;
 }) => {
   const { dateLocale } = useLocalisation();
   const showYear = dueDate ? !isSameYear(dueDate, new Date()) : false;
   const isOverdue = dueDate ? isBefore(dueDate, startOfDay(new Date())) : false;
-  const completedItems = checklists.reduce((acc, checklist) => {
-    return acc + checklist.items.filter((item) => item.completed).length;
-  }, 0);
-
-  const totalItems = checklists.reduce((acc, checklist) => {
-    return acc + checklist.items.length;
-  }, 0);
-
+  const cardSummary = summary ?? {
+    hasDescription:
+      (description?.replace(/<[^>]*>/g, "").trim().length ?? 0) > 0,
+    attachmentCount: attachments.length,
+    hasComments: comments.length > 0,
+    checklistItemCount: checklists.reduce(
+      (count, checklist) => count + checklist.items.length,
+      0,
+    ),
+    completedChecklistItemCount: checklists.reduce(
+      (count, checklist) =>
+        count + checklist.items.filter((item) => item.completed).length,
+      0,
+    ),
+  };
   const progress =
-    totalItems > 0 ? Math.round((completedItems / totalItems) * 100) : 0;
-
-  const hasDescription =
-    description && description.replace(/<[^>]*>/g, "").trim().length > 0;
-  const hasAttachments = attachments && attachments.length > 0;
+    cardSummary.checklistItemCount > 0
+      ? Math.round(
+          (cardSummary.completedChecklistItemCount /
+            cardSummary.checklistItemCount) *
+            100,
+        )
+      : 0;
   const hasDueDate = !!dueDate;
 
   return (
@@ -77,11 +94,11 @@ const Card = ({
       <span className="break-words">{title}</span>
       {labels.length ||
       members.length ||
-      checklists.length > 0 ||
-      hasDescription ||
-      comments.length > 0 ||
+      cardSummary.checklistItemCount > 0 ||
+      cardSummary.hasDescription ||
+      cardSummary.hasComments ||
       hasDueDate ||
-      hasAttachments ? (
+      cardSummary.attachmentCount > 0 ? (
         <div className="mt-2 flex flex-col justify-end">
           <div className="space-x-0.5">
             {labels.map((label) => (
@@ -93,7 +110,7 @@ const Card = ({
           </div>
           <div className="mt-2 flex items-center justify-between gap-1">
             <div className="flex items-center gap-2">
-              {hasDescription && (
+              {cardSummary.hasDescription && (
                 <div className="flex items-center gap-1 text-light-700 dark:text-dark-800">
                   <HiBars3BottomLeft className="h-4 w-4" />
                 </div>
@@ -115,19 +132,19 @@ const Card = ({
                   </span>
                 </div>
               )}
-              {comments.length > 0 && (
+              {cardSummary.hasComments && (
                 <div className="flex items-center gap-1 text-light-700 dark:text-dark-800">
                   <HiChatBubbleLeft className="h-4 w-4" />
                 </div>
               )}
-              {hasAttachments && (
+              {cardSummary.attachmentCount > 0 && (
                 <div className="flex items-center gap-1 text-light-700 dark:text-dark-800">
                   <HiOutlinePaperClip className="h-4 w-4" />
                 </div>
               )}
             </div>
             <div className="flex items-center justify-end gap-1">
-              {checklists.length > 0 && (
+              {cardSummary.checklistItemCount > 0 && (
                 <div className="flex items-center gap-1 rounded-full border-[1px] border-light-300 px-2 py-1 dark:border-dark-600">
                   <CircularProgress
                     progress={progress || 2}
@@ -135,7 +152,8 @@ const Card = ({
                     className="flex-shrink-0"
                   />
                   <span className="text-[10px] text-light-900 dark:text-dark-950">
-                    {completedItems}/{totalItems}
+                    {cardSummary.completedChecklistItemCount}/
+                    {cardSummary.checklistItemCount}
                   </span>
                 </div>
               )}

--- a/apps/web/src/views/board/components/CardContextDuplicateModal.tsx
+++ b/apps/web/src/views/board/components/CardContextDuplicateModal.tsx
@@ -17,24 +17,15 @@ import { usePopup } from "~/providers/popup";
 import { api } from "~/utils/api";
 
 interface CardContextDuplicateModalProps {
-  boardPublicId?: string;
-  isTemplate?: boolean;
+  lists: { publicId: string; name: string }[];
 }
 
 export function CardContextDuplicateModal({
-  boardPublicId: boardPublicIdProp,
-  isTemplate: isTemplateProp,
-}: CardContextDuplicateModalProps = {}) {
-  const { entityId: cardPublicId, closeModal, getModalState } = useModal();
+  lists,
+}: CardContextDuplicateModalProps) {
+  const { entityId: cardPublicId, closeModal } = useModal();
   const { showPopup } = usePopup();
   const utils = api.useUtils();
-
-  const modalState = getModalState("CARD_CONTEXT_DUPLICATE") as
-    | { boardPublicId: string; isTemplate?: boolean }
-    | undefined;
-  const boardPublicId =
-    boardPublicIdProp ?? modalState?.boardPublicId ?? "";
-  const isTemplate = isTemplateProp ?? modalState?.isTemplate ?? false;
 
   const [listPublicId, setListPublicId] = useState("");
   const [copyLabels, setCopyLabels] = useState(true);
@@ -48,13 +39,10 @@ export function CardContextDuplicateModal({
     { enabled: !!cardPublicId && cardPublicId.length >= 12 },
   );
 
-  const boardType = isTemplate ? "template" : "regular";
-  const { data: board } = api.board.byId.useQuery(
-    { boardPublicId, type: boardType },
-    { enabled: !!boardPublicId },
-  );
-  const lists = board?.lists ?? [];
-  const listOptions = lists.map((l) => ({ publicId: l.publicId, name: l.name }));
+  const listOptions = lists.map((l) => ({
+    publicId: l.publicId,
+    name: l.name,
+  }));
   const currentListPublicId = card?.list?.publicId;
   const hasLabels = (card?.labels?.length ?? 0) > 0;
   const hasMembers = (card?.members?.length ?? 0) > 0;

--- a/apps/web/src/views/board/components/DeleteListConfirmation.tsx
+++ b/apps/web/src/views/board/components/DeleteListConfirmation.tsx
@@ -13,6 +13,7 @@ interface QueryParams {
   members: string[];
   labels: string[];
   lists: string[];
+  cardView: "summary";
 }
 
 export function DeleteListConfirmation({

--- a/apps/web/src/views/board/components/NewCardForm.tsx
+++ b/apps/web/src/views/board/components/NewCardForm.tsx
@@ -11,7 +11,7 @@ import {
   HiXMark,
 } from "react-icons/hi2";
 
-import type { NewCardInput } from "@kan/api/types";
+import type { GetBoardByIdOutput, NewCardInput } from "@kan/api/types";
 import { generateUID } from "@kan/shared/utils";
 
 import type { WorkspaceMember } from "~/components/Editor";
@@ -40,18 +40,19 @@ interface QueryParams {
   members: string[];
   labels: string[];
   lists: string[];
+  cardView: "summary";
 }
 
 interface NewCardFormProps {
   isTemplate: boolean;
-  boardPublicId: string;
+  boardData?: GetBoardByIdOutput;
   listPublicId: string;
   queryParams: QueryParams;
 }
 
 export function NewCardForm({
   isTemplate,
-  boardPublicId,
+  boardData,
   listPublicId,
   queryParams,
 }: NewCardFormProps) {
@@ -105,10 +106,6 @@ export function NewCardForm({
     return () => subscription.unsubscribe();
   }, [watch, saveFormState]);
 
-  const { data: boardData } = api.board.byId.useQuery(queryParams, {
-    enabled: !!boardPublicId,
-  });
-
   // this adds the new created label to selected labels
   useEffect(() => {
     const newLabelId = modalStates.NEW_LABEL_CREATED;
@@ -158,6 +155,13 @@ export function NewCardForm({
               comments: [],
               checklists: [],
               attachments: [],
+              summary: {
+                hasDescription: false,
+                attachmentCount: 0,
+                hasComments: false,
+                checklistItemCount: 0,
+                completedChecklistItemCount: 0,
+              },
               labels: oldBoard.labels.filter((label) =>
                 args.labelPublicIds.includes(label.publicId),
               ),
@@ -321,7 +325,10 @@ export function NewCardForm({
     }
 
     if (filesToUpload.length > 0) {
-      const failedCount = await uploadAttachments(newCard.publicId, filesToUpload);
+      const failedCount = await uploadAttachments(
+        newCard.publicId,
+        filesToUpload,
+      );
       if (failedCount > 0) {
         showPopup({
           header: t`Some attachments failed`,

--- a/apps/web/src/views/board/components/NewListForm.tsx
+++ b/apps/web/src/views/board/components/NewListForm.tsx
@@ -22,6 +22,7 @@ interface QueryParams {
   members: string[];
   labels: string[];
   lists: string[];
+  cardView: "summary";
 }
 
 export function NewListForm({

--- a/apps/web/src/views/board/index.tsx
+++ b/apps/web/src/views/board/index.tsx
@@ -65,8 +65,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
   const utils = api.useUtils();
   const { showPopup } = usePopup();
   const { workspace } = useWorkspace();
-  const { openModal, modalContentType, entityId, isOpen, setModalState } =
-    useModal();
+  const { openModal, modalContentType, entityId, isOpen } = useModal();
   const [selectedPublicListId, setSelectedPublicListId] =
     useState<PublicListId>("");
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -141,6 +140,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
       dueDateFilters: semanticFilters,
     }),
     type: boardType,
+    cardView: "summary" as const,
   };
 
   const {
@@ -166,7 +166,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
   }, [router, boardId, isQueryLoading, error, boardData]);
 
   const refetchBoard = async () => {
-    if (boardId) await utils.board.byId.refetch({ boardPublicId: boardId });
+    if (boardId) await utils.board.byId.refetch(queryParams);
   };
 
   useEffect(() => {
@@ -325,10 +325,6 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
       return;
     }
     if (action === "duplicate") {
-      setModalState("CARD_CONTEXT_DUPLICATE", {
-        boardPublicId: boardId ?? "",
-        isTemplate: !!isTemplate,
-      });
       openModal("CARD_CONTEXT_DUPLICATE", cardPublicId);
       return;
     }
@@ -411,7 +407,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
         >
           <NewCardForm
             isTemplate={!!isTemplate}
-            boardPublicId={boardId ?? ""}
+            boardData={boardData}
             listPublicId={selectedPublicListId}
             queryParams={queryParams}
           />
@@ -527,10 +523,7 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
           modalSize="md"
           isVisible={isOpen && modalContentType === "CARD_CONTEXT_DUPLICATE"}
         >
-          <CardContextDuplicateModal
-            boardPublicId={boardId ?? ""}
-            isTemplate={!!isTemplate}
-          />
+          <CardContextDuplicateModal lists={boardData?.lists ?? []} />
         </Modal>
         <Modal
           modalSize="sm"
@@ -789,11 +782,10 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
                                             }
                                             labels={card.labels}
                                             members={card.members}
-                                            checklists={card.checklists ?? []}
-                                            description={
-                                              card.description ?? null
-                                            }
-                                            comments={card.comments ?? []}
+                                            summary={card.summary}
+                                            checklists={card.checklists}
+                                            description={card.description}
+                                            comments={card.comments}
                                             attachments={card.attachments}
                                             dueDate={card.dueDate ?? null}
                                           />

--- a/packages/api/integration-tests/board-summary.integration.test.ts
+++ b/packages/api/integration-tests/board-summary.integration.test.ts
@@ -58,7 +58,7 @@ describe("board summary repository view", () => {
     await db.insert(cards).values({
       publicId: "empty1234567",
       title: "Empty summary",
-      description: "<p> </p>",
+      description: null,
       index: 1,
       listId: list!.id,
       createdBy: user.id,

--- a/packages/api/integration-tests/board-summary.integration.test.ts
+++ b/packages/api/integration-tests/board-summary.integration.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import * as boardRepo from "@kan/db/repository/board.repo";
+import {
+  boards,
+  cardAttachments,
+  cards,
+  checklistItems,
+  checklists,
+  comments,
+  lists,
+} from "@kan/db/schema";
+
+import type { TestDbClient } from "./test-db";
+import { boardDetailSchema } from "../src/schemas/board";
+import { createTestDb, seedTestData } from "./test-db";
+
+describe("board summary repository view", () => {
+  let db: TestDbClient;
+  let userId: string;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    const { user, workspace } = await seedTestData(db);
+    userId = user.id;
+
+    const [board] = await db
+      .insert(boards)
+      .values({
+        publicId: "board1234567",
+        name: "Summary board",
+        slug: "summary-board",
+        workspaceId: workspace.id,
+        createdBy: user.id,
+      })
+      .returning();
+    const [list] = await db
+      .insert(lists)
+      .values({
+        publicId: "list12345678",
+        name: "Todo",
+        index: 0,
+        boardId: board!.id,
+        createdBy: user.id,
+      })
+      .returning();
+    const [card] = await db
+      .insert(cards)
+      .values({
+        publicId: "card12345678",
+        title: "Summarise me",
+        description: "<p>Visible details</p>",
+        index: 0,
+        listId: list!.id,
+        createdBy: user.id,
+      })
+      .returning();
+    await db.insert(cards).values({
+      publicId: "empty1234567",
+      title: "Empty summary",
+      description: "<p> </p>",
+      index: 1,
+      listId: list!.id,
+      createdBy: user.id,
+    });
+    const [checklist] = await db
+      .insert(checklists)
+      .values({
+        publicId: "check1234567",
+        name: "Checklist",
+        index: 0,
+        cardId: card!.id,
+        createdBy: user.id,
+      })
+      .returning();
+
+    await db.insert(checklistItems).values([
+      {
+        publicId: "item12345678",
+        title: "Complete",
+        completed: true,
+        index: 0,
+        checklistId: checklist!.id,
+        createdBy: user.id,
+      },
+      {
+        publicId: "item23456789",
+        title: "Open",
+        completed: false,
+        index: 1,
+        checklistId: checklist!.id,
+        createdBy: user.id,
+      },
+      {
+        publicId: "item34567890",
+        title: "Deleted",
+        completed: true,
+        index: 2,
+        checklistId: checklist!.id,
+        createdBy: user.id,
+        deletedAt: new Date(),
+      },
+    ]);
+    await db.insert(cardAttachments).values([
+      {
+        publicId: "attach123456",
+        cardId: card!.id,
+        filename: "active.txt",
+        originalFilename: "active.txt",
+        contentType: "text/plain",
+        size: 1,
+        s3Key: "active.txt",
+        createdBy: user.id,
+      },
+      {
+        publicId: "attach234567",
+        cardId: card!.id,
+        filename: "deleted.txt",
+        originalFilename: "deleted.txt",
+        contentType: "text/plain",
+        size: 1,
+        s3Key: "deleted.txt",
+        createdBy: user.id,
+        deletedAt: new Date(),
+      },
+    ]);
+    await db.insert(comments).values([
+      {
+        publicId: "comment12345",
+        comment: "Active comment",
+        cardId: card!.id,
+        createdBy: user.id,
+      },
+      {
+        publicId: "comment23456",
+        comment: "Deleted comment",
+        cardId: card!.id,
+        createdBy: user.id,
+        deletedAt: new Date(),
+      },
+    ]);
+  });
+
+  it("returns matching full details and compact aggregates", async () => {
+    const filters = {
+      members: [],
+      labels: [],
+      lists: [],
+      dueDate: [],
+      type: "regular" as const,
+    };
+    const full = await boardRepo.getByPublicId(db, "board1234567", userId, {
+      ...filters,
+      cardView: "full",
+    });
+    const summary = await boardRepo.getByPublicId(db, "board1234567", userId, {
+      ...filters,
+      cardView: "summary",
+    });
+    const fullCard = full?.lists[0]?.cards[0];
+    const summaryCard = summary?.lists[0]?.cards[0];
+    const emptySummaryCard = summary?.lists[0]?.cards[1];
+
+    expect(fullCard).toMatchObject({
+      description: "<p>Visible details</p>",
+      attachments: [{ publicId: "attach123456" }],
+      comments: [{ publicId: "comment12345" }],
+    });
+    expect(fullCard?.checklists[0]?.items).toHaveLength(2);
+    expect(fullCard?.summary).toBeUndefined();
+    expect(summaryCard).toMatchObject({
+      description: null,
+      attachments: [],
+      comments: [],
+      checklists: [],
+      summary: {
+        hasDescription: true,
+        attachmentCount: 1,
+        hasComments: true,
+        checklistItemCount: 2,
+        completedChecklistItemCount: 1,
+      },
+    });
+    expect(emptySummaryCard).toMatchObject({
+      description: null,
+      attachments: [],
+      comments: [],
+      checklists: [],
+      summary: {
+        hasDescription: false,
+        attachmentCount: 0,
+        hasComments: false,
+        checklistItemCount: 0,
+        completedChecklistItemCount: 0,
+      },
+    });
+
+    expect(() => boardDetailSchema.parse(full)).not.toThrow();
+    expect(() => boardDetailSchema.parse(summary)).not.toThrow();
+  });
+});

--- a/packages/api/src/routers/board.ts
+++ b/packages/api/src/routers/board.ts
@@ -109,6 +109,7 @@ export const boardRouter = createTRPCRouter({
           )
           .optional(),
         type: z.enum(["regular", "template"]).optional(),
+        cardView: z.enum(["full", "summary"]).default("full"),
       }),
     )
     .output(boardDetailSchema)
@@ -149,6 +150,7 @@ export const boardRouter = createTRPCRouter({
           lists: input.lists ?? [],
           dueDate: dueDateFilters,
           type: input.type,
+          cardView: input.cardView,
         },
       );
 
@@ -189,9 +191,8 @@ export const boardRouter = createTRPCRouter({
         result.lists.map(async (list) => ({
           ...list,
           cards: await Promise.all(
-            list.cards.map(async (card) => ({
-              ...card,
-              members: await Promise.all(
+            list.cards.map(async (card) => {
+              const members = await Promise.all(
                 card.members.map(async (member) => {
                   if (!member.user?.image) return member;
                   const avatarUrl = await resolveAvatarUrl(member.user.image);
@@ -200,8 +201,25 @@ export const boardRouter = createTRPCRouter({
                     user: { ...member.user, image: avatarUrl },
                   };
                 }),
-              ),
-            })),
+              );
+
+              if (input.cardView === "summary") {
+                if (!card.summary) {
+                  throw new TRPCError({
+                    message: "Card summary was not returned",
+                    code: "INTERNAL_SERVER_ERROR",
+                  });
+                }
+
+                return {
+                  ...card,
+                  members,
+                  summary: card.summary,
+                };
+              }
+
+              return { ...card, members };
+            }),
           ),
         })),
       );

--- a/packages/api/src/schemas/board.ts
+++ b/packages/api/src/schemas/board.ts
@@ -46,6 +46,15 @@ const boardDetailCardSchema = z.object({
   attachments: z.array(z.object({ publicId: z.string() })),
   checklists: z.array(checklistResponseSchema),
   comments: z.array(z.object({ publicId: z.string() })),
+  summary: z
+    .object({
+      hasDescription: z.boolean(),
+      attachmentCount: z.number().int().nonnegative(),
+      hasComments: z.boolean(),
+      checklistItemCount: z.number().int().nonnegative(),
+      completedChecklistItemCount: z.number().int().nonnegative(),
+    })
+    .optional(),
 });
 
 // ─── board.byId ──────────────────────────────────────────────

--- a/packages/db/src/repository/board.repo.ts
+++ b/packages/db/src/repository/board.repo.ts
@@ -272,7 +272,7 @@ export const getByPublicId = async (
               ).as("description"),
               hasDescription: (includeCardDetails
                 ? sql<boolean>`FALSE`
-                : sql<boolean>`COALESCE(BTRIM(REGEXP_REPLACE(COALESCE(${card.description}, ''), '<[^>]*>', '', 'g')), '') <> ''`
+                : sql<boolean>`${card.description} IS NOT NULL`
               ).as("has_description"),
               attachmentCount: (includeCardDetails
                 ? sql<number>`0`

--- a/packages/db/src/repository/board.repo.ts
+++ b/packages/db/src/repository/board.repo.ts
@@ -10,6 +10,7 @@ import {
   isNull,
   lt,
   or,
+  sql,
 } from "drizzle-orm";
 
 import type { dbClient } from "@kan/db/client";
@@ -156,8 +157,10 @@ export const getByPublicId = async (
     lists: string[];
     dueDate: DueDateFilter[];
     type: "regular" | "template" | undefined;
+    cardView?: "full" | "summary";
   },
 ) => {
+  const includeCardDetails = filters.cardView !== "summary";
   let cardIds: string[] = [];
 
   if (filters.labels.length > 0 || filters.members.length > 0) {
@@ -254,12 +257,42 @@ export const getByPublicId = async (
             columns: {
               publicId: true,
               title: true,
-              description: true,
+              description: false,
               listId: true,
               index: true,
               dueDate: true,
               cardNumber: true,
             },
+            extras: (card) => ({
+              // Drizzle rewrites interpolated columns in relational extras to
+              // the outer card alias, so inner table aliases stay static SQL.
+              description: (includeCardDetails
+                ? sql<string | null>`${card.description}`
+                : sql<string | null>`NULL::text`
+              ).as("description"),
+              hasDescription: (includeCardDetails
+                ? sql<boolean>`FALSE`
+                : sql<boolean>`COALESCE(BTRIM(REGEXP_REPLACE(COALESCE(${card.description}, ''), '<[^>]*>', '', 'g')), '') <> ''`
+              ).as("has_description"),
+              attachmentCount: (includeCardDetails
+                ? sql<number>`0`
+                : sql<number>`(SELECT COUNT(*)::int FROM "card_attachment" AS attachment WHERE attachment."cardId" = ${card.id} AND attachment."deletedAt" IS NULL)`
+              ).as("attachment_count"),
+              hasComments: (includeCardDetails
+                ? sql<boolean>`FALSE`
+                : sql<boolean>`EXISTS (SELECT 1 FROM "card_comments" AS comment WHERE comment."cardId" = ${card.id} AND comment."deletedAt" IS NULL)`
+              ).as("has_comments"),
+              checklistSummary: (includeCardDetails
+                ? sql<{
+                    itemCount: number;
+                    completedItemCount: number;
+                  } | null>`NULL::json`
+                : sql<{
+                    itemCount: number;
+                    completedItemCount: number;
+                  }>`(SELECT JSON_BUILD_OBJECT('itemCount', COUNT(*)::int, 'completedItemCount', COUNT(*) FILTER (WHERE checklist_item.completed)::int) FROM "card_checklist_item" AS checklist_item INNER JOIN "card_checklist" AS checklist ON checklist_item."checklistId" = checklist.id WHERE checklist."cardId" = ${card.id} AND checklist."deletedAt" IS NULL AND checklist_item."deletedAt" IS NULL)`
+              ).as("checklist_summary"),
+            }),
             with: {
               labels: {
                 with: {
@@ -297,7 +330,10 @@ export const getByPublicId = async (
                 columns: {
                   publicId: true,
                 },
-                where: isNull(cardAttachments.deletedAt),
+                where: and(
+                  isNull(cardAttachments.deletedAt),
+                  includeCardDetails ? undefined : sql`FALSE`,
+                ),
                 orderBy: asc(cardAttachments.createdAt),
               },
               checklists: {
@@ -306,7 +342,10 @@ export const getByPublicId = async (
                   name: true,
                   index: true,
                 },
-                where: isNull(checklists.deletedAt),
+                where: and(
+                  isNull(checklists.deletedAt),
+                  includeCardDetails ? undefined : sql`FALSE`,
+                ),
                 orderBy: asc(checklists.index),
                 with: {
                   items: {
@@ -325,7 +364,10 @@ export const getByPublicId = async (
                 columns: {
                   publicId: true,
                 },
-                where: isNull(comments.deletedAt),
+                where: and(
+                  isNull(comments.deletedAt),
+                  includeCardDetails ? undefined : sql`FALSE`,
+                ),
                 limit: 1,
               },
             },
@@ -369,13 +411,29 @@ export const getByPublicId = async (
     userFavorites: undefined,
     lists: board.lists.map((list) => ({
       ...list,
-      cards: list.cards.map((card) => ({
-        ...card,
-        labels: card.labels.map((label) => label.label),
-        members: card.members
-          .map((member) => member.member)
-          .filter((member) => member.deletedAt === null),
-      })),
+      cards: list.cards.map((card) => {
+        return {
+          ...card,
+          ...(filters.cardView === "summary" && {
+            summary: {
+              hasDescription: card.hasDescription,
+              attachmentCount: card.attachmentCount,
+              hasComments: card.hasComments,
+              checklistItemCount: card.checklistSummary?.itemCount ?? 0,
+              completedChecklistItemCount:
+                card.checklistSummary?.completedItemCount ?? 0,
+            },
+          }),
+          hasDescription: undefined,
+          attachmentCount: undefined,
+          hasComments: undefined,
+          checklistSummary: undefined,
+          labels: card.labels.map((label) => label.label),
+          members: card.members
+            .map((member) => member.member)
+            .filter((member) => member.deletedAt === null),
+        };
+      }),
     })),
   };
 

--- a/packages/e2e/tests/self-hosted/card-detail-extras.spec.ts
+++ b/packages/e2e/tests/self-hosted/card-detail-extras.spec.ts
@@ -23,6 +23,8 @@ test(
     await dashboard.expectSignedInAs(user);
 
     await board.createBoard("E2E Test Board");
+    const boardPublicId = page.url().split("/boards/")[1];
+    if (!boardPublicId) throw new Error("Could not resolve boardPublicId");
     await board.createList("To do");
     await board.createCard("Card detail test card");
     await board.openCard("Card detail test card");
@@ -80,6 +82,58 @@ test(
       ),
     ).toBe(true);
     expect(cardJson.dueDate).not.toBeNull();
+
+    const boardResponse = await page.request.get(
+      `/api/trpc/board.byId?batch=1&input=${encodeURIComponent(
+        JSON.stringify({
+          "0": { json: { boardPublicId, cardView: "summary" } },
+        }),
+      )}`,
+    );
+    expect(boardResponse.ok()).toBe(true);
+    const boardBody = (await boardResponse.json()) as [
+      {
+        result: {
+          data: {
+            json: {
+              lists: {
+                cards: {
+                  publicId: string;
+                  description: string | null;
+                  attachments: { publicId: string }[];
+                  comments: { publicId: string }[];
+                  checklists: { publicId: string }[];
+                  summary?: {
+                    hasDescription: boolean;
+                    attachmentCount: number;
+                    hasComments: boolean;
+                    checklistItemCount: number;
+                    completedChecklistItemCount: number;
+                  };
+                }[];
+              }[];
+            };
+          };
+        };
+      },
+    ];
+    const boardCard = boardBody[0].result.data.json.lists
+      .flatMap((list) => list.cards)
+      .find((item) => item.publicId === cardPublicId);
+
+    expect(boardCard).toMatchObject({
+      description: null,
+      attachments: [],
+      comments: [],
+      checklists: [],
+      summary: {
+        hasDescription: false,
+        attachmentCount: 0,
+        hasComments: false,
+        checklistItemCount: 1,
+        completedChecklistItemCount: 1,
+      },
+    });
 
     await card.deleteChecklist();
     await expect(


### PR DESCRIPTION
## Title

perf: reduce board payload with compact card summaries

## Description

The authenticated board view only renders a small set of card indicators, but
`board.byId` currently loads and serializes full descriptions, comments,
attachments, checklists, and checklist items for every card. This becomes
expensive on large imported boards even after the relation lookups themselves
are indexed.

This adds an opt-in `cardView: "summary"` read model and uses it for the board
UI. Each card receives only the aggregate values needed for its description,
comment, attachment, and checklist indicators. The existing `"full"` mode
remains the default, preserving the response contract for existing API
consumers and the public board view.

The change also removes redundant board requests from the new-card and
duplicate-card flows. A proposed 30-second board query `staleTime` was removed
after E2E testing showed that it could hide labels created from the card view.

The issue was reproduced on imported self-hosted data containing 38 boards and
14,524 cards. Representative active boards contained 1,203, 1,587, 1,890, and
2,511 cards.

For two large boards, the compressed `board.byId` response dropped from
approximately 510–954 KB to 98–216 KB. End-to-end requests through the reverse
proxy dropped from roughly 2.15–3.24 seconds to 1.29–1.60 seconds.

`EXPLAIN (ANALYZE, BUFFERS)` on the 1,890-card board confirmed index scans for
card attachments, comments, checklists, and checklist items. Consolidating the
two checklist counters into one aggregate reduced the representative summary
query from 75.6 to 67.4 ms and from 19,872 to 15,521 shared buffer hits.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [ ] I have included screenshots for any UI changes

## Testing

- `git diff --check upstream/main...HEAD`
- `pnpm --filter @kan/api typecheck`
- `pnpm --filter @kan/db typecheck`
- `pnpm --filter @kan/e2e typecheck`
- `pnpm --filter @kan/web test` — 8 tests passed
- `pnpm --filter @kan/api test -- board-summary.integration.test.ts`
- production build completed successfully
- focused self-hosted Playwright coverage passed for compact card details,
  board filters, card move/delete, and card duplication
- PostgreSQL execution plans verified on a 1,890-card board

No screenshots are included because the change does not intentionally alter
the rendered UI.

## Linked issue

Not applicable: this is a board loading performance bug fix and does not change
product behavior.
