### PR TITLE
test: update card member mock for description normalization

### DIFF
--- a/packages/api/src/routers/card-members.test.ts
+++ b/packages/api/src/routers/card-members.test.ts
@@ -44,6 +44,7 @@ vi.mock("@kan/auth/server", () => ({
 vi.mock("@kan/shared/utils", () => ({
   generateAttachmentUrl: vi.fn(),
   generateAvatarUrl: vi.fn(),
+  normalizeDescription: vi.fn((description: string) => description),
 }));
 vi.mock("../utils/notifications", () => ({
   sendMentionEmails: vi.fn(),


### PR DESCRIPTION
## What changed

Adds `normalizeDescription` to the shared-utils mock used by the card-member router tests.

## Why

The card-member tests introduced in #576 fully mock `@kan/shared/utils`. After #582 began normalising descriptions in card create and duplicate, those tests fail before reaching their workspace-scoping assertions because the mock does not expose the new helper.

This is test-only and does not change runtime behaviour.

It also restores the unit-test baseline currently blocking otherwise passing
#572, #579, #581, and #586.

## Verification

`pnpm --filter @kan/api exec vitest run src/routers/card-members.test.ts` — 5 tests passed.
