### PR TITLE
feat: define paused member card behavior

### DIFF
--- a/apps/web/src/views/board/components/Card.tsx
+++ b/apps/web/src/views/board/components/Card.tsx
@@ -1,3 +1,4 @@
+import { t } from "@lingui/core/macro";
 import { format, isBefore, isSameYear, startOfDay } from "date-fns";
 import { HiOutlinePaperClip } from "react-icons/hi";
 import {
@@ -31,6 +32,7 @@ const Card = ({
   members: {
     publicId: string;
     email: string;
+    status: "active" | "invited" | "removed" | "paused";
     user: { name: string | null; email: string; image: string | null } | null;
   }[];
   checklists: {
@@ -141,18 +143,26 @@ const Card = ({
               )}
               {members.length > 0 && (
                 <div className="isolate flex justify-end -space-x-1 overflow-hidden">
-                  {members.map(({ user, email }) => {
+                  {members.map(({ publicId, user, email, status }) => {
                     const avatarUrl = user?.image
                       ? getAvatarUrl(user.image)
                       : undefined;
 
                     return (
-                      <Avatar
-                        name={user?.name ?? ""}
-                        email={user?.email ?? email}
-                        imageUrl={avatarUrl}
-                        size="sm"
-                      />
+                      <span
+                        key={publicId}
+                        className={
+                          status === "paused" ? "opacity-50" : undefined
+                        }
+                        title={status === "paused" ? t`Paused` : undefined}
+                      >
+                        <Avatar
+                          name={user?.name ?? ""}
+                          email={user?.email ?? email}
+                          imageUrl={avatarUrl}
+                          size="sm"
+                        />
+                      </span>
                     );
                   })}
                 </div>

--- a/apps/web/src/views/board/components/CardContextMembersModal.tsx
+++ b/apps/web/src/views/board/components/CardContextMembersModal.tsx
@@ -1,9 +1,9 @@
 import { t } from "@lingui/core/macro";
 
+import Avatar from "~/components/Avatar";
 import { useModal } from "~/providers/modal";
 import { api } from "~/utils/api";
 import { formatMemberDisplayName, getAvatarUrl } from "~/utils/helpers";
-import Avatar from "~/components/Avatar";
 import MemberSelector from "~/views/card/components/MemberSelector";
 
 export function CardContextMembersModal() {
@@ -18,29 +18,49 @@ export function CardContextMembersModal() {
   const workspaceMembers = board?.workspace?.members ?? [];
   const selectedMembers = card?.members ?? [];
 
-  const formattedMembers = workspaceMembers.map((member) => {
+  const formattedMembers = workspaceMembers.flatMap((member) => {
     const isSelected = selectedMembers.some(
       (m) => m.publicId === member.publicId,
     );
-    return {
-      key: member.publicId,
-      value: formatMemberDisplayName(
-        member.user?.name ?? null,
-        member.user?.email ?? member.email,
-      ),
-      imageUrl: member.user?.image ? getAvatarUrl(member.user.image) : undefined,
-      selected: isSelected,
-      leftIcon: (
-        <Avatar
-          size="xs"
-          name={member.user?.name ?? ""}
-          imageUrl={
-            member.user?.image ? getAvatarUrl(member.user.image) : undefined
-          }
-          email={member.user?.email ?? member.email}
-        />
-      ),
-    };
+
+    if (member.status === "paused" && !isSelected) return [];
+
+    const displayName = formatMemberDisplayName(
+      member.user?.name ?? null,
+      member.user?.email ?? member.email,
+    );
+
+    return [
+      {
+        key: member.publicId,
+        value:
+          member.status === "paused"
+            ? `${displayName} (${t`Paused`})`
+            : displayName,
+        imageUrl: member.user?.image
+          ? getAvatarUrl(member.user.image)
+          : undefined,
+        email: member.user?.email ?? member.email,
+        userId: member.user?.id ?? null,
+        name: member.user?.name ?? null,
+        status: member.status,
+        selected: isSelected,
+        leftIcon: (
+          <span
+            className={member.status === "paused" ? "opacity-50" : undefined}
+          >
+            <Avatar
+              size="xs"
+              name={member.user?.name ?? ""}
+              imageUrl={
+                member.user?.image ? getAvatarUrl(member.user.image) : undefined
+              }
+              email={member.user?.email ?? member.email}
+            />
+          </span>
+        ),
+      },
+    ];
   });
 
   if (!cardPublicId) return null;

--- a/apps/web/src/views/board/components/Filters.tsx
+++ b/apps/web/src/views/board/components/Filters.tsx
@@ -18,9 +18,11 @@ import {
   formatToArray,
   getAvatarUrl,
 } from "~/utils/helpers";
+import { getBoardFilterMembers } from "../memberFilters";
 
 interface Member {
   publicId: string;
+  status: "active" | "invited" | "removed" | "paused";
   user: {
     name: string | null;
     image: string | null;
@@ -43,12 +45,14 @@ const Filters = ({
   position = "right",
   labels,
   members,
+  assignedMemberPublicIds,
   lists,
   isLoading,
 }: {
   position?: "left" | "right";
   labels: Label[];
   members: Member[];
+  assignedMemberPublicIds?: Set<string>;
   lists: List[];
   isLoading: boolean;
 }) => {
@@ -71,24 +75,29 @@ const Filters = ({
     }
   };
 
-  const formattedMembers = members.map((member) => ({
-    key: member.publicId,
-    value: formatMemberDisplayName(
-      member.user?.name ?? null,
-      member.user?.email ?? null,
-    ),
-    selected: !!router.query.members?.includes(member.publicId),
-    leftIcon: (
-      <Avatar
-        size="xs"
-        name={member.user?.name ?? ""}
-        imageUrl={
-          member.user?.image ? getAvatarUrl(member.user.image) : undefined
-        }
-        email={member.user?.email ?? ""}
-      />
-    ),
-  }));
+  const formattedMembers = getBoardFilterMembers(
+    members,
+    assignedMemberPublicIds,
+  ).map((member) => ({
+      key: member.publicId,
+      value: `${formatMemberDisplayName(
+        member.user?.name ?? null,
+        member.user?.email ?? null,
+      )}${member.status === "paused" ? ` (${t`Paused`})` : ""}`,
+      selected: !!router.query.members?.includes(member.publicId),
+      leftIcon: (
+        <span className={member.status === "paused" ? "opacity-50" : undefined}>
+          <Avatar
+            size="xs"
+            name={member.user?.name ?? ""}
+            imageUrl={
+              member.user?.image ? getAvatarUrl(member.user.image) : undefined
+            }
+            email={member.user?.email ?? ""}
+          />
+        </span>
+      ),
+    }));
 
   const formattedLabels = labels.map((label) => ({
     key: label.publicId,

--- a/apps/web/src/views/board/components/Filters.tsx
+++ b/apps/web/src/views/board/components/Filters.tsx
@@ -79,25 +79,25 @@ const Filters = ({
     members,
     assignedMemberPublicIds,
   ).map((member) => ({
-      key: member.publicId,
-      value: `${formatMemberDisplayName(
-        member.user?.name ?? null,
-        member.user?.email ?? null,
-      )}${member.status === "paused" ? ` (${t`Paused`})` : ""}`,
-      selected: !!router.query.members?.includes(member.publicId),
-      leftIcon: (
-        <span className={member.status === "paused" ? "opacity-50" : undefined}>
-          <Avatar
-            size="xs"
-            name={member.user?.name ?? ""}
-            imageUrl={
-              member.user?.image ? getAvatarUrl(member.user.image) : undefined
-            }
-            email={member.user?.email ?? ""}
-          />
-        </span>
-      ),
-    }));
+    key: member.publicId,
+    value: `${formatMemberDisplayName(
+      member.user?.name ?? null,
+      member.user?.email ?? null,
+    )}${member.status === "paused" ? ` (${t`Paused`})` : ""}`,
+    selected: !!router.query.members?.includes(member.publicId),
+    leftIcon: (
+      <span className={member.status === "paused" ? "opacity-50" : undefined}>
+        <Avatar
+          size="xs"
+          name={member.user?.name ?? ""}
+          imageUrl={
+            member.user?.image ? getAvatarUrl(member.user.image) : undefined
+          }
+          email={member.user?.email ?? ""}
+        />
+      </span>
+    ),
+  }));
 
   const formattedLabels = labels.map((label) => ({
     key: label.publicId,

--- a/apps/web/src/views/board/components/NewCardForm.tsx
+++ b/apps/web/src/views/board/components/NewCardForm.tsx
@@ -244,25 +244,30 @@ export function NewCardForm({
       selected: list.publicId === watch("listPublicId"),
     })) ?? [];
 
-  const formattedMembers =
-    boardData?.workspace.members.map((member) => ({
-      key: member.publicId,
-      value: formatMemberDisplayName(
-        member.user?.name ?? null,
-        member.user?.email ?? member.email,
-      ),
-      selected: memberPublicIds.includes(member.publicId),
-      leftIcon: (
-        <Avatar
-          size="xs"
-          name={member.user?.name ?? ""}
-          imageUrl={
-            member.user?.image ? getAvatarUrl(member.user.image) : undefined
-          }
-          email={member.user?.email ?? member.email}
-        />
-      ),
-    })) ?? [];
+  const assignableMembers =
+    boardData?.workspace.members.filter(
+      (member) => member.status !== "paused",
+    ) ?? [];
+
+  const formattedMembers = assignableMembers.map((member) => ({
+    key: member.publicId,
+    value: formatMemberDisplayName(
+      member.user?.name ?? null,
+      member.user?.email ?? member.email,
+    ),
+    selected: memberPublicIds.includes(member.publicId),
+    status: member.status,
+    leftIcon: (
+      <Avatar
+        size="xs"
+        name={member.user?.name ?? ""}
+        imageUrl={
+          member.user?.image ? getAvatarUrl(member.user.image) : undefined
+        }
+        email={member.user?.email ?? member.email}
+      />
+    ),
+  }));
 
   const addFiles = (files: File[]) => {
     if (files.length === 0) return;
@@ -439,21 +444,19 @@ export function NewCardForm({
                 setValue("description", value);
                 saveFormState({ ...formState, description: value });
               }}
-              workspaceMembers={
-                boardData?.workspace.members.map(
-                  (member): WorkspaceMember => ({
-                    publicId: member.publicId,
-                    email: member.email,
-                    user: member.user
-                      ? {
-                          id: member.publicId,
-                          name: member.user.name,
-                          image: member.user.image ?? null,
-                        }
-                      : null,
-                  }),
-                ) ?? []
-              }
+              workspaceMembers={assignableMembers.map(
+                (member): WorkspaceMember => ({
+                  publicId: member.publicId,
+                  email: member.email,
+                  user: member.user
+                    ? {
+                        id: member.publicId,
+                        name: member.user.name,
+                        image: member.user.image ?? null,
+                      }
+                    : null,
+                }),
+              )}
               enableYouTubeEmbed={false}
             />
           </div>

--- a/apps/web/src/views/board/index.tsx
+++ b/apps/web/src/views/board/index.tsx
@@ -613,6 +613,9 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
                     members={boardData.workspace.members.filter(
                       (member) => member.user !== null,
                     )}
+                    assignedMemberPublicIds={new Set(
+                      boardData.assignedMemberPublicIds,
+                    )}
                     lists={boardData.allLists}
                     position="left"
                     isLoading={!boardData}

--- a/apps/web/src/views/board/memberFilters.test.ts
+++ b/apps/web/src/views/board/memberFilters.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { getBoardFilterMembers } from "./memberFilters";
+
+describe("getBoardFilterMembers", () => {
+  const members = [
+    { publicId: "paused-a", status: "paused" as const },
+    { publicId: "active-a", status: "active" as const },
+    { publicId: "unassigned", status: "active" as const },
+    { publicId: "invited-a", status: "invited" as const },
+    { publicId: "paused-b", status: "paused" as const },
+  ];
+
+  it("keeps assigned members and places paused members last", () => {
+    const result = getBoardFilterMembers(
+      members,
+      new Set(["paused-a", "active-a", "invited-a", "paused-b"]),
+    );
+
+    expect(result.map((member) => member.publicId)).toEqual([
+      "active-a",
+      "invited-a",
+      "paused-a",
+      "paused-b",
+    ]);
+  });
+
+  it("returns no choices when no board assignments are available", () => {
+    expect(getBoardFilterMembers(members, undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/views/board/memberFilters.ts
+++ b/apps/web/src/views/board/memberFilters.ts
@@ -1,0 +1,15 @@
+interface BoardFilterMember {
+  publicId: string;
+  status: "active" | "invited" | "removed" | "paused";
+}
+
+export const getBoardFilterMembers = <T extends BoardFilterMember>(
+  members: T[],
+  assignedMemberPublicIds: ReadonlySet<string> | undefined,
+) =>
+  members
+    .filter((member) => assignedMemberPublicIds?.has(member.publicId))
+    .sort(
+      (a, b) =>
+        Number(a.status === "paused") - Number(b.status === "paused"),
+    );

--- a/apps/web/src/views/card/components/ActivityList.tsx
+++ b/apps/web/src/views/card/components/ActivityList.tsx
@@ -517,6 +517,7 @@ const ActivityList = ({
               key={activity.publicId}
               publicId={activity.comment?.publicId}
               cardPublicId={cardPublicId}
+              userId={activity.user?.id ?? null}
               name={activity.user?.name ?? ""}
               email={activity.user?.email ?? ""}
               image={activity.user?.image ?? null}

--- a/apps/web/src/views/card/components/Comment.tsx
+++ b/apps/web/src/views/card/components/Comment.tsx
@@ -23,6 +23,7 @@ interface FormValues {
 const Comment = ({
   publicId,
   cardPublicId,
+  userId,
   name,
   email,
   image,
@@ -35,6 +36,7 @@ const Comment = ({
 }: {
   publicId: string | undefined;
   cardPublicId: string;
+  userId: string | null;
   name: string;
   email: string;
   image: string | null;
@@ -65,12 +67,15 @@ const Comment = ({
     },
   );
 
-  const workspaceMembers: WorkspaceMember[] =
+  const workspaceMembers: (WorkspaceMember & {
+    status: "active" | "invited" | "removed" | "paused";
+  })[] =
     cardData?.list.board.workspace.members
       .filter((member) => member.email)
       .map((member) => ({
         publicId: member.publicId,
         email: member.email,
+        status: member.status,
         user: member.user
           ? {
               id: member.user.id,
@@ -79,6 +84,16 @@ const Comment = ({
             }
           : null,
       })) ?? [];
+
+  const isPaused = workspaceMembers.some(
+    (member) =>
+      member.status === "paused" &&
+      (userId ? member.user?.id === userId : member.email === email),
+  );
+
+  const mentionableWorkspaceMembers = workspaceMembers.filter(
+    (member) => member.status !== "paused",
+  );
 
   if (!publicId) return null;
 
@@ -132,16 +147,23 @@ const Comment = ({
     >
       <div className="flex justify-between">
         <div className="flex items-center space-x-2">
-          <Avatar
-            size="sm"
-            name={name ?? ""}
-            email={email ?? ""}
-            imageUrl={getAvatarUrl(image) || undefined}
-            isLoading={isLoading}
-          />
+          <span className={isPaused ? "opacity-50" : undefined}>
+            <Avatar
+              size="sm"
+              name={name ?? ""}
+              email={email ?? ""}
+              imageUrl={getAvatarUrl(image) || undefined}
+              isLoading={isLoading}
+            />
+          </span>
 
           <p className="text-sm">
             <span className="font-medium dark:text-dark-1000">{`${name} `}</span>
+            {isPaused && (
+              <span className="text-light-800 dark:text-dark-800">
+                ({t`Paused`})
+              </span>
+            )}
             <span className="mx-1 text-light-900 dark:text-dark-800">·</span>
             <span className="space-x-1 text-light-900 dark:text-dark-800">
               {formatDistanceToNow(new Date(createdAt), {
@@ -169,7 +191,7 @@ const Comment = ({
           <Editor
             content={comment ?? null}
             readOnly={true}
-            workspaceMembers={workspaceMembers}
+            workspaceMembers={mentionableWorkspaceMembers}
             enableYouTubeEmbed={false}
             disableHeadings={true}
           />
@@ -180,7 +202,7 @@ const Comment = ({
             <Editor
               content={watch("comment")}
               onChange={(value) => setValue("comment", value)}
-              workspaceMembers={workspaceMembers}
+              workspaceMembers={mentionableWorkspaceMembers}
               enableYouTubeEmbed={false}
               placeholder={t`Add comment... (type '/' to open commands or '@' to mention)`}
               disableHeadings={true}

--- a/apps/web/src/views/card/components/MemberSelector.tsx
+++ b/apps/web/src/views/card/components/MemberSelector.tsx
@@ -17,6 +17,10 @@ interface MemberSelectorProps {
     selected: boolean;
     leftIcon: React.ReactNode;
     imageUrl: string | undefined;
+    email: string;
+    userId: string | null;
+    name: string | null;
+    status: "active" | "invited" | "removed" | "paused";
   }[];
   isLoading: boolean;
   disabled?: boolean;
@@ -46,8 +50,8 @@ export default function MemberSelector({
           (member) => member.publicId === update.workspaceMemberPublicId,
         );
 
-        const memberToAdd = oldCard.members.find(
-          (member) => member.publicId === update.workspaceMemberPublicId,
+        const memberToAdd = members.find(
+          (member) => member.key === update.workspaceMemberPublicId,
         );
 
         const updatedMembers = hasMember
@@ -60,9 +64,10 @@ export default function MemberSelector({
                 publicId: update.workspaceMemberPublicId,
                 email: memberToAdd?.email ?? "",
                 deletedAt: null,
+                status: memberToAdd?.status ?? "active",
                 user: {
-                  id: memberToAdd?.user?.id ?? "",
-                  name: memberToAdd?.user?.name ?? "",
+                  id: memberToAdd?.userId ?? null,
+                  name: memberToAdd?.name ?? null,
                 },
               },
             ];
@@ -122,14 +127,19 @@ export default function MemberSelector({
           >
             {selectedMembers.length ? (
               <div className="isolate flex justify-end -space-x-1 overflow-hidden">
-                {selectedMembers.map(({ value, imageUrl }) => (
-                  <Avatar
+                {selectedMembers.map(({ value, imageUrl, status }) => (
+                  <span
                     key={value}
-                    size="sm"
-                    name={value}
-                    imageUrl={imageUrl}
-                    email={value}
-                  />
+                    className={status === "paused" ? "opacity-50" : undefined}
+                    title={status === "paused" ? t`Paused` : undefined}
+                  >
+                    <Avatar
+                      size="sm"
+                      name={value}
+                      imageUrl={imageUrl}
+                      email={value}
+                    />
+                  </span>
                 ))}
               </div>
             ) : (

--- a/apps/web/src/views/card/index.tsx
+++ b/apps/web/src/views/card/index.tsx
@@ -90,32 +90,51 @@ export function CardRightPanel({ isTemplate }: { isTemplate?: boolean }) {
     })) ?? [];
 
   const formattedMembers =
-    workspaceMembers?.map((member) => {
+    workspaceMembers?.flatMap((member) => {
       const isSelected = selectedMembers?.some(
         (assignedMember) => assignedMember.publicId === member.publicId,
       );
 
-      return {
-        key: member.publicId,
-        value: formatMemberDisplayName(
-          member.user?.name ?? null,
-          member.user?.email ?? member.email,
-        ),
-        imageUrl: member.user?.image
-          ? getAvatarUrl(member.user.image)
-          : undefined,
-        selected: isSelected ?? false,
-        leftIcon: (
-          <Avatar
-            size="xs"
-            name={member.user?.name ?? ""}
-            imageUrl={
-              member.user?.image ? getAvatarUrl(member.user.image) : undefined
-            }
-            email={member.user?.email ?? member.email}
-          />
-        ),
-      };
+      if (member.status === "paused" && !isSelected) return [];
+
+      const displayName = formatMemberDisplayName(
+        member.user?.name ?? null,
+        member.user?.email ?? member.email,
+      );
+
+      return [
+        {
+          key: member.publicId,
+          value:
+            member.status === "paused"
+              ? `${displayName} (${t`Paused`})`
+              : displayName,
+          imageUrl: member.user?.image
+            ? getAvatarUrl(member.user.image)
+            : undefined,
+          email: member.user?.email ?? member.email,
+          userId: member.user?.id ?? null,
+          name: member.user?.name ?? null,
+          status: member.status,
+          selected: isSelected ?? false,
+          leftIcon: (
+            <span
+              className={member.status === "paused" ? "opacity-50" : undefined}
+            >
+              <Avatar
+                size="xs"
+                name={member.user?.name ?? ""}
+                imageUrl={
+                  member.user?.image
+                    ? getAvatarUrl(member.user.image)
+                    : undefined
+                }
+                email={member.user?.email ?? member.email}
+              />
+            </span>
+          ),
+        },
+      ];
     }) ?? [];
 
   return (
@@ -216,7 +235,7 @@ export default function CardPage({ isTemplate }: { isTemplate?: boolean }) {
 
   const editorWorkspaceMembers =
     workspaceMembers
-      ?.filter((member) => member.email)
+      ?.filter((member) => member.email && member.status !== "paused")
       .map((member) => ({
         publicId: member.publicId,
         email: member.email,

--- a/packages/api/src/routers/card-members.test.ts
+++ b/packages/api/src/routers/card-members.test.ts
@@ -128,7 +128,7 @@ describe("card member workspace scoping", () => {
         id: 17,
         publicId: "card-12345678",
       });
-      mockGetMembers.mockResolvedValue([{ id: 21 }]);
+      mockGetMembers.mockResolvedValue([{ id: 21, status: "active" }]);
       mockBulkCreateCardMembers.mockResolvedValue([
         { cardId: 17, workspaceMemberId: 21 },
       ]);
@@ -158,6 +158,20 @@ describe("card member workspace scoping", () => {
         }),
       ).rejects.toMatchObject({
         code: "NOT_FOUND",
+      } satisfies Partial<TRPCError>);
+
+      expect(mockCardCreate).not.toHaveBeenCalled();
+      expect(mockBulkCreateCardMembers).not.toHaveBeenCalled();
+    });
+
+    it("rejects paused members before creating the card", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetMembers.mockResolvedValueOnce([{ id: 21, status: "paused" }]);
+
+      await expect(
+        cardRouter.createCaller(ctx).create(input),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
       } satisfies Partial<TRPCError>);
 
       expect(mockCardCreate).not.toHaveBeenCalled();
@@ -195,7 +209,7 @@ describe("card member workspace scoping", () => {
 
     it("removes an existing member relationship in the scoped workspace", async () => {
       const { cardRouter } = await import("./card");
-      mockGetMember.mockResolvedValueOnce({ id: 21 });
+      mockGetMember.mockResolvedValueOnce({ id: 21, status: "paused" });
       mockGetCardMember.mockResolvedValueOnce({ cardId: 17, memberId: 21 });
       mockDeleteCardMember.mockResolvedValueOnce({ success: true });
       mockCreateActivity.mockResolvedValueOnce(undefined);
@@ -205,6 +219,64 @@ describe("card member workspace scoping", () => {
       ).resolves.toEqual({ newMember: false });
 
       expect(mockCreateCardMember).not.toHaveBeenCalled();
+    });
+
+    it("rejects assigning a paused member", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetMember.mockResolvedValueOnce({ id: 21, status: "paused" });
+      mockGetCardMember.mockResolvedValueOnce(undefined);
+
+      await expect(
+        cardRouter.createCaller(ctx).addOrRemoveMember(input),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      } satisfies Partial<TRPCError>);
+
+      expect(mockCreateCardMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("duplicate", () => {
+    it("does not copy paused member assignments", async () => {
+      const { cardRouter } = await import("./card");
+      mockGetCard.mockResolvedValueOnce({ id: 17, workspaceId: 7 });
+      mockGetList.mockResolvedValueOnce({ id: 11, workspaceId: 7 });
+      mockGetCardWithMembers.mockResolvedValueOnce({
+        title: "Source card",
+        description: "",
+        dueDate: null,
+        labels: [],
+        checklists: [],
+        members: [
+          { publicId: "active-member" },
+          { publicId: "paused-member" },
+        ],
+      });
+      mockCardCreate.mockResolvedValueOnce({
+        id: 18,
+        publicId: "duplicate-123",
+      });
+      mockGetMembers.mockResolvedValueOnce([
+        { id: 21, status: "active" },
+        { id: 22, status: "paused" },
+      ]);
+
+      await expect(
+        cardRouter.createCaller(ctx).duplicate({
+          cardPublicId: "source-card-1",
+          listPublicId: "target-list-1",
+          copyLabels: false,
+          copyMembers: true,
+          copyChecklists: false,
+        }),
+      ).resolves.toEqual({ publicId: "duplicate-123" });
+
+      expect(mockBulkCreateCardMembers).toHaveBeenCalledWith(mockDb, [
+        { cardId: 18, workspaceMemberId: 21 },
+      ]);
+      expect(mockBulkCreateActivities).toHaveBeenCalledWith(mockDb, [
+        expect.objectContaining({ workspaceMemberId: 21 }),
+      ]);
     });
   });
 

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -95,6 +95,12 @@ export const cardRouter = createTRPCRouter({
           code: "NOT_FOUND",
         });
 
+      if (members.some((member) => member.status === "paused"))
+        throw new TRPCError({
+          message: `Paused members cannot be assigned to cards`,
+          code: "BAD_REQUEST",
+        });
+
       const newCard = await cardRepo.create(ctx.db, {
         title: input.title,
         description: normalizeDescription(input.description),
@@ -633,6 +639,12 @@ export const cardRouter = createTRPCRouter({
 
         return { newMember: false };
       }
+
+      if (member.status === "paused")
+        throw new TRPCError({
+          message: `Paused members cannot be assigned to cards`,
+          code: "BAD_REQUEST",
+        });
 
       const newCardMemberRelationship =
         await cardRepo.createCardMemberRelationship(ctx.db, cardMemberIds);
@@ -1347,8 +1359,11 @@ export const cardRouter = createTRPCRouter({
           memberPublicIds,
           sourceCardMeta.workspaceId,
         );
-        if (members.length) {
-          const membersInsert = members.map((member) => ({
+        const assignableMembers = members.filter(
+          (member) => member.status !== "paused",
+        );
+        if (assignableMembers.length) {
+          const membersInsert = assignableMembers.map((member) => ({
             cardId: newCard.id,
             workspaceMemberId: member.id,
           }));
@@ -1356,7 +1371,7 @@ export const cardRouter = createTRPCRouter({
             ctx.db,
             membersInsert,
           );
-          const cardActivitesInsert = members.map((member) => ({
+          const cardActivitesInsert = assignableMembers.map((member) => ({
             type: "card.updated.member.added" as const,
             cardId: newCard.id,
             workspaceMemberId: member.id,

--- a/packages/api/src/schemas/board.ts
+++ b/packages/api/src/schemas/board.ts
@@ -4,6 +4,7 @@ import {
   checklistResponseSchema,
   labelSchema,
   workspaceMemberSchema,
+  workspaceMemberStatusSchema,
 } from "./common";
 
 // ─── board.all ───────────────────────────────────────────────
@@ -25,6 +26,7 @@ export const boardListItemSchema = z.object({
 const boardCardMemberSchema = z.object({
   publicId: z.string(),
   email: z.string(),
+  status: workspaceMemberStatusSchema,
   user: z
     .object({
       name: z.string().nullable(),
@@ -56,6 +58,7 @@ export const boardDetailSchema = z.object({
   visibility: z.string(),
   isArchived: z.boolean(),
   favorite: z.boolean(),
+  assignedMemberPublicIds: z.array(z.string()),
   workspace: z.object({
     publicId: z.string(),
     cardPrefix: z.string(),

--- a/packages/api/src/schemas/card.ts
+++ b/packages/api/src/schemas/card.ts
@@ -4,6 +4,7 @@ import {
   checklistResponseSchema,
   labelSchema,
   workspaceMemberSchema,
+  workspaceMemberStatusSchema,
 } from "./common";
 
 // ─── card.create ─────────────────────────────────────────────
@@ -34,6 +35,7 @@ export const commentDeleteResponseSchema = z.object({
 const cardMemberSchema = z.object({
   publicId: z.string(),
   email: z.string(),
+  status: workspaceMemberStatusSchema,
   user: z
     .object({
       id: z.string().nullable(),

--- a/packages/api/src/schemas/common.ts
+++ b/packages/api/src/schemas/common.ts
@@ -32,9 +32,16 @@ export const userSchema = z.object({
 });
 
 // Workspace member sub-object
+export const workspaceMemberStatusSchema = z.enum([
+  "active",
+  "invited",
+  "removed",
+  "paused",
+]);
+
 export const workspaceMemberSchema = z.object({
   publicId: z.string(),
   email: z.string(),
-  status: z.string(),
+  status: workspaceMemberStatusSchema,
   user: userSchema.nullable(),
 });

--- a/packages/db/src/repository/board.repo.ts
+++ b/packages/db/src/repository/board.repo.ts
@@ -160,6 +160,26 @@ export const getByPublicId = async (
 ) => {
   let cardIds: string[] = [];
 
+  const assignedMembers = await db
+    .selectDistinct({ publicId: workspaceMembers.publicId })
+    .from(cardToWorkspaceMembers)
+    .innerJoin(cards, eq(cardToWorkspaceMembers.cardId, cards.id))
+    .innerJoin(lists, eq(cards.listId, lists.id))
+    .innerJoin(boards, eq(lists.boardId, boards.id))
+    .innerJoin(
+      workspaceMembers,
+      eq(cardToWorkspaceMembers.workspaceMemberId, workspaceMembers.id),
+    )
+    .where(
+      and(
+        eq(boards.publicId, boardPublicId),
+        isNull(boards.deletedAt),
+        isNull(lists.deletedAt),
+        isNull(cards.deletedAt),
+        isNull(workspaceMembers.deletedAt),
+      ),
+    );
+
   if (filters.labels.length > 0 || filters.members.length > 0) {
     const filteredCards = await db
       .select({
@@ -279,6 +299,7 @@ export const getByPublicId = async (
                       publicId: true,
                       email: true,
                       deletedAt: true,
+                      status: true,
                     },
                     with: {
                       user: {
@@ -365,6 +386,7 @@ export const getByPublicId = async (
 
   const formattedResult = {
     ...board,
+    assignedMemberPublicIds: assignedMembers.map((member) => member.publicId),
     favorite: board.userFavorites.length > 0,
     userFavorites: undefined,
     lists: board.lists.map((list) => ({

--- a/packages/db/src/repository/card.repo.ts
+++ b/packages/db/src/repository/card.repo.ts
@@ -602,6 +602,7 @@ export const getWithListAndMembersByPublicId = async (
             columns: {
               publicId: true,
               email: true,
+              status: true,
             },
             with: {
               user: {

--- a/packages/db/src/repository/workspace.repo.ts
+++ b/packages/db/src/repository/workspace.repo.ts
@@ -335,6 +335,7 @@ export const getMemberByPublicId = (
   return db.query.workspaceMembers.findFirst({
     columns: {
       id: true,
+      status: true,
     },
     where: and(
       eq(workspaceMembers.publicId, memberPublicId),
@@ -352,6 +353,7 @@ export const getAllMembersByPublicIds = (
   return db.query.workspaceMembers.findMany({
     columns: {
       id: true,
+      status: true,
     },
     where: and(
       inArray(workspaceMembers.publicId, memberPublicIds),


### PR DESCRIPTION
## Description

Paused workspace members currently remain available for new card assignments
and mentions, with no indication that they are paused. Hiding them everywhere
would create the opposite problem: existing ownership and historical comments
would become difficult to understand.

This change treats pause as an eligibility state rather than a history rewrite:

- paused members cannot be newly assigned or mentioned;
- existing assignments survive and can still be removed;
- selected paused assignees remain visible with a `Paused` label and muted
  avatar;
- board filters retain paused members only while they are assigned somewhere on
  that board, place them after current members, and identify their status;
- comment attribution remains readable and gains a compact status label;
- reactivation restores normal eligibility without changing historical data;
- `invited` keeps its existing behavior and is not treated as paused.

The API enforces assignment eligibility so non-UI clients cannot bypass it.
Member status is included in existing card and board payloads; the UI does not
add per-comment or per-avatar requests.

## Type of change

- [ ] Bug fix
- [x] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes

## Testing

- `pnpm --filter @kan/api exec vitest run src/routers/card-members.test.ts`
- `pnpm --filter @kan/web exec vitest run src/views/board/memberFilters.test.ts`
- `pnpm --filter @kan/db typecheck`
- `pnpm --filter @kan/api exec tsc --noEmit --jsx preserve`

## Linked issue

Closes #575.

The workspace-scoping prerequisite was merged separately in #576.

The unit-test mock correction required by the description-normalization
baseline was merged in #585. This branch is now rebased onto that fixed
baseline.

## Screenshots

The screenshots use a synthetic Middle-earth workspace. Boromir is a retained
historical assignee after being paused; Faramir is the active assignee taking
over the work.

### Card member selector and historical comments

![Card member selector, light](https://raw.githubusercontent.com/habralab/kan/pr-assets-paused-members/screenshots/card-members-light.png)

![Card member selector, dark](https://raw.githubusercontent.com/habralab/kan/pr-assets-paused-members/screenshots/card-members-dark.png)

### Board member filter

![Board member filter, light](https://raw.githubusercontent.com/habralab/kan/pr-assets-paused-members/screenshots/board-filter-light.png)

![Board member filter, dark](https://raw.githubusercontent.com/habralab/kan/pr-assets-paused-members/screenshots/board-filter-dark.png)
