### PR TITLE
fix: validate attachment download URLs when S3_ENDPOINT is unset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,12 +24,12 @@ NEXT_PUBLIC_DISABLE_EMAIL=
 
 # S3 storage (optional)
 S3_REGION= # required for AWS S3 (e.g. us-east-1); ignored by most S3-compatible providers — defaults to us-east-1 if unset
-S3_ENDPOINT= # set for S3-compatible providers (MinIO, R2, Spaces, etc.); leave blank for AWS S3
+S3_ENDPOINT= # set for S3-compatible providers (MinIO, R2, Spaces, etc.); leave blank for AWS S3 and set NEXT_PUBLIC_STORAGE_URL instead
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_FORCE_PATH_STYLE=
 # S3_AVATAR_UPLOAD_LIMIT=2097152 # Avatar upload size limit in bytes (default: 2MB)
-NEXT_PUBLIC_STORAGE_URL=
+NEXT_PUBLIC_STORAGE_URL= # public S3 base URL; required for attachment downloads (with S3_ENDPOINT it forms the download allowlist)
 NEXT_PUBLIC_AVATAR_BUCKET_NAME=
 NEXT_PUBLIC_ATTACHMENTS_BUCKET_NAME=
 NEXT_PUBLIC_STORAGE_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ S3_FORCE_PATH_STYLE=
 # S3_AVATAR_UPLOAD_LIMIT=2097152 # Avatar upload size limit in bytes (default: 2MB)
 NEXT_PUBLIC_STORAGE_URL= # public S3 base URL; required for attachment downloads (with S3_ENDPOINT it forms the download allowlist)
 NEXT_PUBLIC_AVATAR_BUCKET_NAME=
-NEXT_PUBLIC_ATTACHMENTS_BUCKET_NAME=
+NEXT_PUBLIC_ATTACHMENTS_BUCKET_NAME= # also scopes the attachment download allowlist to this bucket
 NEXT_PUBLIC_STORAGE_DOMAIN=
 NEXT_PUBLIC_USE_VIRTUAL_HOSTED_URLS=
 

--- a/apps/web/src/pages/api/download/attatchment.ts
+++ b/apps/web/src/pages/api/download/attatchment.ts
@@ -4,6 +4,10 @@ import { withApiLogging } from "@kan/api/utils/apiLogging";
 import { withRateLimit } from "@kan/api/utils/rateLimit";
 
 import { env } from "~/env";
+import {
+  getAllowedAttachmentHosts,
+  isAttachmentUrlAllowed,
+} from "~/utils/attachmentDownload";
 
 export default withRateLimit(
   { points: 100, duration: 60 },
@@ -18,29 +22,26 @@ export default withRateLimit(
       return res.status(400).json({ message: "url parameter is required" });
     }
 
-    const s3Endpoint = env.S3_ENDPOINT;
+    const allowedHosts = getAllowedAttachmentHosts(
+      env.S3_ENDPOINT,
+      env.NEXT_PUBLIC_STORAGE_URL,
+    );
 
-    if (s3Endpoint) {
-      let parsed: URL;
-      try {
-        parsed = new URL(url);
-      } catch {
-        return res.status(400).json({ message: "Invalid URL" });
-      }
+    if (allowedHosts === null) {
+      return res
+        .status(500)
+        .json({ message: "Storage endpoint misconfigured" });
+    }
 
-      const hostname = parsed.hostname.toLowerCase();
-      let allowedHost: string;
-      try {
-        allowedHost = new URL(s3Endpoint).hostname.toLowerCase();
-      } catch {
-        return res
-          .status(500)
-          .json({ message: "Storage endpoint misconfigured" });
-      }
+    if (!allowedHosts.length) {
+      return res.status(403).json({
+        message:
+          "Attachment downloads require S3_ENDPOINT or NEXT_PUBLIC_STORAGE_URL to be configured",
+      });
+    }
 
-      if (hostname !== allowedHost && !hostname.endsWith(`.${allowedHost}`)) {
-        return res.status(403).json({ message: "URL not allowed" });
-      }
+    if (!isAttachmentUrlAllowed(url, allowedHosts)) {
+      return res.status(403).json({ message: "URL not allowed" });
     }
 
     try {

--- a/apps/web/src/pages/api/download/attatchment.ts
+++ b/apps/web/src/pages/api/download/attatchment.ts
@@ -22,10 +22,13 @@ export default withRateLimit(
       return res.status(400).json({ message: "url parameter is required" });
     }
 
-    const allowedHosts = getAllowedAttachmentHosts(
-      env.S3_ENDPOINT,
-      env.NEXT_PUBLIC_STORAGE_URL,
-    );
+    const bucket = env.NEXT_PUBLIC_ATTACHMENTS_BUCKET_NAME;
+
+    const allowedHosts = getAllowedAttachmentHosts({
+      s3Endpoint: env.S3_ENDPOINT,
+      storageUrl: env.NEXT_PUBLIC_STORAGE_URL,
+      bucket,
+    });
 
     if (allowedHosts === null) {
       return res
@@ -33,14 +36,14 @@ export default withRateLimit(
         .json({ message: "Storage endpoint misconfigured" });
     }
 
-    if (!allowedHosts.length) {
+    if (!allowedHosts.length || !bucket) {
       return res.status(403).json({
         message:
-          "Attachment downloads require S3_ENDPOINT or NEXT_PUBLIC_STORAGE_URL to be configured",
+          "Attachment downloads require NEXT_PUBLIC_ATTACHMENTS_BUCKET_NAME and one of S3_ENDPOINT or NEXT_PUBLIC_STORAGE_URL to be configured",
       });
     }
 
-    if (!isAttachmentUrlAllowed(url, allowedHosts)) {
+    if (!isAttachmentUrlAllowed(url, allowedHosts, bucket)) {
       return res.status(403).json({ message: "URL not allowed" });
     }
 

--- a/apps/web/src/utils/attachmentDownload.test.ts
+++ b/apps/web/src/utils/attachmentDownload.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getAllowedAttachmentHosts,
+  isAttachmentUrlAllowed,
+} from "./attachmentDownload";
+
+const METADATA_URL =
+  "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+
+describe("getAllowedAttachmentHosts", () => {
+  it("returns no hosts when neither storage variable is set", () => {
+    expect(getAllowedAttachmentHosts(undefined, undefined)).toEqual([]);
+  });
+
+  it("uses NEXT_PUBLIC_STORAGE_URL when S3_ENDPOINT is blank (AWS S3 setup)", () => {
+    expect(
+      getAllowedAttachmentHosts(
+        undefined,
+        "https://s3.us-east-1.amazonaws.com",
+      ),
+    ).toEqual(["s3.us-east-1.amazonaws.com"]);
+  });
+
+  it("collects both hosts when both are set", () => {
+    expect(
+      getAllowedAttachmentHosts(
+        "http://s3.localtest.me:9000",
+        "http://cdn.localtest.me",
+      ),
+    ).toEqual(["s3.localtest.me", "cdn.localtest.me"]);
+  });
+
+  it("returns null when a configured value is not a valid URL", () => {
+    expect(getAllowedAttachmentHosts("not-a-url", undefined)).toBeNull();
+  });
+});
+
+describe("isAttachmentUrlAllowed", () => {
+  it("rejects everything when no hosts are configured", () => {
+    expect(isAttachmentUrlAllowed(METADATA_URL, [])).toBe(false);
+    expect(
+      isAttachmentUrlAllowed("https://s3.us-east-1.amazonaws.com/a/b", []),
+    ).toBe(false);
+  });
+
+  it("rejects the cloud metadata endpoint when storage is configured", () => {
+    expect(
+      isAttachmentUrlAllowed(METADATA_URL, ["s3.us-east-1.amazonaws.com"]),
+    ).toBe(false);
+  });
+
+  it("allows an exact host match", () => {
+    expect(
+      isAttachmentUrlAllowed("https://s3.localtest.me:9000/bucket/key", [
+        "s3.localtest.me",
+      ]),
+    ).toBe(true);
+  });
+
+  it("allows virtual-hosted style, where the bucket is a subdomain", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        "https://attachments.s3.us-east-1.amazonaws.com/key?X-Amz-Signature=abc",
+        ["s3.us-east-1.amazonaws.com"],
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a lookalike host that merely ends with the allowed name", () => {
+    expect(
+      isAttachmentUrlAllowed("https://evils3.localtest.me/x", [
+        "s3.localtest.me",
+      ]),
+    ).toBe(false);
+  });
+
+  it("rejects a malformed url", () => {
+    expect(isAttachmentUrlAllowed("not-a-url", ["s3.localtest.me"])).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/utils/attachmentDownload.test.ts
+++ b/apps/web/src/utils/attachmentDownload.test.ts
@@ -5,79 +5,159 @@ import {
   isAttachmentUrlAllowed,
 } from "./attachmentDownload";
 
+const BUCKET = "kan-attachments";
+const AWS_HOST = "s3.us-east-1.amazonaws.com";
 const METADATA_URL =
   "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
 
 describe("getAllowedAttachmentHosts", () => {
   it("returns no hosts when neither storage variable is set", () => {
-    expect(getAllowedAttachmentHosts(undefined, undefined)).toEqual([]);
+    expect(
+      getAllowedAttachmentHosts({
+        s3Endpoint: undefined,
+        storageUrl: undefined,
+        bucket: BUCKET,
+      }),
+    ).toEqual([]);
   });
 
   it("uses NEXT_PUBLIC_STORAGE_URL when S3_ENDPOINT is blank (AWS S3 setup)", () => {
     expect(
-      getAllowedAttachmentHosts(
-        undefined,
-        "https://s3.us-east-1.amazonaws.com",
-      ),
-    ).toEqual(["s3.us-east-1.amazonaws.com"]);
+      getAllowedAttachmentHosts({
+        s3Endpoint: undefined,
+        storageUrl: `https://${AWS_HOST}`,
+        bucket: BUCKET,
+      }),
+    ).toEqual([AWS_HOST]);
   });
 
-  it("collects both hosts when both are set", () => {
+  it("rejects a schemeless endpoint rather than deriving an empty host", () => {
+    // new URL("minio.internal:9000").hostname is "", which would otherwise make
+    // the allowlist a single empty string and match any trailing-dot hostname.
     expect(
-      getAllowedAttachmentHosts(
-        "http://s3.localtest.me:9000",
-        "http://cdn.localtest.me",
-      ),
-    ).toEqual(["s3.localtest.me", "cdn.localtest.me"]);
+      getAllowedAttachmentHosts({
+        s3Endpoint: "minio.internal:9000",
+        storageUrl: undefined,
+        bucket: BUCKET,
+      }),
+    ).toBeNull();
   });
 
-  it("returns null when a configured value is not a valid URL", () => {
-    expect(getAllowedAttachmentHosts("not-a-url", undefined)).toBeNull();
+  it("accepts the same endpoint once it carries a scheme", () => {
+    expect(
+      getAllowedAttachmentHosts({
+        s3Endpoint: "http://minio.internal:9000",
+        storageUrl: undefined,
+        bucket: BUCKET,
+      }),
+    ).toEqual(["minio.internal"]);
+  });
+
+  it("rejects a non-http scheme", () => {
+    expect(
+      getAllowedAttachmentHosts({
+        s3Endpoint: "file:///etc/passwd",
+        storageUrl: undefined,
+        bucket: BUCKET,
+      }),
+    ).toBeNull();
   });
 });
 
 describe("isAttachmentUrlAllowed", () => {
   it("rejects everything when no hosts are configured", () => {
-    expect(isAttachmentUrlAllowed(METADATA_URL, [])).toBe(false);
-    expect(
-      isAttachmentUrlAllowed("https://s3.us-east-1.amazonaws.com/a/b", []),
-    ).toBe(false);
+    expect(isAttachmentUrlAllowed(METADATA_URL, [], BUCKET)).toBe(false);
   });
 
-  it("rejects the cloud metadata endpoint when storage is configured", () => {
-    expect(
-      isAttachmentUrlAllowed(METADATA_URL, ["s3.us-east-1.amazonaws.com"]),
-    ).toBe(false);
-  });
-
-  it("allows an exact host match", () => {
-    expect(
-      isAttachmentUrlAllowed("https://s3.localtest.me:9000/bucket/key", [
-        "s3.localtest.me",
-      ]),
-    ).toBe(true);
-  });
-
-  it("allows virtual-hosted style, where the bucket is a subdomain", () => {
+  it("rejects everything when the bucket is not configured", () => {
     expect(
       isAttachmentUrlAllowed(
-        "https://attachments.s3.us-east-1.amazonaws.com/key?X-Amz-Signature=abc",
-        ["s3.us-east-1.amazonaws.com"],
+        `https://${BUCKET}.${AWS_HOST}/key`,
+        [AWS_HOST],
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects the cloud metadata endpoint", () => {
+    expect(isAttachmentUrlAllowed(METADATA_URL, [AWS_HOST], BUCKET)).toBe(
+      false,
+    );
+  });
+
+  it("allows virtual-hosted URLs for our own bucket", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        `https://${BUCKET}.${AWS_HOST}/key?X-Amz-Signature=abc`,
+        [AWS_HOST],
+        BUCKET,
       ),
     ).toBe(true);
   });
 
+  it("rejects another tenant's bucket on the same shared domain", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        `https://someone-elses-bucket.${AWS_HOST}/key`,
+        [AWS_HOST],
+        BUCKET,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a deeper subdomain that ends with our bucket host", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        `https://evil.${BUCKET}.${AWS_HOST}/key`,
+        [AWS_HOST],
+        BUCKET,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows path-style URLs for our own bucket", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        `http://minio.internal:9000/${BUCKET}/key`,
+        ["minio.internal"],
+        BUCKET,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects path-style URLs for another bucket on our host", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        "http://minio.internal:9000/other-bucket/key",
+        ["minio.internal"],
+        BUCKET,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a trailing-dot hostname", () => {
+    expect(
+      isAttachmentUrlAllowed(
+        "http://metadata.google.internal./computeMetadata/v1/",
+        [AWS_HOST],
+        BUCKET,
+      ),
+    ).toBe(false);
+  });
+
   it("rejects a lookalike host that merely ends with the allowed name", () => {
     expect(
-      isAttachmentUrlAllowed("https://evils3.localtest.me/x", [
-        "s3.localtest.me",
-      ]),
+      isAttachmentUrlAllowed(`https://evil${AWS_HOST}/x`, [AWS_HOST], BUCKET),
+    ).toBe(false);
+  });
+
+  it("rejects non-http schemes", () => {
+    expect(
+      isAttachmentUrlAllowed("file:///etc/passwd", [AWS_HOST], BUCKET),
     ).toBe(false);
   });
 
   it("rejects a malformed url", () => {
-    expect(isAttachmentUrlAllowed("not-a-url", ["s3.localtest.me"])).toBe(
-      false,
-    );
+    expect(isAttachmentUrlAllowed("not-a-url", [AWS_HOST], BUCKET)).toBe(false);
   });
 });

--- a/apps/web/src/utils/attachmentDownload.ts
+++ b/apps/web/src/utils/attachmentDownload.ts
@@ -1,0 +1,45 @@
+/**
+ * Attachment URLs are presigned S3 URLs produced by generateAttachmentUrl, so
+ * their host is whichever endpoint the S3 client resolved. Virtual-hosted style
+ * puts the bucket in a subdomain, so subdomains of an allowed host are accepted.
+ *
+ * Returns null when a configured value is not a valid URL.
+ */
+export const getAllowedAttachmentHosts = (
+  s3Endpoint: string | undefined,
+  storageUrl: string | undefined,
+): string[] | null => {
+  const hosts: string[] = [];
+
+  for (const candidate of [s3Endpoint, storageUrl]) {
+    if (!candidate) continue;
+    try {
+      hosts.push(new URL(candidate).hostname.toLowerCase());
+    } catch {
+      return null;
+    }
+  }
+
+  return hosts;
+};
+
+export const isAttachmentUrlAllowed = (
+  url: string,
+  allowedHosts: string[],
+): boolean => {
+  if (!allowedHosts.length) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  return allowedHosts.some(
+    (allowedHost) =>
+      hostname === allowedHost || hostname.endsWith(`.${allowedHost}`),
+  );
+};

--- a/apps/web/src/utils/attachmentDownload.ts
+++ b/apps/web/src/utils/attachmentDownload.ts
@@ -1,23 +1,48 @@
 /**
- * Attachment URLs are presigned S3 URLs produced by generateAttachmentUrl, so
- * their host is whichever endpoint the S3 client resolved. Virtual-hosted style
- * puts the bucket in a subdomain, so subdomains of an allowed host are accepted.
+ * Attachment URLs are presigned S3 URLs produced by generateAttachmentUrl, so a
+ * legitimate URL always points at our own bucket on our own storage host, in one
+ * of two shapes:
  *
- * Returns null when a configured value is not a valid URL.
+ *   virtual-hosted:  https://{bucket}.{host}/{key}
+ *   path-style:      https://{host}/{bucket}/{key}
+ *
+ * Matching the host alone is not enough: on a shared domain such as
+ * s3.us-east-1.amazonaws.com every other tenant's bucket is a sibling
+ * subdomain, so the bucket has to be part of the check.
  */
+export interface AttachmentStorageConfig {
+  s3Endpoint: string | undefined;
+  storageUrl: string | undefined;
+  bucket: string | undefined;
+}
+
+const parseHost = (value: string): string | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+
+  // A schemeless value such as "minio.internal:9000" parses with the host as
+  // the protocol and an empty hostname, so require an explicit http(s) scheme.
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (!parsed.hostname) return null;
+
+  return parsed.hostname.toLowerCase();
+};
+
+/** Returns null when a configured endpoint is present but unusable. */
 export const getAllowedAttachmentHosts = (
-  s3Endpoint: string | undefined,
-  storageUrl: string | undefined,
+  config: AttachmentStorageConfig,
 ): string[] | null => {
   const hosts: string[] = [];
 
-  for (const candidate of [s3Endpoint, storageUrl]) {
+  for (const candidate of [config.s3Endpoint, config.storageUrl]) {
     if (!candidate) continue;
-    try {
-      hosts.push(new URL(candidate).hostname.toLowerCase());
-    } catch {
-      return null;
-    }
+    const host = parseHost(candidate);
+    if (host === null) return null;
+    hosts.push(host);
   }
 
   return hosts;
@@ -26,8 +51,9 @@ export const getAllowedAttachmentHosts = (
 export const isAttachmentUrlAllowed = (
   url: string,
   allowedHosts: string[],
+  bucket: string | undefined,
 ): boolean => {
-  if (!allowedHosts.length) return false;
+  if (!allowedHosts.length || !bucket) return false;
 
   let parsed: URL;
   try {
@@ -36,10 +62,17 @@ export const isAttachmentUrlAllowed = (
     return false;
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
 
-  return allowedHosts.some(
-    (allowedHost) =>
-      hostname === allowedHost || hostname.endsWith(`.${allowedHost}`),
-  );
+  const hostname = parsed.hostname.toLowerCase();
+  const wantedBucket = bucket.toLowerCase();
+
+  return allowedHosts.some((allowedHost) => {
+    // path-style: the bucket is the first path segment
+    if (hostname === allowedHost) {
+      return parsed.pathname.startsWith(`/${wantedBucket}/`);
+    }
+    // virtual-hosted: the bucket is the only permitted subdomain label
+    return hostname === `${wantedBucket}.${allowedHost}`;
+  });
 };


### PR DESCRIPTION
## Description

The URL allowlist added in #432 for CVE-2026-32255 runs inside `if (s3Endpoint)`. S3_ENDPOINT is optional, and .env.example recommends leaving it blank for AWS S3, so on that configuration no validation ran and the endpoint still fetched any user-supplied URL unauthenticated.

Attachment URLs are presigned S3 URLs from `generateAttachmentUrl`, so the allowlist is now built from S3_ENDPOINT and NEXT_PUBLIC_STORAGE_URL, whichever are set, and the request is refused when neither is. Subdomain matching is kept because virtual-hosted style puts the bucket in a subdomain of the endpoint host.

## Type of change

Behaviour change: deployments with neither variable set will now get a 403 from this endpoint instead of an unvalidated fetch.