### PR TITLE
fix: preserve custom label colours when editing

### DIFF
--- a/apps/web/src/components/LabelForm.tsx
+++ b/apps/web/src/components/LabelForm.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { HiChevronUpDown, HiXMark } from "react-icons/hi2";
 
+import type { Colour } from "@kan/shared/constants";
 import { colours } from "@kan/shared/constants";
 
 import Button from "~/components/Button";
@@ -11,16 +12,12 @@ import Input from "~/components/Input";
 import Toggle from "~/components/Toggle";
 import { useModal } from "~/providers/modal";
 import { api } from "~/utils/api";
+import { resolveLabelColour } from "~/utils/labelColours";
 
 interface LabelFormInput {
   name: string;
   colour: Colour;
   isCreateAnotherEnabled?: boolean;
-}
-
-interface Colour {
-  name: string;
-  code: string;
 }
 
 export function LabelForm({
@@ -47,9 +44,7 @@ export function LabelForm({
     useForm<LabelFormInput>({
       values: {
         name: isEdit && label.data?.name ? label.data.name : "",
-        colour: (isEdit && label.data?.colourCode
-          ? colours.find((c) => c.code === label.data?.colourCode)
-          : colours[0]) as Colour,
+        colour: resolveLabelColour(isEdit ? label.data?.colourCode : undefined),
         isCreateAnotherEnabled: false,
       },
     });

--- a/apps/web/src/utils/labelColours.test.ts
+++ b/apps/web/src/utils/labelColours.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { colours } from "@kan/shared/constants";
+
+import { resolveLabelColour } from "./labelColours";
+
+describe("resolveLabelColour", () => {
+  it("returns the matching palette colour", () => {
+    expect(resolveLabelColour(colours[1]?.code)).toEqual(colours[1]);
+  });
+
+  it("preserves a custom colour", () => {
+    expect(resolveLabelColour("#4bce97")).toEqual({
+      name: "#4bce97",
+      code: "#4bce97",
+    });
+  });
+
+  it("uses the default colour when no colour is stored", () => {
+    expect(resolveLabelColour(null)).toEqual(colours[0]);
+    expect(resolveLabelColour(undefined)).toEqual(colours[0]);
+  });
+});

--- a/apps/web/src/utils/labelColours.ts
+++ b/apps/web/src/utils/labelColours.ts
@@ -1,0 +1,18 @@
+import type { Colour } from "@kan/shared/constants";
+import { colours } from "@kan/shared/constants";
+
+export const resolveLabelColour = (
+  colourCode: string | null | undefined,
+): Colour => {
+  const defaultColour = colours[0];
+
+  if (!defaultColour) throw new Error("Label colour palette is empty");
+  if (!colourCode) return defaultColour;
+
+  return (
+    colours.find((colour) => colour.code === colourCode) ?? {
+      name: colourCode,
+      code: colourCode,
+    }
+  );
+};

--- a/packages/e2e/tests/self-hosted/card-labels.spec.ts
+++ b/packages/e2e/tests/self-hosted/card-labels.spec.ts
@@ -6,9 +6,10 @@ import { CardPage } from "../support/pages/card-page";
 import { DashboardPage } from "../support/pages/dashboard-page";
 import { SelfHostedOnboardingPage } from "../support/pages/self-hosted-onboarding-page";
 import { createTestUser } from "../support/test-user";
+import { waitForTrpcMutation } from "../support/wait-for-trpc";
 
 test(
-  "a label can be created and assigned to a card, and the assignment persists",
+  "a label can be created, assigned, and edited with a custom colour",
   { tag: "@self-hosted" },
   async ({ page }) => {
     const user = createTestUser();
@@ -27,11 +28,35 @@ test(
     await board.createCard("Label test card");
     await board.openCard("Label test card");
 
-    await card.createAndAssignLabel("Urgent");
+    const labelPublicId = await card.createAndAssignLabel("Urgent");
 
     await expect(card.assignedLabelBadge("Urgent")).toBeVisible();
 
     await page.reload();
     await expect(card.assignedLabelBadge("Urgent")).toBeVisible();
+
+    const response = await page.request.post("/api/trpc/label.update?batch=1", {
+      data: {
+        "0": {
+          json: {
+            labelPublicId,
+            name: "Urgent",
+            colourCode: "#4bce97",
+          },
+        },
+      },
+    });
+    expect(response.ok()).toBe(true);
+
+    await page.reload();
+    await card.openLabelEditor("Urgent");
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByRole("button", { name: "#4bce97" })).toBeVisible();
+
+    const updated = waitForTrpcMutation(page, "label.update");
+    await dialog.getByRole("button", { name: "Update label" }).click();
+    const updatedResponse = await updated;
+    expect(updatedResponse.ok()).toBe(true);
   },
 );

--- a/packages/e2e/tests/support/pages/card-page.ts
+++ b/packages/e2e/tests/support/pages/card-page.ts
@@ -69,8 +69,26 @@ export class CardPage {
     const created = waitForTrpcMutation(this.page, "label.create");
     const assigned = waitForTrpcMutation(this.page, "card.addOrRemoveLabel");
     await dialog.getByRole("button", { name: "Create label" }).click();
-    await created;
+    const createdResponse = await created;
     await assigned;
+
+    const body = (await createdResponse.json()) as [
+      { result: { data: { json: { publicId: string } } } },
+    ];
+
+    return body[0].result.data.json.publicId;
+  }
+
+  async openLabelEditor(name: string) {
+    await this.labelSelectorTrigger().click();
+
+    const checkbox = this.page
+      .getByRole("checkbox", { name })
+      .filter({ visible: true });
+    const row = checkbox.locator("..");
+
+    await row.hover();
+    await row.getByRole("button").click();
   }
 
   async uploadAttachment(filePath: string) {


### PR DESCRIPTION
## Description

Labels created through the API or MCP can use a colour outside the built-in
eight-colour palette. When one of those labels was opened for editing,
`LabelForm` could not resolve a selected option and attempted to render an
undefined value.

This keeps the existing creation palette unchanged while treating the stored
HEX value as the current option when it is not one of the presets. The label can
then be opened and saved without losing its colour, or changed to one of the
normal presets.

The shared resolver is covered for preset, custom and missing colour values.
The existing self-hosted label scenario now also assigns a custom colour via
the API, opens the edit form and saves it again.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [ ] I have included screenshots for any UI changes

There is no intended layout or design change; this restores the edit form for
an already supported stored value.

## Testing

- `pnpm --filter @kan/web test` — 11 tests passed
- targeted ESLint and Prettier checks for the changed files
- `pnpm --filter @kan/e2e typecheck`
- self-hosted `card-labels.spec.ts` against PostgreSQL 16 — 1 test passed
- Next.js production build completed as part of the Playwright run

## Linked issue

Not applicable: this fixes editing for custom label colours already accepted by
the API, database and MCP.
