### PR TITLE
fix(trello): protect stored access tokens

### DIFF
--- a/apps/web/src/pages/api/trello/authenticate.ts
+++ b/apps/web/src/pages/api/trello/authenticate.ts
@@ -4,7 +4,10 @@ import { addYears } from "date-fns";
 import { createNextApiContext } from "@kan/api/trpc";
 import { withApiLogging } from "@kan/api/utils/apiLogging";
 import { withRateLimit } from "@kan/api/utils/rateLimit";
-import { integrations } from "@kan/db/schema";
+import { encryptTrelloToken } from "@kan/api/utils/trello-token";
+import * as integrationsRepo from "@kan/db/repository/integration.repo";
+
+import { env } from "~/env";
 
 export default withRateLimit(
   { points: 100, duration: 60 },
@@ -18,40 +21,36 @@ export default withRateLimit(
     if (!user)
       return res.status(401).json({ message: "User not authenticated" });
 
-    const apiKey = process.env.TRELLO_APP_API_KEY;
+    const apiKey = env.TRELLO_APP_API_KEY;
 
     if (!apiKey)
       return res
         .status(500)
         .json({ message: "Trello API key not set in Environment Variables" });
 
-    const token = req.body.token;
+    const body: unknown = req.body;
+    const token =
+      typeof body === "object" && body !== null && "token" in body
+        ? body.token
+        : null;
 
-    if (!token) return res.status(400).json({ message: "No token found" });
+    if (typeof token !== "string" || !token)
+      return res.status(400).json({ message: "No token found" });
 
     try {
       const { db } = await createNextApiContext(req);
 
-      await db
-        .insert(integrations)
-        .values({
-          provider: "trello",
-          userId: user.id,
-          accessToken: token,
-          expiresAt: addYears(new Date(), 1),
-        })
-        .onConflictDoUpdate({
-          set: {
-            accessToken: token,
-            expiresAt: addYears(new Date(), 1),
-          },
-          target: [integrations.userId, integrations.provider],
-        });
+      await integrationsRepo.createOrUpdateProvider(db, {
+        provider: "trello",
+        userId: user.id,
+        accessToken: encryptTrelloToken(token),
+        expiresAt: addYears(new Date(), 1),
+      });
 
       return res
         .status(200)
         .json({ message: "Trello authentication successful" });
-    } catch (err) {
+    } catch {
       return res.status(400).json({ message: "Trello authentication failed" });
     }
   }),

--- a/packages/api/integration-tests/integration.repo.integration.test.ts
+++ b/packages/api/integration-tests/integration.repo.integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import * as integrationsRepo from "@kan/db/repository/integration.repo";
+
+import { createTestDb, seedTestData } from "./test-db";
+
+describe("integration repository", () => {
+  it("replaces a legacy access token only while it is still current", async () => {
+    const db = await createTestDb();
+    const { user } = await seedTestData(db);
+
+    await integrationsRepo.createOrUpdateProvider(db, {
+      provider: "trello",
+      userId: user.id,
+      accessToken: "legacy-token",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    await integrationsRepo.updateAccessTokenIfCurrent(db, {
+      provider: "trello",
+      userId: user.id,
+      currentAccessToken: "legacy-token",
+      accessToken: "encrypted-token",
+    });
+    await integrationsRepo.updateAccessTokenIfCurrent(db, {
+      provider: "trello",
+      userId: user.id,
+      currentAccessToken: "legacy-token",
+      accessToken: "stale-token",
+    });
+
+    const integration = await integrationsRepo.getProviderForUser(
+      db,
+      user.id,
+      "trello",
+    );
+    expect(integration?.accessToken).toBe("encrypted-token");
+  });
+
+  it("does not return credentials when listing providers", async () => {
+    const db = await createTestDb();
+    const { user } = await seedTestData(db);
+
+    await integrationsRepo.createOrUpdateProvider(db, {
+      provider: "trello",
+      userId: user.id,
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    });
+
+    const [provider] = await integrationsRepo.getProvidersForUser(db, user.id);
+
+    expect(provider).toMatchObject({ provider: "trello", userId: user.id });
+    expect(provider).not.toHaveProperty("accessToken");
+    expect(provider).not.toHaveProperty("refreshToken");
+  });
+});

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,6 +36,10 @@
       "types": "./src/utils/permissions.ts",
       "default": "./src/utils/permissions.ts"
     },
+    "./utils/trello-token": {
+      "types": "./src/utils/trello-token.ts",
+      "default": "./src/utils/trello-token.ts"
+    },
     "./utils/workspace": {
       "types": "./src/utils/workspace.ts",
       "default": "./src/utils/workspace.ts"

--- a/packages/api/src/routers/import.ts
+++ b/packages/api/src/routers/import.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import type { dbClient } from "@kan/db/client";
 import * as boardRepo from "@kan/db/repository/board.repo";
 import * as cardRepo from "@kan/db/repository/card.repo";
 import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
@@ -22,10 +23,40 @@ import { assertUserInWorkspace } from "../utils/auth";
 import { decryptToken } from "../utils/encryption";
 import { assertPermission } from "../utils/permissions";
 import { getTrelloLabelColour } from "../utils/trello";
-import { decryptTrelloToken } from "../utils/trello-token";
+import {
+  decryptTrelloToken,
+  encryptTrelloToken,
+  isEncryptedTrelloToken,
+} from "../utils/trello-token";
 import { apiKeys, urls } from "./integration";
 
 const log = createLogger("import");
+
+const getTrelloTokenForUser = async (db: dbClient, userId: string) => {
+  const integration = await integrationsRepo.getProviderForUser(
+    db,
+    userId,
+    "trello",
+  );
+
+  if (!integration)
+    throw new TRPCError({
+      message: "Trello token not found",
+      code: "UNAUTHORIZED",
+    });
+
+  const token = decryptTrelloToken(integration.accessToken);
+
+  if (!isEncryptedTrelloToken(integration.accessToken))
+    await integrationsRepo.updateAccessTokenIfCurrent(db, {
+      userId,
+      provider: "trello",
+      currentAccessToken: integration.accessToken,
+      accessToken: encryptTrelloToken(token),
+    });
+
+  return token;
+};
 
 export interface TrelloBoard {
   id: string;
@@ -154,21 +185,7 @@ export const importRouter = createTRPCRouter({
             code: "UNAUTHORIZED",
           });
 
-        const integration = await integrationsRepo.getProviderForUser(
-          ctx.db,
-          user.id,
-          "trello",
-        );
-
-        const token = integration
-          ? decryptTrelloToken(integration.accessToken)
-          : null;
-
-        if (!token)
-          throw new TRPCError({
-            message: "Trello token not found",
-            code: "UNAUTHORIZED",
-          });
+        const token = await getTrelloTokenForUser(ctx.db, user.id);
 
         const response = await fetch(
           `${urls.trello}/members/me/boards?key=${apiKey}&token=${token}`,
@@ -227,19 +244,7 @@ export const importRouter = createTRPCRouter({
             code: "UNAUTHORIZED",
           });
 
-        const integration = await integrationsRepo.getProviderForUser(
-          ctx.db,
-          userId,
-          "trello",
-        );
-
-        if (!integration)
-          throw new TRPCError({
-            message: "Trello token not found",
-            code: "UNAUTHORIZED",
-          });
-
-        const token = decryptTrelloToken(integration.accessToken);
+        const token = await getTrelloTokenForUser(ctx.db, userId);
 
         const workspace = await workspaceRepo.getByPublicId(
           ctx.db,

--- a/packages/api/src/routers/import.ts
+++ b/packages/api/src/routers/import.ts
@@ -22,6 +22,7 @@ import { assertUserInWorkspace } from "../utils/auth";
 import { decryptToken } from "../utils/encryption";
 import { assertPermission } from "../utils/permissions";
 import { getTrelloLabelColour } from "../utils/trello";
+import { decryptTrelloToken } from "../utils/trello-token";
 import { apiKeys, urls } from "./integration";
 
 const log = createLogger("import");
@@ -159,7 +160,9 @@ export const importRouter = createTRPCRouter({
           "trello",
         );
 
-        const token = integration?.accessToken;
+        const token = integration
+          ? decryptTrelloToken(integration.accessToken)
+          : null;
 
         if (!token)
           throw new TRPCError({
@@ -236,6 +239,8 @@ export const importRouter = createTRPCRouter({
             code: "UNAUTHORIZED",
           });
 
+        const token = decryptTrelloToken(integration.accessToken);
+
         const workspace = await workspaceRepo.getByPublicId(
           ctx.db,
           input.workspacePublicId,
@@ -257,7 +262,7 @@ export const importRouter = createTRPCRouter({
 
         const importSingleBoard = async (boardId: string): Promise<void> => {
           const response = await fetch(
-            `${urls.trello}/boards/${boardId}?key=${apiKey}&token=${integration.accessToken}&lists=open&cards=open&labels=all&labels_limit=1000&checklists=all&checkItemStates=all`,
+            `${urls.trello}/boards/${boardId}?key=${apiKey}&token=${token}&lists=open&cards=open&labels=all&labels_limit=1000&checklists=all&checkItemStates=all`,
           );
 
           if (!response.ok) {

--- a/packages/api/src/routers/integration.ts
+++ b/packages/api/src/routers/integration.ts
@@ -89,19 +89,7 @@ export const integrationRouter = createTRPCRouter({
       },
     })
     .input(z.void())
-    .output(
-      z.array(
-        z.object({
-          expiresAt: z.date(),
-          createdAt: z.date(),
-          updatedAt: z.date().nullable(),
-          userId: z.string(),
-          accessToken: z.string(),
-          refreshToken: z.string().nullable(),
-          provider: z.string(),
-        }),
-      ),
-    )
+    .output(z.array(z.object({ provider: z.string() })))
     .query(async ({ ctx }) => {
       const user = ctx.user;
 
@@ -202,14 +190,7 @@ export const integrationRouter = createTRPCRouter({
           code: "BAD_REQUEST",
         });
 
-      if (input.provider === "trello") {
-        const url = `${urls[input.provider]}/authorize?key=${apiKey}&expiration=never&response_type=token&scope=read&return_url=${env("NEXT_PUBLIC_BASE_URL")}/settings/trello/authorize&callback_method=fragment`;
-        return { url };
-      }
-
-      throw new TRPCError({
-        message: "Invalid provider",
-        code: "BAD_REQUEST",
-      });
+      const url = `${urls[input.provider]}/authorize?key=${apiKey}&expiration=never&response_type=token&scope=read&return_url=${env("NEXT_PUBLIC_BASE_URL")}/settings/trello/authorize&callback_method=fragment`;
+      return { url };
     }),
 });

--- a/packages/api/src/routers/integration.ts
+++ b/packages/api/src/routers/integration.ts
@@ -89,7 +89,17 @@ export const integrationRouter = createTRPCRouter({
       },
     })
     .input(z.void())
-    .output(z.array(z.object({ provider: z.string() })))
+    .output(
+      z.array(
+        z.object({
+          expiresAt: z.date(),
+          createdAt: z.date(),
+          updatedAt: z.date().nullable(),
+          userId: z.string(),
+          provider: z.string(),
+        }),
+      ),
+    )
     .query(async ({ ctx }) => {
       const user = ctx.user;
 
@@ -190,7 +200,14 @@ export const integrationRouter = createTRPCRouter({
           code: "BAD_REQUEST",
         });
 
-      const url = `${urls[input.provider]}/authorize?key=${apiKey}&expiration=never&response_type=token&scope=read&return_url=${env("NEXT_PUBLIC_BASE_URL")}/settings/trello/authorize&callback_method=fragment`;
-      return { url };
+      if (input.provider === "trello") {
+        const url = `${urls[input.provider]}/authorize?key=${apiKey}&expiration=never&response_type=token&scope=read&return_url=${env("NEXT_PUBLIC_BASE_URL")}/settings/trello/authorize&callback_method=fragment`;
+        return { url };
+      }
+
+      throw new TRPCError({
+        message: "Invalid provider",
+        code: "BAD_REQUEST",
+      });
     }),
 });

--- a/packages/api/src/utils/trello-token.test.ts
+++ b/packages/api/src/utils/trello-token.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { decryptTrelloToken, encryptTrelloToken } from "./trello-token";
+
+describe("Trello token storage", () => {
+  it("encrypts new tokens", () => {
+    const token = "trello-token";
+    const storedToken = encryptTrelloToken(token);
+
+    expect(storedToken).not.toContain(token);
+    expect(decryptTrelloToken(storedToken)).toBe(token);
+  });
+
+  it("continues to read legacy plaintext tokens", () => {
+    expect(decryptTrelloToken("legacy-trello-token")).toBe(
+      "legacy-trello-token",
+    );
+  });
+
+  it("rejects corrupted encrypted tokens", () => {
+    const storedToken = encryptTrelloToken("trello-token");
+
+    expect(() => decryptTrelloToken(`${storedToken}corrupted`)).toThrow();
+  });
+});

--- a/packages/api/src/utils/trello-token.test.ts
+++ b/packages/api/src/utils/trello-token.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   decryptTrelloToken,
   encryptTrelloToken,
   isEncryptedTrelloToken,
 } from "./trello-token";
+
+vi.hoisted(() => {
+  process.env.BETTER_AUTH_SECRET = "test-only-trello-secret-123456789";
+});
 
 describe("Trello token storage", () => {
   it("encrypts new tokens", () => {

--- a/packages/api/src/utils/trello-token.test.ts
+++ b/packages/api/src/utils/trello-token.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { decryptTrelloToken, encryptTrelloToken } from "./trello-token";
+import {
+  decryptTrelloToken,
+  encryptTrelloToken,
+  isEncryptedTrelloToken,
+} from "./trello-token";
 
 describe("Trello token storage", () => {
   it("encrypts new tokens", () => {
@@ -8,10 +12,12 @@ describe("Trello token storage", () => {
     const storedToken = encryptTrelloToken(token);
 
     expect(storedToken).not.toContain(token);
+    expect(isEncryptedTrelloToken(storedToken)).toBe(true);
     expect(decryptTrelloToken(storedToken)).toBe(token);
   });
 
   it("continues to read legacy plaintext tokens", () => {
+    expect(isEncryptedTrelloToken("legacy-trello-token")).toBe(false);
     expect(decryptTrelloToken("legacy-trello-token")).toBe(
       "legacy-trello-token",
     );

--- a/packages/api/src/utils/trello-token.ts
+++ b/packages/api/src/utils/trello-token.ts
@@ -2,10 +2,13 @@ import { decryptToken, encryptToken } from "./encryption";
 
 const encryptedTrelloTokenPrefix = "kan:trello:v1:";
 
+export const isEncryptedTrelloToken = (token: string) =>
+  token.startsWith(encryptedTrelloTokenPrefix);
+
 export const encryptTrelloToken = (token: string) =>
   `${encryptedTrelloTokenPrefix}${encryptToken(token)}`;
 
 export const decryptTrelloToken = (storedToken: string) =>
-  storedToken.startsWith(encryptedTrelloTokenPrefix)
+  isEncryptedTrelloToken(storedToken)
     ? decryptToken(storedToken.slice(encryptedTrelloTokenPrefix.length))
     : storedToken;

--- a/packages/api/src/utils/trello-token.ts
+++ b/packages/api/src/utils/trello-token.ts
@@ -1,0 +1,11 @@
+import { decryptToken, encryptToken } from "./encryption";
+
+const encryptedTrelloTokenPrefix = "kan:trello:v1:";
+
+export const encryptTrelloToken = (token: string) =>
+  `${encryptedTrelloTokenPrefix}${encryptToken(token)}`;
+
+export const decryptTrelloToken = (storedToken: string) =>
+  storedToken.startsWith(encryptedTrelloTokenPrefix)
+    ? decryptToken(storedToken.slice(encryptedTrelloTokenPrefix.length))
+    : storedToken;

--- a/packages/db/src/repository/integration.repo.ts
+++ b/packages/db/src/repository/integration.repo.ts
@@ -37,6 +37,9 @@ export const getProviderForUser = async (
 
 export const getProvidersForUser = async (db: dbClient, userId: string) => {
   const integration = await db.query.integrations.findMany({
+    columns: {
+      provider: true,
+    },
     where: and(
       eq(integrations.userId, userId),
       gte(integrations.expiresAt, new Date()),

--- a/packages/db/src/repository/integration.repo.ts
+++ b/packages/db/src/repository/integration.repo.ts
@@ -38,7 +38,11 @@ export const getProviderForUser = async (
 export const getProvidersForUser = async (db: dbClient, userId: string) => {
   const integration = await db.query.integrations.findMany({
     columns: {
+      createdAt: true,
+      expiresAt: true,
       provider: true,
+      updatedAt: true,
+      userId: true,
     },
     where: and(
       eq(integrations.userId, userId),
@@ -76,6 +80,27 @@ export const createOrUpdateProvider = async (
         expiresAt: data.expiresAt,
       },
     });
+};
+
+export const updateAccessTokenIfCurrent = async (
+  db: dbClient,
+  data: {
+    userId: string;
+    provider: string;
+    currentAccessToken: string;
+    accessToken: string;
+  },
+) => {
+  await db
+    .update(integrations)
+    .set({ accessToken: data.accessToken })
+    .where(
+      and(
+        eq(integrations.userId, data.userId),
+        eq(integrations.provider, data.provider),
+        eq(integrations.accessToken, data.currentAccessToken),
+      ),
+    );
 };
 
 export const deleteProviderForUser = async (

--- a/packages/e2e/tests/support/trello-mock-server.js
+++ b/packages/e2e/tests/support/trello-mock-server.js
@@ -53,15 +53,24 @@ const server = createServer((req, res) => {
   }
 
   if (url.pathname === "/members/me/boards") {
+    if (url.searchParams.get("token") !== "mock-trello-token") {
+      res.writeHead(401);
+      res.end(JSON.stringify({ message: "Invalid token" }));
+      return;
+    }
+
     res.writeHead(200);
     res.end(JSON.stringify([{ id: board.id, name: board.name }]));
     return;
   }
 
   if (url.pathname === `/boards/${board.id}`) {
-    if (url.searchParams.get("labels_limit") !== "1000") {
+    if (
+      url.searchParams.get("labels_limit") !== "1000" ||
+      url.searchParams.get("token") !== "mock-trello-token"
+    ) {
       res.writeHead(400);
-      res.end(JSON.stringify({ message: "labels_limit must be 1000" }));
+      res.end(JSON.stringify({ message: "Required board fields are missing" }));
       return;
     }
 


### PR DESCRIPTION
## Description

While preparing the stock Trello importer for an on-premise migration, we
noticed that Trello access tokens do not follow the storage pattern already
used by the GitHub integration. `saveGitHubToken` encrypts a token with Kan's
shared AES-GCM helper, and the GitHub importer decrypts it only when making an
API request. The Trello authentication endpoint currently stores the raw token,
and the Trello importer reads that raw value back.

This PR applies the existing GitHub approach to Trello. Newly connected Trello
tokens are encrypted with the same helper and `BETTER_AUTH_SECRET`, then
decrypted for Trello API requests.

Existing Trello installations need one additional compatibility step because
their stored tokens may still be plaintext. Encrypted Trello values therefore
have a versioned prefix: unprefixed values remain readable and are rewritten in
encrypted form the next time the integration is used. The rewrite has a
compare-and-swap condition so it cannot overwrite a token entered by a
concurrent reconnect. No database migration is required.

The integration providers endpoint also stops returning access and refresh
tokens. It retains the existing non-secret provider metadata. The GitHub token
save and use paths are otherwise unchanged.

We needed this behaviour in our fork before allowing users to connect Trello.
Since it is an extension of an existing Kan security pattern and is independent
of our migration tooling and product changes, we are contributing the same fix
upstream rather than keeping a private patch.

Tested with:

- `pnpm --filter @kan/api test -- trello-token.test.ts`
- `pnpm --filter @kan/api test -- integration-tests/integration.repo.integration.test.ts`
- `pnpm --filter @kan/api typecheck`
- `pnpm --filter @kan/db typecheck`
- `pnpm --filter @kan/e2e typecheck`
- the self-hosted Trello import Playwright tests
- the repository's unit, E2E and Docker build checks

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below — not required for this bug fix
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes — no UI changes

## Linked issue

Not required for this bug fix.
