### PR TITLE
fix: scope card member assignments to the workspace

### DIFF
--- a/packages/api/src/routers/card-members.test.ts
+++ b/packages/api/src/routers/card-members.test.ts
@@ -1,0 +1,251 @@
+import type { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as cardRepo from "@kan/db/repository/card.repo";
+import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
+import * as listRepo from "@kan/db/repository/list.repo";
+import * as workspaceRepo from "@kan/db/repository/workspace.repo";
+
+import { assertPermission } from "../utils/permissions";
+
+vi.mock("@kan/db/repository/card.repo", () => ({
+  create: vi.fn(),
+  bulkCreateCardWorkspaceMemberRelationships: vi.fn(),
+  getWorkspaceAndCardIdByCardPublicId: vi.fn(),
+  getCardMemberRelationship: vi.fn(),
+  hardDeleteCardMemberRelationship: vi.fn(),
+  createCardMemberRelationship: vi.fn(),
+  getWithListAndMembersByPublicId: vi.fn(),
+}));
+
+vi.mock("@kan/db/repository/cardActivity.repo", () => ({
+  bulkCreate: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock("@kan/db/repository/cardComment.repo", () => ({}));
+vi.mock("@kan/db/repository/checklist.repo", () => ({}));
+vi.mock("@kan/db/repository/label.repo", () => ({
+  getAllByPublicIds: vi.fn(),
+}));
+vi.mock("@kan/db/repository/list.repo", () => ({
+  getWorkspaceAndListIdByListPublicId: vi.fn(),
+}));
+vi.mock("@kan/db/repository/workspace.repo", () => ({
+  getAllMembersByPublicIds: vi.fn(),
+  getMemberByPublicId: vi.fn(),
+}));
+vi.mock("@kan/db/client", () => ({
+  createDrizzleClient: vi.fn(() => ({})),
+}));
+vi.mock("@kan/auth/server", () => ({
+  initAuth: vi.fn(() => ({ api: {} })),
+}));
+vi.mock("@kan/shared/utils", () => ({
+  generateAttachmentUrl: vi.fn(),
+  generateAvatarUrl: vi.fn(),
+}));
+vi.mock("../utils/notifications", () => ({
+  sendMentionEmails: vi.fn(),
+}));
+vi.mock("../utils/permissions", () => ({
+  assertCanDelete: vi.fn(),
+  assertCanEdit: vi.fn(),
+  assertPermission: vi.fn(),
+}));
+vi.mock("../utils/webhook", () => ({
+  createCardWebhookPayload: vi.fn(() => ({})),
+  sendWebhooksForWorkspace: vi.fn(() => Promise.resolve()),
+}));
+
+const mockCardCreate = cardRepo.create as ReturnType<typeof vi.fn>;
+const mockBulkCreateCardMembers =
+  cardRepo.bulkCreateCardWorkspaceMemberRelationships as ReturnType<
+    typeof vi.fn
+  >;
+const mockGetCard = cardRepo.getWorkspaceAndCardIdByCardPublicId as ReturnType<
+  typeof vi.fn
+>;
+const mockGetCardMember = cardRepo.getCardMemberRelationship as ReturnType<
+  typeof vi.fn
+>;
+const mockDeleteCardMember =
+  cardRepo.hardDeleteCardMemberRelationship as ReturnType<typeof vi.fn>;
+const mockCreateCardMember =
+  cardRepo.createCardMemberRelationship as ReturnType<typeof vi.fn>;
+const mockGetCardWithMembers =
+  cardRepo.getWithListAndMembersByPublicId as ReturnType<typeof vi.fn>;
+const mockCreateActivity = cardActivityRepo.create as ReturnType<typeof vi.fn>;
+const mockBulkCreateActivities = cardActivityRepo.bulkCreate as ReturnType<
+  typeof vi.fn
+>;
+const mockGetList = listRepo.getWorkspaceAndListIdByListPublicId as ReturnType<
+  typeof vi.fn
+>;
+const mockGetMembers = workspaceRepo.getAllMembersByPublicIds as ReturnType<
+  typeof vi.fn
+>;
+const mockGetMember = workspaceRepo.getMemberByPublicId as ReturnType<
+  typeof vi.fn
+>;
+const mockAssertPermission = assertPermission as ReturnType<typeof vi.fn>;
+
+describe("card member workspace scoping", () => {
+  const mockDb = {} as never;
+  const mockUser = {
+    id: "user-123",
+    name: "Test User",
+    email: "test@example.com",
+  };
+  const ctx = { user: mockUser, db: mockDb } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAssertPermission.mockResolvedValue(undefined);
+  });
+
+  describe("create", () => {
+    const input = {
+      title: "Scoped card",
+      description: "",
+      listPublicId: "list-12345678",
+      labelPublicIds: [],
+      memberPublicIds: ["member-a-123"],
+      position: "end" as const,
+    };
+
+    beforeEach(() => {
+      mockGetList.mockResolvedValue({
+        id: 11,
+        publicId: input.listPublicId,
+        name: "Inbox",
+        boardPublicId: "board-1234567",
+        boardName: "Board",
+        workspaceId: 7,
+      });
+      mockCardCreate.mockResolvedValue({
+        id: 17,
+        publicId: "card-12345678",
+      });
+      mockGetMembers.mockResolvedValue([{ id: 21 }]);
+      mockBulkCreateCardMembers.mockResolvedValue([
+        { cardId: 17, workspaceMemberId: 21 },
+      ]);
+      mockBulkCreateActivities.mockResolvedValue(undefined);
+    });
+
+    it("scopes member lookup to the list workspace", async () => {
+      const { cardRouter } = await import("./card");
+
+      await cardRouter.createCaller(ctx).create(input);
+
+      expect(mockGetMembers).toHaveBeenCalledWith(
+        mockDb,
+        input.memberPublicIds,
+        7,
+      );
+    });
+
+    it("rejects the whole request when any member is outside the workspace", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetMembers.mockResolvedValueOnce([{ id: 21 }]);
+
+      await expect(
+        cardRouter.createCaller(ctx).create({
+          ...input,
+          memberPublicIds: ["member-a-123", "member-b-123"],
+        }),
+      ).rejects.toMatchObject({
+        code: "NOT_FOUND",
+      } satisfies Partial<TRPCError>);
+
+      expect(mockCardCreate).not.toHaveBeenCalled();
+      expect(mockBulkCreateCardMembers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("addOrRemoveMember", () => {
+    const input = {
+      cardPublicId: "card-12345678",
+      workspaceMemberPublicId: "member-a-123",
+    };
+
+    beforeEach(() => {
+      mockGetCard.mockResolvedValue({ id: 17, workspaceId: 7 });
+    });
+
+    it("scopes member lookup to the card workspace", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetMember.mockResolvedValueOnce(undefined);
+
+      await expect(
+        cardRouter.createCaller(ctx).addOrRemoveMember(input),
+      ).rejects.toMatchObject({
+        code: "NOT_FOUND",
+      } satisfies Partial<TRPCError>);
+
+      expect(mockGetMember).toHaveBeenCalledWith(
+        mockDb,
+        input.workspaceMemberPublicId,
+        7,
+      );
+      expect(mockGetCardMember).not.toHaveBeenCalled();
+    });
+
+    it("removes an existing member relationship in the scoped workspace", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetMember.mockResolvedValueOnce({ id: 21 });
+      mockGetCardMember.mockResolvedValueOnce({ cardId: 17, memberId: 21 });
+      mockDeleteCardMember.mockResolvedValueOnce({ success: true });
+      mockCreateActivity.mockResolvedValueOnce(undefined);
+
+      await expect(
+        cardRouter.createCaller(ctx).addOrRemoveMember(input),
+      ).resolves.toEqual({ newMember: false });
+
+      expect(mockCreateCardMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("duplicate", () => {
+    const input = {
+      cardPublicId: "card-12345678",
+      listPublicId: "list-12345678",
+      copyLabels: false,
+      copyMembers: true,
+      copyChecklists: false,
+    };
+
+    it("only copies members from the source card workspace", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetCard.mockResolvedValueOnce({ id: 17, workspaceId: 7 });
+      mockGetList.mockResolvedValueOnce({
+        id: 11,
+        workspaceId: 7,
+      });
+      mockGetCardWithMembers.mockResolvedValueOnce({
+        title: "Source card",
+        description: "",
+        dueDate: null,
+        members: [{ publicId: "member-a-123" }],
+        labels: [],
+        checklists: [],
+      });
+      mockCardCreate.mockResolvedValueOnce({
+        id: 18,
+        publicId: "copy-12345678",
+      });
+      mockGetMembers.mockResolvedValueOnce([{ id: 21 }]);
+      mockBulkCreateCardMembers.mockResolvedValueOnce([
+        { cardId: 18, workspaceMemberId: 21 },
+      ]);
+      mockBulkCreateActivities.mockResolvedValueOnce(undefined);
+
+      await expect(
+        cardRouter.createCaller(ctx).duplicate(input),
+      ).resolves.toEqual({ publicId: "copy-12345678" });
+
+      expect(mockGetMembers).toHaveBeenCalledWith(mockDb, ["member-a-123"], 7);
+    });
+  });
+});

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -77,6 +77,20 @@ export const cardRouter = createTRPCRouter({
 
       await assertPermission(ctx.db, userId, list.workspaceId, "card:create");
 
+      const members = input.memberPublicIds.length
+        ? await workspaceRepo.getAllMembersByPublicIds(
+            ctx.db,
+            input.memberPublicIds,
+            list.workspaceId,
+          )
+        : [];
+
+      if (members.length !== new Set(input.memberPublicIds).size)
+        throw new TRPCError({
+          message: `Members with public IDs (${input.memberPublicIds.join(", ")}) not found`,
+          code: "NOT_FOUND",
+        });
+
       const newCard = await cardRepo.create(ctx.db, {
         title: input.title,
         description: input.description,
@@ -133,18 +147,7 @@ export const cardRouter = createTRPCRouter({
         await cardActivityRepo.bulkCreate(ctx.db, cardActivitesInsert);
       }
 
-      if (newCardId && input.memberPublicIds.length) {
-        const members = await workspaceRepo.getAllMembersByPublicIds(
-          ctx.db,
-          input.memberPublicIds,
-        );
-
-        if (!members.length)
-          throw new TRPCError({
-            message: `Members with public IDs (${input.memberPublicIds.join(", ")}) not found`,
-            code: "NOT_FOUND",
-          });
-
+      if (newCardId && members.length) {
         const membersInsert = members.map((member) => ({
           cardId: newCardId,
           workspaceMemberId: member.id,
@@ -591,6 +594,7 @@ export const cardRouter = createTRPCRouter({
       const member = await workspaceRepo.getMemberByPublicId(
         ctx.db,
         input.workspaceMemberPublicId,
+        card.workspaceId,
       );
 
       if (!member)
@@ -1324,6 +1328,7 @@ export const cardRouter = createTRPCRouter({
         const members = await workspaceRepo.getAllMembersByPublicIds(
           ctx.db,
           memberPublicIds,
+          sourceCardMeta.workspaceId,
         );
         if (members.length) {
           const membersInsert = members.map((member) => ({

--- a/packages/db/src/repository/workspace.repo.ts
+++ b/packages/db/src/repository/workspace.repo.ts
@@ -327,24 +327,37 @@ export const getAllOwnedByUserId = async (db: dbClient, userId: string) => {
   });
 };
 
-export const getMemberByPublicId = (db: dbClient, memberPublicId: string) => {
+export const getMemberByPublicId = (
+  db: dbClient,
+  memberPublicId: string,
+  workspaceId: number,
+) => {
   return db.query.workspaceMembers.findFirst({
     columns: {
       id: true,
     },
-    where: eq(workspaceMembers.publicId, memberPublicId),
+    where: and(
+      eq(workspaceMembers.publicId, memberPublicId),
+      eq(workspaceMembers.workspaceId, workspaceId),
+      isNull(workspaceMembers.deletedAt),
+    ),
   });
 };
 
 export const getAllMembersByPublicIds = (
   db: dbClient,
   memberPublicIds: string[],
+  workspaceId: number,
 ) => {
   return db.query.workspaceMembers.findMany({
     columns: {
       id: true,
     },
-    where: inArray(workspaceMembers.publicId, memberPublicIds),
+    where: and(
+      inArray(workspaceMembers.publicId, memberPublicIds),
+      eq(workspaceMembers.workspaceId, workspaceId),
+      isNull(workspaceMembers.deletedAt),
+    ),
   });
 };
 


### PR DESCRIPTION
## Description

Card member IDs were resolved globally in the create and add/remove paths. A
caller with permission to edit a card could therefore supply a membership ID
from another workspace.

This change derives the workspace from the target card or list and uses it for
all member lookups. Card creation validates the complete member set before
writing the card, so a mixed valid/foreign request fails atomically. Card
duplication applies the same boundary as defense in depth for legacy or
otherwise inconsistent relationships. Soft-deleted memberships are excluded
from these assignment lookups as well.

The behavior is covered for card creation, add/remove and duplication.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes (not applicable)

## Testing

- `pnpm --filter @kan/api test -- card-members.test.ts`
- `pnpm --filter @kan/db typecheck`
- `pnpm --filter @kan/api exec tsc --noEmit --jsx preserve`

## Linked issue

Refs #416. This intentionally addresses only the card-member assignment part
of that report, so it does not close the broader issue.

The same workspace-boundary class was previously addressed for member and
permission endpoints in #410 / #413.
