### PR TITLE
feat: clarify active board filters

### DIFF
--- a/apps/web/src/components/CheckboxDropdown.tsx
+++ b/apps/web/src/components/CheckboxDropdown.tsx
@@ -1,6 +1,11 @@
 import { Menu, Transition } from "@headlessui/react";
 import { Fragment, useState } from "react";
-import { HiEllipsisHorizontal, HiMiniPlus } from "react-icons/hi2";
+import {
+  HiChevronLeft,
+  HiChevronRight,
+  HiEllipsisHorizontal,
+  HiMiniPlus,
+} from "react-icons/hi2";
 import { twMerge } from "tailwind-merge";
 
 interface Item {
@@ -15,6 +20,7 @@ interface Group {
   label: string;
   icon: React.ReactNode;
   items: Item[];
+  selectedCount?: number;
 }
 
 interface CheckboxDropdownProps {
@@ -33,6 +39,8 @@ interface CheckboxDropdownProps {
   asChild?: boolean;
   disabled?: boolean;
   ariaLabel?: string;
+  backLabel?: string;
+  footer?: React.ReactNode;
 }
 
 export default function CheckboxDropdown({
@@ -48,14 +56,27 @@ export default function CheckboxDropdown({
   asChild = true,
   disabled = false,
   ariaLabel,
+  backLabel = "Back",
+  footer,
 }: CheckboxDropdownProps) {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
+
+  const selectedGroupDetails = groups?.find(
+    (group) => group.key === selectedGroup,
+  );
 
   const menuSpacingClass = {
     sm: "top-[26px]",
     md: "top-[32px]",
     lg: "top-[38px]",
   };
+
+  const renderSelectedCount = (count?: number) =>
+    count ? (
+      <span className="min-w-5 rounded-full bg-light-300 px-1.5 py-0.5 text-center text-[10px] font-semibold leading-4 dark:bg-dark-400">
+        {count}
+      </span>
+    ) : null;
 
   const renderMenuItems = (items: Item[], groupKey: string | null) => (
     <>
@@ -178,20 +199,48 @@ export default function CheckboxDropdown({
                         <span className="pointer-events-none text-[12px] text-dark-900">
                           {group.label}
                         </span>
+                        <span className="ml-auto flex items-center gap-2 text-dark-900">
+                          {renderSelectedCount(group.selectedCount)}
+                          <HiChevronRight size={14} aria-hidden="true" />
+                        </span>
                       </div>
                     </Menu.Item>
                   ))}
                 </>
               ) : (
                 <>
-                  {groups?.find((g) => g.key === selectedGroup)?.items &&
-                    renderMenuItems(
-                      groups.find((g) => g.key === selectedGroup)?.items || [],
-                      selectedGroup,
-                    )}
+                  <Menu.Item>
+                    <button
+                      type="button"
+                      className="flex w-full items-center rounded-[5px] p-2 text-dark-900 hover:bg-light-200 dark:hover:bg-dark-300"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setSelectedGroup(null);
+                      }}
+                    >
+                      <span className="sr-only">{backLabel}</span>
+                      <HiChevronLeft size={14} aria-hidden="true" />
+                      <span className="ml-2 text-[12px] font-semibold">
+                        {selectedGroupDetails?.label}
+                      </span>
+                      <span className="ml-auto">
+                        {renderSelectedCount(
+                          selectedGroupDetails?.selectedCount,
+                        )}
+                      </span>
+                    </button>
+                  </Menu.Item>
+                  <div className="my-1 border-t border-light-200 dark:border-dark-500" />
+                  {selectedGroupDetails?.items &&
+                    renderMenuItems(selectedGroupDetails.items, selectedGroup)}
                 </>
               )}
             </div>
+            {footer && (
+              <div className="border-t border-light-200 p-1 dark:border-dark-500">
+                <Menu.Item>{footer}</Menu.Item>
+              </div>
+            )}
           </Menu.Items>
         </Transition>
       </>

--- a/apps/web/src/components/CheckboxDropdown.tsx
+++ b/apps/web/src/components/CheckboxDropdown.tsx
@@ -223,7 +223,7 @@ export default function CheckboxDropdown({
                       <span className="ml-2 text-[12px] font-semibold">
                         {selectedGroupDetails?.label}
                       </span>
-                      <span className="ml-auto">
+                      <span className="ml-auto flex items-center">
                         {renderSelectedCount(
                           selectedGroupDetails?.selectedCount,
                         )}

--- a/apps/web/src/views/board/components/Filters.tsx
+++ b/apps/web/src/views/board/components/Filters.tsx
@@ -54,10 +54,7 @@ const Filters = ({
 }) => {
   const router = useRouter();
 
-  const clearFilters = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-
+  const clearFilters = async () => {
     try {
       await router.push({
         pathname: router.pathname,
@@ -139,6 +136,13 @@ const Filters = ({
     },
   ];
 
+  const filterCounts = {
+    members: formatToArray(router.query.members).length,
+    labels: formatToArray(router.query.labels).length,
+    lists: formatToArray(router.query.lists).length,
+    dueDate: formatToArray(router.query.dueDate).length,
+  };
+
   const groups = [
     ...(formattedMembers.length
       ? [
@@ -147,6 +151,7 @@ const Filters = ({
             label: t`Members`,
             icon: <HiOutlineUserCircle size={16} />,
             items: formattedMembers,
+            selectedCount: filterCounts.members,
           },
         ]
       : []),
@@ -155,6 +160,7 @@ const Filters = ({
       label: t`Labels`,
       icon: <HiOutlineTag size={16} />,
       items: formattedLabels,
+      selectedCount: filterCounts.labels,
     },
     ...(formattedLists.length
       ? [
@@ -163,6 +169,7 @@ const Filters = ({
             label: t`Lists`,
             icon: <HiOutlineSquare3Stack3D size={16} />,
             items: formattedLists,
+            selectedCount: filterCounts.lists,
           },
         ]
       : []),
@@ -171,6 +178,7 @@ const Filters = ({
       label: t`Due date`,
       icon: <HiOutlineClock size={16} />,
       items: dueDateItems,
+      selectedCount: filterCounts.dueDate,
     },
   ];
 
@@ -198,12 +206,10 @@ const Filters = ({
     }
   };
 
-  const numOfFilters = [
-    ...formatToArray(router.query.members),
-    ...formatToArray(router.query.labels),
-    ...formatToArray(router.query.lists),
-    ...formatToArray(router.query.dueDate),
-  ].length;
+  const numOfFilters = Object.values(filterCounts).reduce(
+    (total, count) => total + count,
+    0,
+  );
 
   return (
     <div className="relative">
@@ -212,6 +218,19 @@ const Filters = ({
         handleSelect={handleSelect}
         menuSpacing="md"
         position={position}
+        backLabel={t`Back`}
+        footer={
+          numOfFilters > 0 ? (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="flex w-full items-center rounded-[5px] p-2 text-[12px] font-semibold text-dark-900 hover:bg-light-200 dark:hover:bg-dark-300"
+            >
+              <HiMiniXMark size={16} className="mr-2" aria-hidden="true" />
+              {t`Clear filters`}
+            </button>
+          ) : undefined
+        }
       >
         <Button
           variant="secondary"
@@ -221,17 +240,12 @@ const Filters = ({
           {t`Filter`}
         </Button>
         {numOfFilters > 0 && (
-          <button
-            type="button"
-            onClick={clearFilters}
-            aria-label={t`Clear filters`}
-            className="group absolute -right-[8px] -top-[8px] flex h-5 w-5 items-center justify-center rounded-full border-2 border-light-100 bg-light-1000 text-[8px] font-[700] text-light-600 dark:border-dark-50 dark:bg-dark-1000 dark:text-dark-600"
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute -right-[8px] -top-[8px] flex h-5 w-5 items-center justify-center rounded-full border-2 border-light-100 bg-light-1000 text-[8px] font-[700] text-light-600 dark:border-dark-50 dark:bg-dark-1000 dark:text-dark-600"
           >
-            <span className="group-hover:hidden">{numOfFilters}</span>
-            <span className="hidden text-light-50 group-hover:inline dark:text-dark-50">
-              <HiMiniXMark size={12} />
-            </span>
-          </button>
+            {numOfFilters}
+          </span>
         )}
       </CheckboxDropdown>
     </div>

--- a/apps/web/src/views/board/components/Filters.tsx
+++ b/apps/web/src/views/board/components/Filters.tsx
@@ -242,7 +242,7 @@ const Filters = ({
         {numOfFilters > 0 && (
           <span
             aria-hidden="true"
-            className="pointer-events-none absolute -right-[8px] -top-[8px] flex h-5 w-5 items-center justify-center rounded-full border-2 border-light-100 bg-light-1000 text-[8px] font-[700] text-light-600 dark:border-dark-50 dark:bg-dark-1000 dark:text-dark-600"
+            className="pointer-events-none absolute -right-2.5 -top-2.5 flex h-5 w-5 items-center justify-center rounded-full border-2 border-light-100 bg-light-1000 text-[8px] font-[700] leading-none text-light-600 dark:border-dark-50 dark:bg-dark-1000 dark:text-dark-600"
           >
             {numOfFilters}
           </span>

--- a/packages/e2e/tests/self-hosted/board-filters.spec.ts
+++ b/packages/e2e/tests/self-hosted/board-filters.spec.ts
@@ -44,8 +44,17 @@ test(
       0,
     );
 
+    await page.getByRole("button", { name: "Filter", exact: true }).click();
+    await expect(
+      page.getByRole("menuitem", { name: "Labels 1", exact: true }),
+    ).toBeVisible();
+    await page.getByRole("menuitem", { name: "Labels 1", exact: true }).click();
+    await expect(
+      page.getByRole("checkbox", { name: "Urgent", exact: true }),
+    ).toBeChecked();
+
     await page
-      .getByRole("button", { name: "Clear filters", exact: true })
+      .getByRole("menuitem", { name: "Clear filters", exact: true })
       .click();
 
     await expect(page.getByText("Labeled card", { exact: true })).toBeVisible();

--- a/packages/e2e/tests/self-hosted/board-filters.spec.ts
+++ b/packages/e2e/tests/self-hosted/board-filters.spec.ts
@@ -43,6 +43,7 @@ test(
     await expect(page.getByText("Unlabeled card", { exact: true })).toHaveCount(
       0,
     );
+    await expect(page.getByRole("menu")).toHaveCount(0);
 
     await page.getByRole("button", { name: "Filter", exact: true }).click();
     await expect(


### PR DESCRIPTION
## Description

Board filters currently show only a total count on the Filter button. The
dropdown does not indicate which groups contain selected values, and clearing
filters is hidden behind a hover interaction on the count badge.

This change:

- shows the selected-value count next to each filter group;
- keeps the total badge as a status indicator instead of a hidden action;
- adds an explicit `Clear filters` action at the bottom of the menu;
- adds a back row for moving between filter groups without reopening the menu;
- extends the existing board-filter E2E scenario to cover the count, selected
  checkbox and clear action.

Filter state and behavior are unchanged. The existing URL query remains the
source of truth, and the shared dropdown only gains optional presentation
slots.

## Type of change

- [ ] Bug fix
- [x] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Screenshots

Group counts and explicit reset, desktop:

![Filter group counts on desktop](https://raw.githubusercontent.com/habralab/kan/pr-assets-filter-ui/screenshots/00-filter-groups-desktop-dark.png)

Selected value inside a group, desktop:

![Selected filter value on desktop](https://raw.githubusercontent.com/habralab/kan/pr-assets-filter-ui/screenshots/01-selected-value-desktop-dark.png)

Group counts and explicit reset, mobile:

![Filter group counts on mobile](https://raw.githubusercontent.com/habralab/kan/pr-assets-filter-ui/screenshots/02-filter-groups-mobile-dark.png)

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes

## Linked issue

Closes #580
