### PR TITLE
fix: deduplicate mention emails per content change

### DIFF
--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -173,13 +173,12 @@ export const cardRouter = createTRPCRouter({
       }
 
       if (input.description) {
-        sendMentionEmails({
+        void sendMentionEmails({
           db: ctx.db,
           cardPublicId: newCard.publicId,
-          commentHtml: input.description,
+          previousHtml: null,
+          nextHtml: input.description,
           commenterUserId: userId,
-        }).catch((error) => {
-          console.error("Failed to send mention emails:", error);
         });
       }
 
@@ -277,14 +276,13 @@ export const cardRouter = createTRPCRouter({
         createdBy: userId,
       });
 
-      sendMentionEmails({
+      void sendMentionEmails({
         db: ctx.db,
         cardPublicId: input.cardPublicId,
-        commentHtml: input.comment,
+        previousHtml: null,
+        nextHtml: input.comment,
         commenterUserId: userId,
         commentId: newComment.id,
-      }).catch((error) => {
-        console.error("Failed to send mention emails:", error);
       });
 
       return newComment;
@@ -367,14 +365,13 @@ export const cardRouter = createTRPCRouter({
         createdBy: userId,
       });
 
-      sendMentionEmails({
+      void sendMentionEmails({
         db: ctx.db,
         cardPublicId: input.cardPublicId,
-        commentHtml: input.comment,
+        previousHtml: existingComment.comment,
+        nextHtml: input.comment,
         commenterUserId: userId,
         commentId: updatedComment.id,
-      }).catch((error) => {
-        console.error("Failed to send mention emails:", error);
       });
 
       return updatedComment;
@@ -987,13 +984,12 @@ export const cardRouter = createTRPCRouter({
           toDescription: input.description,
         });
 
-        sendMentionEmails({
+        void sendMentionEmails({
           db: ctx.db,
           cardPublicId: input.cardPublicId,
-          commentHtml: input.description,
+          previousHtml: existingCard.description,
+          nextHtml: input.description,
           commenterUserId: userId,
-        }).catch((error) => {
-          console.error("Failed to send mention emails:", error);
         });
       }
 

--- a/packages/api/src/utils/mention-notifications.test.ts
+++ b/packages/api/src/utils/mention-notifications.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getNewMentionPublicIds } from "./mention-notifications";
+
+const mention = (publicId: string) =>
+  `<span data-type="mention" data-id="${publicId}" data-label="Member">@Member</span>`;
+
+describe("getNewMentionPublicIds", () => {
+  const firstMemberPublicId = "memberPublic1";
+  const secondMemberPublicId = "memberPublic2";
+
+  it("returns unique mentions for newly created content", () => {
+    expect(
+      getNewMentionPublicIds(
+        null,
+        `${mention(firstMemberPublicId)} ${mention(firstMemberPublicId)}`,
+      ),
+    ).toEqual([firstMemberPublicId]);
+  });
+
+  it("ignores mentions preserved while editing surrounding content", () => {
+    expect(
+      getNewMentionPublicIds(
+        `Before ${mention(firstMemberPublicId)}`,
+        `After ${mention(firstMemberPublicId)}`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns only mentions added by an edit", () => {
+    expect(
+      getNewMentionPublicIds(
+        mention(firstMemberPublicId),
+        `${mention(firstMemberPublicId)} ${mention(secondMemberPublicId)}`,
+      ),
+    ).toEqual([secondMemberPublicId]);
+  });
+
+  it("treats a removed and later re-added mention as new", () => {
+    expect(getNewMentionPublicIds(mention(firstMemberPublicId), "")).toEqual(
+      [],
+    );
+    expect(getNewMentionPublicIds("", mention(firstMemberPublicId))).toEqual([
+      firstMemberPublicId,
+    ]);
+  });
+});

--- a/packages/api/src/utils/mention-notifications.ts
+++ b/packages/api/src/utils/mention-notifications.ts
@@ -1,0 +1,14 @@
+import { parseMentionsFromHTML } from "@kan/shared/utils";
+
+export function getNewMentionPublicIds(
+  previousHtml: string | null,
+  nextHtml: string,
+): string[] {
+  const previousMentionPublicIds = new Set(
+    parseMentionsFromHTML(previousHtml ?? ""),
+  );
+
+  return parseMentionsFromHTML(nextHtml).filter(
+    (publicId) => !previousMentionPublicIds.has(publicId),
+  );
+}

--- a/packages/api/src/utils/notifications.test.ts
+++ b/packages/api/src/utils/notifications.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { dbClient } from "@kan/db/client";
+
+import { sendMentionEmails } from "./notifications";
+
+const mocks = vi.hoisted(() => ({
+  getCard: vi.fn(),
+  getMembers: vi.fn(),
+  createNotification: vi.fn(),
+  getUser: vi.fn(),
+  getWorkspace: vi.fn(),
+  sendEmail: vi.fn(),
+  log: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("next-runtime-env", () => ({
+  env: vi.fn(() => "https://kan.example.com"),
+}));
+
+vi.mock("@kan/db/repository/card.repo", () => ({
+  getWithListAndMembersByPublicId: mocks.getCard,
+}));
+
+vi.mock("@kan/db/repository/member.repo", () => ({
+  getByPublicIdsWithUsers: mocks.getMembers,
+}));
+
+vi.mock("@kan/db/repository/notification.repo", () => ({
+  create: mocks.createNotification,
+}));
+
+vi.mock("@kan/db/repository/user.repo", () => ({
+  getById: mocks.getUser,
+}));
+
+vi.mock("@kan/db/repository/workspace.repo", () => ({
+  getByPublicId: mocks.getWorkspace,
+}));
+
+vi.mock("@kan/email", () => ({
+  sendEmail: mocks.sendEmail,
+}));
+
+vi.mock("@kan/logger", () => ({
+  createLogger: vi.fn(() => mocks.log),
+}));
+
+const db = {} as dbClient;
+const authorUserId = "author-user-id";
+const mentionedMemberPublicId = "memberPublic1";
+const anotherMemberPublicId = "memberPublic2";
+
+const mention = (publicId: string) =>
+  `<span data-type="mention" data-id="${publicId}" data-label="Member">@Member</span>`;
+
+describe("sendMentionEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getCard.mockResolvedValue({
+      id: 42,
+      title: "A card",
+      list: {
+        board: {
+          name: "A board",
+          workspace: { publicId: "workspace-public-id" },
+        },
+      },
+    });
+    mocks.getWorkspace.mockResolvedValue({ id: 7 });
+    mocks.getUser.mockResolvedValue({
+      id: authorUserId,
+      name: "Author",
+      email: "author@example.com",
+    });
+    mocks.getMembers.mockResolvedValue([
+      {
+        email: "member@example.com",
+        user: { id: "mentioned-user-id", email: "member@example.com" },
+      },
+    ]);
+    mocks.sendEmail.mockResolvedValue(undefined);
+    mocks.createNotification.mockResolvedValue(undefined);
+  });
+
+  it("notifies only members added by the current edit", async () => {
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: mention(mentionedMemberPublicId),
+      nextHtml: `${mention(mentionedMemberPublicId)} ${mention(anotherMemberPublicId)}`,
+      commenterUserId: authorUserId,
+      commentId: 21,
+    });
+
+    expect(mocks.getMembers).toHaveBeenCalledWith(
+      db,
+      [anotherMemberPublicId],
+      7,
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledOnce();
+  });
+
+  it("records the notification only after SMTP accepts the email", async () => {
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: null,
+      nextHtml: mention(mentionedMemberPublicId),
+      commenterUserId: authorUserId,
+      commentId: 21,
+    });
+
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      "member@example.com",
+      "Author mentioned you in a comment on A card",
+      "MENTION",
+      {
+        commenterName: "Author",
+        boardName: "A board",
+        cardTitle: "A card",
+        cardUrl: "https://kan.example.com/cards/card-public-id",
+      },
+    );
+    expect(mocks.createNotification).toHaveBeenCalledWith(db, {
+      type: "mention",
+      userId: "mentioned-user-id",
+      cardId: 42,
+      commentId: 21,
+    });
+    expect(mocks.sendEmail.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.createNotification.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("does not record a notification when email delivery fails", async () => {
+    const error = new Error("SMTP rejected the message");
+    mocks.sendEmail.mockRejectedValue(error);
+
+    await expect(
+      sendMentionEmails({
+        db,
+        cardPublicId: "card-public-id",
+        previousHtml: null,
+        nextHtml: mention(mentionedMemberPublicId),
+        commenterUserId: authorUserId,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.createNotification).not.toHaveBeenCalled();
+    expect(mocks.log.error).toHaveBeenCalledWith(
+      {
+        err: error,
+        email: "member@example.com",
+        cardPublicId: "card-public-id",
+      },
+      "Failed to send mention email",
+    );
+  });
+
+  it("reports a recording failure separately after sending the email", async () => {
+    const error = new Error("Database unavailable");
+    mocks.createNotification.mockRejectedValue(error);
+
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: null,
+      nextHtml: mention(mentionedMemberPublicId),
+      commenterUserId: authorUserId,
+    });
+
+    expect(mocks.sendEmail).toHaveBeenCalledOnce();
+    expect(mocks.log.error).toHaveBeenCalledWith(
+      {
+        err: error,
+        email: "member@example.com",
+        cardPublicId: "card-public-id",
+      },
+      "Failed to record mention notification",
+    );
+  });
+
+  it("does not email the author or pending members", async () => {
+    mocks.getMembers.mockResolvedValue([
+      {
+        email: "author@example.com",
+        user: { id: authorUserId, email: "author@example.com" },
+      },
+      {
+        email: "pending@example.com",
+        user: null,
+      },
+    ]);
+
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: null,
+      nextHtml: `${mention(mentionedMemberPublicId)} ${mention(anotherMemberPublicId)}`,
+      commenterUserId: authorUserId,
+    });
+
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("allows the same member to be notified by another content event", async () => {
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: null,
+      nextHtml: mention(mentionedMemberPublicId),
+      commenterUserId: authorUserId,
+      commentId: 21,
+    });
+    await sendMentionEmails({
+      db,
+      cardPublicId: "card-public-id",
+      previousHtml: null,
+      nextHtml: mention(mentionedMemberPublicId),
+      commenterUserId: authorUserId,
+      commentId: 22,
+    });
+
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(2);
+    expect(mocks.createNotification).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api/src/utils/notifications.ts
+++ b/packages/api/src/utils/notifications.ts
@@ -1,41 +1,45 @@
 import { env } from "next-runtime-env";
 
 import type { dbClient } from "@kan/db/client";
-import { createLogger } from "@kan/logger";
-
-const log = createLogger("notifications");
 import * as cardRepo from "@kan/db/repository/card.repo";
 import * as memberRepo from "@kan/db/repository/member.repo";
 import * as notificationRepo from "@kan/db/repository/notification.repo";
 import * as userRepo from "@kan/db/repository/user.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import { sendEmail } from "@kan/email";
-import { parseMentionsFromHTML } from "@kan/shared/utils";
+import { createLogger } from "@kan/logger";
+
+import { getNewMentionPublicIds } from "./mention-notifications";
+
+const log = createLogger("notifications");
 
 /**
- * Sends mention notification emails to mentioned members
- * Only sends emails for new mentions (checks notification table to avoid duplicates)
+ * Sends mention notification emails to members newly mentioned in the content.
  */
 export async function sendMentionEmails({
   db,
   cardPublicId,
-  commentHtml,
+  previousHtml,
+  nextHtml,
   commenterUserId,
   commentId,
 }: {
   db: dbClient;
   cardPublicId: string;
-  commentHtml: string;
+  previousHtml: string | null;
+  nextHtml: string;
   commenterUserId: string;
   commentId?: number;
 }) {
   try {
-    // Parse mentions from HTML
-    const mentionPublicIds = parseMentionsFromHTML(commentHtml);
+    const mentionPublicIds = getNewMentionPublicIds(previousHtml, nextHtml);
     if (mentionPublicIds.length === 0) return;
 
     // Get card with board information
-    const card = await cardRepo.getWithListAndMembersByPublicId(db, cardPublicId);
+    const card = await cardRepo.getWithListAndMembersByPublicId(
+      db,
+      cardPublicId,
+    );
     if (!card?.list.board) return;
 
     const board = card.list.board;
@@ -56,7 +60,10 @@ export async function sendMentionEmails({
     const commenter = await userRepo.getById(db, commenterUserId);
     if (!commenter) return;
 
-    const commenterName = commenter.name?.trim() || commenter.email;
+    const trimmedCommenterName = commenter.name?.trim();
+    const commenterName = trimmedCommenterName?.length
+      ? trimmedCommenterName
+      : commenter.email;
 
     // Get mentioned members with full details (filtered by workspace)
     const membersWithDetails = await memberRepo.getByPublicIdsWithUsers(
@@ -75,8 +82,15 @@ export async function sendMentionEmails({
     const baseUrl = env("NEXT_PUBLIC_BASE_URL");
     const cardUrl = `${baseUrl}/cards/${cardPublicId}`;
 
-    log.info({ cardPublicId, mentionCount: membersToNotify.length, commenterUserId }, "Sending mention emails");
-    // Send emails to all mentioned members (only if notification doesn't exist)
+    log.info(
+      {
+        cardPublicId,
+        mentionCount: membersToNotify.length,
+        commenterUserId,
+      },
+      "Sending mention emails",
+    );
+
     await Promise.all(
       membersToNotify.map(async (member) => {
         const userId = member.user?.id;
@@ -86,28 +100,6 @@ export async function sendMentionEmails({
         if (!userId || !email) return;
 
         try {
-          // Check if notification already exists for this mention
-          const notificationExists = await notificationRepo.exists(db, {
-            userId,
-            cardId,
-            type: "mention",
-          });
-
-          // If notification already exists, skip sending email
-          if (notificationExists) {
-            log.debug({ email, cardPublicId }, "Skipping duplicate mention email");
-            return;
-          }
-
-          // Create notification record
-          await notificationRepo.create(db, {
-            type: "mention",
-            userId,
-            cardId,
-            commentId,
-          });
-
-          // Send email
           await sendEmail(
             email,
             `${commenterName} mentioned you in a comment on ${cardTitle}`,
@@ -121,7 +113,25 @@ export async function sendMentionEmails({
           );
           log.info({ email, cardPublicId }, "Mention email sent");
         } catch (error) {
-          log.error({ err: error, email, cardPublicId }, "Failed to send mention email");
+          log.error(
+            { err: error, email, cardPublicId },
+            "Failed to send mention email",
+          );
+          return;
+        }
+
+        try {
+          await notificationRepo.create(db, {
+            type: "mention",
+            userId,
+            cardId,
+            commentId,
+          });
+        } catch (error) {
+          log.error(
+            { err: error, email, cardPublicId },
+            "Failed to record mention notification",
+          );
         }
       }),
     );
@@ -129,4 +139,3 @@ export async function sendMentionEmails({
     log.error({ err: error, cardPublicId }, "Error sending mention emails");
   }
 }
-

--- a/packages/e2e/tests/self-hosted/mention-email.spec.ts
+++ b/packages/e2e/tests/self-hosted/mention-email.spec.ts
@@ -1,0 +1,135 @@
+import type { Browser, Locator, Page } from "@playwright/test";
+import { test } from "@playwright/test";
+
+import type { TestUser } from "../support/test-user";
+import {
+  clearMailpitInbox,
+  expectMailpitMessageCountToRemain,
+  waitForMailpitMessageCount,
+} from "../support/mailpit-client";
+import { AuthPage } from "../support/pages/auth-page";
+import { BoardPage } from "../support/pages/board-page";
+import { DashboardPage } from "../support/pages/dashboard-page";
+import { MembersPage } from "../support/pages/members-page";
+import { SelfHostedOnboardingPage } from "../support/pages/self-hosted-onboarding-page";
+import { createTestUser } from "../support/test-user";
+import { waitForTrpcMutation } from "../support/wait-for-trpc";
+
+async function joinWorkspace(
+  ownerPage: Page,
+  browser: Browser,
+  member: TestUser,
+) {
+  const members = new MembersPage(ownerPage);
+  await members.open();
+  const inviteLink = await members.createInviteLink();
+
+  const memberContext = await browser.newContext();
+  const memberPage = await memberContext.newPage();
+  await new AuthPage(memberPage).signUp(member);
+  await new SelfHostedOnboardingPage(memberPage).createFirstWorkspace(
+    "Mention Recipient Workspace",
+  );
+  await memberPage.goto(inviteLink);
+  await memberPage.waitForURL(/\/boards\?workspacePublicId=/, {
+    timeout: 20_000,
+  });
+  await memberContext.close();
+}
+
+function commentEditor(page: Page): Locator {
+  return page
+    .locator("div")
+    .filter({
+      has: page.getByRole("heading", { name: "Activity", exact: true }),
+    })
+    .last()
+    .locator('.tiptap[contenteditable="true"]');
+}
+
+async function insertMention(page: Page, editor: Locator, memberName: string) {
+  const query = memberName.split(" ").at(-1) ?? memberName;
+  await editor.pressSequentially(`@${query}`);
+  await page
+    .locator(".tippy-box")
+    .locator("button")
+    .filter({ hasText: memberName })
+    .click();
+}
+
+async function startEditingComment(page: Page): Promise<Locator> {
+  await page
+    .getByRole("button", { name: "Comment options", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Edit comment" }).click();
+
+  return commentEditor(page).first();
+}
+
+async function saveComment(page: Page) {
+  const updated = waitForTrpcMutation(page, "card.updateComment");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await updated;
+}
+
+test(
+  "mention emails follow newly-added mention semantics",
+  { tag: "@self-hosted" },
+  async ({ page, browser }) => {
+    test.setTimeout(60_000);
+
+    const author = { ...createTestUser(), name: "Mention Author" };
+    const recipient = { ...createTestUser(), name: "Mention Recipient" };
+    const auth = new AuthPage(page);
+    const onboarding = new SelfHostedOnboardingPage(page);
+    const dashboard = new DashboardPage(page);
+    const board = new BoardPage(page);
+
+    await auth.signUp(author);
+    await onboarding.createFirstWorkspace("Mention E2E Workspace");
+    await dashboard.expectSignedInAs(author);
+
+    await board.createBoard("Mention E2E Board");
+    await board.createList("To do");
+    await board.createCard("Mention email card");
+    const boardUrl = page.url();
+
+    await joinWorkspace(page, browser, recipient);
+    await page.goto(boardUrl);
+    await board.openCard("Mention email card");
+    await clearMailpitInbox();
+
+    const newCommentEditor = commentEditor(page);
+    await newCommentEditor.click();
+    await newCommentEditor.pressSequentially("Please review this, ");
+    await insertMention(page, newCommentEditor, recipient.name);
+
+    const added = waitForTrpcMutation(page, "card.addComment");
+    await page
+      .getByRole("button", { name: "Submit comment", exact: true })
+      .click();
+    await added;
+    await waitForMailpitMessageCount(recipient.email, 1);
+
+    const preservedMentionEditor = await startEditingComment(page);
+    await preservedMentionEditor.click();
+    await preservedMentionEditor.press("End");
+    await preservedMentionEditor.pressSequentially(" Follow-up text.");
+    await saveComment(page);
+    await expectMailpitMessageCountToRemain(recipient.email, 1);
+
+    const removedMentionEditor = await startEditingComment(page);
+    await removedMentionEditor.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await removedMentionEditor.pressSequentially("Mention removed.");
+    await saveComment(page);
+
+    const readdedMentionEditor = await startEditingComment(page);
+    await readdedMentionEditor.click();
+    await readdedMentionEditor.press("End");
+    await readdedMentionEditor.pressSequentially(" Added again: ");
+    await insertMention(page, readdedMentionEditor, recipient.name);
+    await saveComment(page);
+    await waitForMailpitMessageCount(recipient.email, 2);
+  },
+);

--- a/packages/e2e/tests/support/mailpit-client.ts
+++ b/packages/e2e/tests/support/mailpit-client.ts
@@ -12,14 +12,24 @@ interface MailpitMessage {
   HTML: string;
 }
 
+async function searchMessages(email: string): Promise<MailpitMessageSummary[]> {
+  const response = await fetch(
+    `${mailpitBaseUrl}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Mailpit search failed with status ${response.status}`);
+  }
+
+  const { messages } = (await response.json()) as MailpitSearchResponse;
+  return messages;
+}
+
 async function waitForMessageHtml(email: string): Promise<string> {
   const deadline = Date.now() + 15_000;
 
   while (Date.now() < deadline) {
-    const response = await fetch(
-      `${mailpitBaseUrl}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
-    );
-    const { messages } = (await response.json()) as MailpitSearchResponse;
+    const messages = await searchMessages(email);
     const latest = messages[0];
 
     if (latest) {
@@ -49,4 +59,48 @@ export async function getMagicLinkUrl(email: string): Promise<string> {
 
 export async function clearMailpitInbox() {
   await fetch(`${mailpitBaseUrl}/api/v1/messages`, { method: "DELETE" });
+}
+
+export async function getMailpitMessageCount(email: string): Promise<number> {
+  return (await searchMessages(email)).length;
+}
+
+export async function waitForMailpitMessageCount(
+  email: string,
+  expectedCount: number,
+) {
+  const deadline = Date.now() + 15_000;
+
+  while (Date.now() < deadline) {
+    const count = await getMailpitMessageCount(email);
+    if (count === expectedCount) return;
+    if (count > expectedCount) {
+      throw new Error(
+        `Expected ${expectedCount} messages for ${email}, but found ${count}`,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Expected ${expectedCount} messages for ${email} within 15s`);
+}
+
+export async function expectMailpitMessageCountToRemain(
+  email: string,
+  expectedCount: number,
+  durationMs = 1_500,
+) {
+  const deadline = Date.now() + durationMs;
+
+  while (Date.now() < deadline) {
+    const count = await getMailpitMessageCount(email);
+    if (count !== expectedCount) {
+      throw new Error(
+        `Expected ${expectedCount} messages for ${email}, but found ${count}`,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
 }


### PR DESCRIPTION
## Description

Mention email deduplication currently uses `userId + type + cardId`. Once a
notification row exists, the same member will not receive another mention email
from that card, even when they are explicitly mentioned in a new comment.

The notification row is also created before SMTP delivery. If that delivery
fails, the row remains and suppresses later attempts even though no email was
sent.

This changes the boundary to newly added mentions in each content change:

- new descriptions and comments notify each mentioned member once;
- edits notify only members added relative to the previous HTML;
- editing text around an existing mention does not send another email;
- a mention in another comment, or one removed and later added again, is a new
  event;
- self mentions and pending members remain excluded.

SMTP delivery still runs fire-and-forget after the content mutation. A
notification row is recorded only after SMTP accepts the message. This keeps the
existing lightweight delivery model: there is no queue or automatic retry, and
a process failure between SMTP acceptance and recording can rarely result in a
duplicate.

The original mention email behavior was introduced in #372.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below — no separate issue; related to #372
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes — no UI changes

## Testing

- 10 focused API tests cover old/new mention sets, separate content events,
  self/pending members, SMTP failures and SMTP-before-notification ordering.
- A self-hosted Playwright scenario exercises the editor, tRPC, PostgreSQL and
  Mailpit. It covers the initial mention, an edit that preserves the mention,
  and removal followed by re-adding it.
- API and E2E typechecks and focused lint pass.

## Linked issue

No separate issue. Related implementation: #372.
