### PR TITLE
fix: preserve Trello label colours during import

### DIFF
--- a/packages/api/src/routers/import.ts
+++ b/packages/api/src/routers/import.ts
@@ -11,7 +11,6 @@ import * as labelRepo from "@kan/db/repository/label.repo";
 import * as listRepo from "@kan/db/repository/list.repo";
 import * as workspaceRepo from "@kan/db/repository/workspace.repo";
 import { createLogger } from "@kan/logger";
-import { colours } from "@kan/shared/constants";
 import {
   generateSlug,
   generateUID,
@@ -22,6 +21,7 @@ import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { assertUserInWorkspace } from "../utils/auth";
 import { decryptToken } from "../utils/encryption";
 import { assertPermission } from "../utils/permissions";
+import { getTrelloLabelColour } from "../utils/trello";
 import { apiKeys, urls } from "./integration";
 
 const log = createLogger("import");
@@ -38,6 +38,7 @@ export interface TrelloBoard {
 interface TrelloLabel {
   id: string;
   name: string;
+  color?: string | null;
 }
 
 interface TrelloList {
@@ -256,7 +257,7 @@ export const importRouter = createTRPCRouter({
 
         const importSingleBoard = async (boardId: string): Promise<void> => {
           const response = await fetch(
-            `${urls.trello}/boards/${boardId}?key=${apiKey}&token=${integration.accessToken}&lists=open&cards=open&labels=all&checklists=all&checkItemStates=all`,
+            `${urls.trello}/boards/${boardId}?key=${apiKey}&token=${integration.accessToken}&lists=open&cards=open&labels=all&labels_limit=1000&checklists=all&checkItemStates=all`,
           );
 
           if (!response.ok) {
@@ -273,6 +274,7 @@ export const importRouter = createTRPCRouter({
               .map((label) => ({
                 sourceId: label.id,
                 name: label.name,
+                colourCode: getTrelloLabelColour(label.color),
               }))
               .filter((_label) => !!_label.name),
             lists: data.lists.map((list) => ({
@@ -326,10 +328,10 @@ export const importRouter = createTRPCRouter({
           let createdCards: { id: number; sourceId: string }[] = [];
 
           if (formattedData.labels.length) {
-            const labelsInsert = formattedData.labels.map((label, index) => ({
+            const labelsInsert = formattedData.labels.map((label) => ({
               publicId: generateUID(),
               name: label.name,
-              colourCode: colours[index % colours.length]?.code ?? "#0d9488",
+              colourCode: label.colourCode,
               createdBy: userId,
               boardId: newBoardId,
               importId: newImportId,

--- a/packages/api/src/utils/trello.test.ts
+++ b/packages/api/src/utils/trello.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { getTrelloLabelColour } from "./trello";
+
+describe("getTrelloLabelColour", () => {
+  it.each([
+    ["green", "#4bce97"],
+    ["yellow", "#f5cd47"],
+    ["orange", "#fea362"],
+    ["red", "#f87168"],
+    ["purple", "#9f8fef"],
+    ["blue", "#579dff"],
+    ["sky", "#6cc3e0"],
+    ["lime", "#94c748"],
+    ["pink", "#e774bb"],
+    ["black", "#8590a2"],
+    ["green_dark", "#1f845a"],
+    ["yellow_dark", "#946f00"],
+    ["orange_dark", "#c25100"],
+    ["red_dark", "#c9372c"],
+    ["purple_dark", "#6e5dc6"],
+    ["blue_dark", "#0c66e4"],
+    ["sky_dark", "#227d9b"],
+    ["lime_dark", "#5b7f24"],
+    ["pink_dark", "#ae4787"],
+    ["black_dark", "#626f86"],
+    ["green_light", "#baf3db"],
+    ["yellow_light", "#f8e6a0"],
+    ["orange_light", "#fedec8"],
+    ["red_light", "#ffd5d2"],
+    ["purple_light", "#dfd8fd"],
+    ["blue_light", "#cce0ff"],
+    ["sky_light", "#c6edfb"],
+    ["lime_light", "#d3f1a7"],
+    ["pink_light", "#fdd0ec"],
+    ["black_light", "#dcdfe4"],
+  ])("maps Trello colour %s to %s", (colour, expected) => {
+    expect(getTrelloLabelColour(colour)).toBe(expected);
+  });
+
+  it.each([null, undefined, ""])(
+    "uses a neutral colour for a colourless Trello label",
+    (colour) => {
+      expect(getTrelloLabelColour(colour)).toBe("#8590a2");
+    },
+  );
+
+  it("uses the default Kan colour for an unknown Trello colour", () => {
+    expect(getTrelloLabelColour("future_colour")).toBe("#0d9488");
+  });
+});

--- a/packages/api/src/utils/trello.ts
+++ b/packages/api/src/utils/trello.ts
@@ -1,0 +1,41 @@
+const trelloLabelColours: Record<string, string> = {
+  green: "#4bce97",
+  yellow: "#f5cd47",
+  orange: "#fea362",
+  red: "#f87168",
+  purple: "#9f8fef",
+  blue: "#579dff",
+  sky: "#6cc3e0",
+  lime: "#94c748",
+  pink: "#e774bb",
+  black: "#8590a2",
+  green_dark: "#1f845a",
+  yellow_dark: "#946f00",
+  orange_dark: "#c25100",
+  red_dark: "#c9372c",
+  purple_dark: "#6e5dc6",
+  blue_dark: "#0c66e4",
+  sky_dark: "#227d9b",
+  lime_dark: "#5b7f24",
+  pink_dark: "#ae4787",
+  black_dark: "#626f86",
+  green_light: "#baf3db",
+  yellow_light: "#f8e6a0",
+  orange_light: "#fedec8",
+  red_light: "#ffd5d2",
+  purple_light: "#dfd8fd",
+  blue_light: "#cce0ff",
+  sky_light: "#c6edfb",
+  lime_light: "#d3f1a7",
+  pink_light: "#fdd0ec",
+  black_light: "#dcdfe4",
+};
+
+const defaultLabelColour = "#0d9488";
+const colourlessLabelColour = "#8590a2";
+
+export const getTrelloLabelColour = (colour: string | null | undefined) => {
+  if (!colour) return colourlessLabelColour;
+
+  return trelloLabelColours[colour] ?? defaultLabelColour;
+};

--- a/packages/e2e/tests/self-hosted/trello-import.spec.ts
+++ b/packages/e2e/tests/self-hosted/trello-import.spec.ts
@@ -52,7 +52,12 @@ test(
     await expect(page.getByText("Add dark mode")).toBeVisible();
 
     await board.openCard("Fix login bug");
-    await expect(card.assignedLabelBadge("Bug")).toBeVisible();
+    const bugLabel = card.assignedLabelBadge("Bug");
+    await expect(bugLabel).toBeVisible();
+    await expect(bugLabel.locator("..").locator("svg")).toHaveAttribute(
+      "fill",
+      "#c9372c",
+    );
     await expect(page.getByText("Reproduce issue")).toBeVisible();
     await expect(page.getByText("Write fix")).toBeVisible();
   },

--- a/packages/e2e/tests/support/trello-mock-server.js
+++ b/packages/e2e/tests/support/trello-mock-server.js
@@ -6,8 +6,8 @@ const board = {
   id: "mock-board-1",
   name: "Mock Trello Board",
   labels: [
-    { id: "label-1", name: "Bug" },
-    { id: "label-2", name: "Feature" },
+    { id: "label-1", name: "Bug", color: "red_dark" },
+    { id: "label-2", name: "Feature", color: "blue_light" },
   ],
   lists: [
     { id: "list-1", name: "To Do" },
@@ -19,14 +19,14 @@ const board = {
       name: "Fix login bug",
       desc: "Users can't log in",
       idList: "list-1",
-      labels: [{ id: "label-1", name: "Bug" }],
+      labels: [{ id: "label-1", name: "Bug", color: "red_dark" }],
     },
     {
       id: "card-2",
       name: "Add dark mode",
       desc: "",
       idList: "list-2",
-      labels: [{ id: "label-2", name: "Feature" }],
+      labels: [{ id: "label-2", name: "Feature", color: "blue_light" }],
     },
   ],
   checklists: [
@@ -59,6 +59,12 @@ const server = createServer((req, res) => {
   }
 
   if (url.pathname === `/boards/${board.id}`) {
+    if (url.searchParams.get("labels_limit") !== "1000") {
+      res.writeHead(400);
+      res.end(JSON.stringify({ message: "labels_limit must be 1000" }));
+      return;
+    }
+
     res.writeHead(200);
     res.end(JSON.stringify(board));
     return;


### PR DESCRIPTION
## Summary

- preserve Trello label colours instead of assigning colours by array position
- support all 30 named Trello colour variants, with explicit fallbacks for
  colourless and unknown values
- request up to 1,000 labels per board instead of relying on Trello's default
  nested collection limit
- cover the mapping and import request in unit and self-hosted E2E tests

## Why

We are migrating an established Trello workspace rather than a small example
board. It currently has 422 label definitions; the two largest boards have 75
and 57. There are 77 dark/light colour definitions used by 336 card-label
assignments. The current importer both truncates large label collections and
loses those source colours.

The colour mapping stays inside the Trello import boundary. Kan's shared label
palette and creation UI are unchanged. Colourless labels retain the existing
grey fallback, and unknown future Trello values use a deterministic fallback.

This follows #577, which made imported custom HEX values safe to edit.

## Testing

- `pnpm --filter @kan/api exec vitest run src/utils/trello.test.ts` — 34 passed
- API and E2E typechecks
- package-scoped ESLint and Prettier checks
- both self-hosted Trello import scenarios, including a `red_dark` label and a
  mock assertion for `labels_limit=1000`
