### PR TITLE
fix(db): enable pg_trgm in PGlite

### DIFF
--- a/packages/api/integration-tests/test-db.ts
+++ b/packages/api/integration-tests/test-db.ts
@@ -1,11 +1,10 @@
-import { PGlite } from "@electric-sql/pglite";
-import { uuid_ossp } from "@electric-sql/pglite/contrib/uuid_ossp";
-import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
-import { drizzle } from "drizzle-orm/pglite";
-import { migrate } from "drizzle-orm/pglite/migrator";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { Pool } from "pg";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
 
+import { pgliteExtensions } from "@kan/db/client";
 import * as schema from "@kan/db/schema";
 
 export type TestDbClient = NodePgDatabase<typeof schema> & {
@@ -18,7 +17,7 @@ export type TestDbClient = NodePgDatabase<typeof schema> & {
  */
 export async function createTestDb(): Promise<TestDbClient> {
   const client = new PGlite({
-    extensions: { uuid_ossp, pg_trgm },
+    extensions: pgliteExtensions,
   });
 
   const db = drizzle(client, { schema });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,5 +1,6 @@
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { PGlite } from "@electric-sql/pglite";
+import { pg_trgm } from "@electric-sql/pglite/contrib/pg_trgm";
 import { uuid_ossp } from "@electric-sql/pglite/contrib/uuid_ossp";
 import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import { drizzle as drizzlePgLite } from "drizzle-orm/pglite";
@@ -11,6 +12,8 @@ import { createLogger } from "@kan/logger";
 import * as schema from "./schema";
 
 const log = createLogger("db");
+
+export const pgliteExtensions = { pg_trgm, uuid_ossp };
 
 export type dbClient = NodePgDatabase<typeof schema> & {
   $client: Pool;
@@ -24,7 +27,7 @@ export const createDrizzleClient = (): dbClient => {
 
     const client = new PGlite({
       dataDir: "./pgdata",
-      extensions: { uuid_ossp },
+      extensions: pgliteExtensions,
     });
     const db = drizzlePgLite(client, { schema });
 


### PR DESCRIPTION
The PGlite fallback only registers uuid-ossp, while the fuzzy search migration creates the pg_trgm extension. Starting Kan without POSTGRES_URL can therefore reject the migration because PGlite does not know that extension. In the API test suite this can surface later as an unhandled rejection.

This change registers pg_trgm in the runtime fallback and shares the same extension registry with the integration-test database so the two configurations cannot silently drift again.

Tested with:

- pnpm --filter @kan/db typecheck
- pnpm --filter @kan/api exec vitest run integration-tests/webhook.integration.test.ts (14 tests)