### PR TITLE
fix(card): normalise descriptions on update

### DIFF
--- a/packages/api/src/routers/card-description.test.ts
+++ b/packages/api/src/routers/card-description.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import * as cardRepo from "@kan/db/repository/card.repo";
+import * as cardActivityRepo from "@kan/db/repository/cardActivity.repo";
+
+import { sendMentionEmails } from "../utils/notifications";
+import { assertCanEdit } from "../utils/permissions";
+import {
+  createCardWebhookPayload,
+  sendWebhooksForWorkspace,
+} from "../utils/webhook";
+
+vi.mock("@kan/db/repository/card.repo", () => ({
+  getWorkspaceAndCardIdByCardPublicId: vi.fn(),
+  getByPublicId: vi.fn(),
+  update: vi.fn(),
+  reorder: vi.fn(),
+}));
+vi.mock("@kan/db/repository/cardActivity.repo", () => ({
+  bulkCreate: vi.fn(),
+}));
+vi.mock("../utils/notifications", () => ({
+  sendMentionEmails: vi.fn(),
+}));
+vi.mock("../utils/permissions", () => ({
+  assertCanDelete: vi.fn(),
+  assertCanEdit: vi.fn(),
+  assertPermission: vi.fn(),
+}));
+vi.mock("../utils/webhook", () => ({
+  createCardWebhookPayload: vi.fn(() => ({})),
+  sendWebhooksForWorkspace: vi.fn(() => Promise.resolve()),
+}));
+
+describe("card description updates", () => {
+  it("stores an empty editor document as null", async () => {
+    const mockDb = {} as never;
+    const cardPublicId = "card-12345678";
+    const ctx = {
+      user: {
+        id: "user-123",
+        name: "Test User",
+        email: "test@example.com",
+      },
+      db: mockDb,
+    } as never;
+
+    vi.mocked(assertCanEdit).mockResolvedValue(undefined);
+    vi.mocked(cardRepo.getWorkspaceAndCardIdByCardPublicId).mockResolvedValue({
+      id: 1,
+      createdBy: "user-123",
+      workspaceId: 2,
+      workspaceVisibility: "private",
+      listPublicId: "list-12345678",
+      listName: "Todo",
+      boardPublicId: "board-1234567",
+      boardName: "Board",
+    });
+    vi.mocked(cardRepo.getByPublicId).mockResolvedValue({
+      id: 1,
+      publicId: cardPublicId,
+      title: "Card",
+      description: "<p>Existing description</p>",
+      listId: 3,
+      dueDate: null,
+      list: {
+        publicId: "list-12345678",
+        name: "Todo",
+      },
+    });
+    vi.mocked(cardRepo.update).mockResolvedValue({
+      id: 1,
+      publicId: cardPublicId,
+      title: "Card",
+      description: null,
+      dueDate: null,
+    });
+    vi.mocked(cardActivityRepo.bulkCreate).mockResolvedValue([]);
+    vi.mocked(sendWebhooksForWorkspace).mockResolvedValue(undefined);
+
+    const { cardRouter } = await import("./card");
+
+    await cardRouter.createCaller(ctx).update({
+      cardPublicId,
+      description: "<p></p>",
+    });
+
+    expect(cardRepo.update).toHaveBeenCalledWith(
+      mockDb,
+      { description: null },
+      { cardPublicId },
+    );
+    expect(cardActivityRepo.bulkCreate).toHaveBeenCalledWith(mockDb, [
+      expect.objectContaining({
+        type: "card.updated.description",
+        fromDescription: "<p>Existing description</p>",
+        toDescription: undefined,
+      }),
+    ]);
+    expect(sendMentionEmails).not.toHaveBeenCalled();
+    expect(createCardWebhookPayload).toHaveBeenCalledWith(
+      "card.updated",
+      expect.objectContaining({ description: null }),
+      expect.objectContaining({
+        changes: {
+          description: {
+            from: "<p>Existing description</p>",
+            to: null,
+          },
+        },
+      }),
+    );
+  });
+});

--- a/packages/api/src/routers/card.ts
+++ b/packages/api/src/routers/card.ts
@@ -946,13 +946,26 @@ export const cardRouter = createTRPCRouter({
         | undefined;
 
       const previousDueDate = existingCard.dueDate;
+      const normalizedDescription =
+        input.description !== undefined
+          ? normalizeDescription(input.description)
+          : undefined;
+      const descriptionChanged =
+        normalizedDescription !== undefined &&
+        existingCard.description !== normalizedDescription;
 
-      if (input.title || input.description || input.dueDate !== undefined) {
+      if (
+        input.title ||
+        normalizedDescription !== undefined ||
+        input.dueDate !== undefined
+      ) {
         result = await cardRepo.update(
           ctx.db,
           {
             ...(input.title && { title: input.title }),
-            ...(input.description && { description: input.description }),
+            ...(normalizedDescription !== undefined && {
+              description: normalizedDescription,
+            }),
             ...(input.dueDate !== undefined && { dueDate: input.dueDate }),
           },
           { cardPublicId: input.cardPublicId },
@@ -985,22 +998,24 @@ export const cardRouter = createTRPCRouter({
         });
       }
 
-      if (input.description && existingCard.description !== input.description) {
+      if (descriptionChanged) {
         activities.push({
           type: "card.updated.description" as const,
           cardId: result.id,
           createdBy: userId,
           fromDescription: existingCard.description ?? undefined,
-          toDescription: input.description,
+          toDescription: normalizedDescription ?? undefined,
         });
 
-        void sendMentionEmails({
-          db: ctx.db,
-          cardPublicId: input.cardPublicId,
-          previousHtml: existingCard.description,
-          nextHtml: input.description,
-          commenterUserId: userId,
-        });
+        if (normalizedDescription) {
+          void sendMentionEmails({
+            db: ctx.db,
+            cardPublicId: input.cardPublicId,
+            previousHtml: existingCard.description,
+            nextHtml: normalizedDescription,
+            commenterUserId: userId,
+          });
+        }
       }
 
       if (
@@ -1048,10 +1063,10 @@ export const cardRouter = createTRPCRouter({
       if (input.title && existingCard.title !== input.title) {
         webhookChanges.title = { from: existingCard.title, to: input.title };
       }
-      if (input.description && existingCard.description !== input.description) {
+      if (descriptionChanged) {
         webhookChanges.description = {
           from: existingCard.description,
-          to: input.description,
+          to: normalizedDescription,
         };
       }
       if (

--- a/packages/db/src/repository/card.repo.ts
+++ b/packages/db/src/repository/card.repo.ts
@@ -202,7 +202,7 @@ export const update = async (
   db: dbClient,
   cardInput: {
     title?: string;
-    description?: string;
+    description?: string | null;
     dueDate?: Date | null;
   },
   args: {


### PR DESCRIPTION
## Description

#582 introduced `normalizeDescription` for new, duplicated and imported cards.
The update mutation still forwards editor HTML directly to the repository, so
clearing an existing description can store empty HTML such as `<p></p>` instead
of `NULL`.

This leaves the description storage invariant incomplete and makes simple
presence checks unreliable, including the `description IS NOT NULL`
simplification requested in #572.

This change normalises an optional description once before updating the card
and reuses the canonical value for persistence, activity history and webhook
changes. Empty descriptions do not trigger mention processing. Non-empty
description HTML remains unchanged.

A focused router test reproduces the empty Tiptap document and verifies the
stored value, activity, mention and webhook behaviour.

Tested with:

- `pnpm --filter @kan/api test` — 125 tests passed
- `pnpm --filter @kan/api typecheck`
- `pnpm --filter @kan/db typecheck`
- focused ESLint and Prettier checks
- `git diff --check`

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below — not required for this bug fix
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes — no UI changes

## Linked issue

Follow-up to #582. Unblocks the description invariant used by #572.
