### PR TITLE
fix(board): prevent actions on optimistic lists

### DIFF
--- a/apps/web/src/utils/helpers.test.ts
+++ b/apps/web/src/utils/helpers.test.ts
@@ -5,9 +5,16 @@ vi.mock("next-runtime-env", () => ({
 }));
 
 import { env } from "next-runtime-env";
-import { getAvatarUrl } from "./helpers";
+import { getAvatarUrl, isPlaceholderPublicId } from "./helpers";
 
 const mockEnv = env as ReturnType<typeof vi.fn>;
+
+describe("isPlaceholderPublicId", () => {
+  it("identifies optimistic entity IDs", () => {
+    expect(isPlaceholderPublicId("PLACEHOLDER_abc123")).toBe(true);
+    expect(isPlaceholderPublicId("abc123")).toBe(false);
+  });
+});
 
 describe("getAvatarUrl", () => {
   beforeEach(() => {

--- a/apps/web/src/utils/helpers.ts
+++ b/apps/web/src/utils/helpers.ts
@@ -9,6 +9,9 @@ export const formatToArray = (
   return value ? [value] : [];
 };
 
+export const isPlaceholderPublicId = (publicId: string) =>
+  publicId.startsWith("PLACEHOLDER_");
+
 export const inferInitialsFromEmail = (email: string) => {
   const localPart = email.split("@")[0];
   if (!localPart) return "";

--- a/apps/web/src/views/board/components/List.tsx
+++ b/apps/web/src/views/board/components/List.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from "~/components/Tooltip";
 import { usePermissions } from "~/hooks/usePermissions";
 import { useModal } from "~/providers/modal";
 import { api } from "~/utils/api";
+import { isPlaceholderPublicId } from "~/utils/helpers";
 
 interface ListProps {
   children: ReactNode;
@@ -47,11 +48,12 @@ export default function List({
   const { canCreateCard, canEditList, canDeleteList } = usePermissions();
   const { data: session } = authClient.useSession();
   const isCreator = list.createdBy && session?.user.id === list.createdBy;
+  const isOptimistic = isPlaceholderPublicId(list.publicId);
   const canEdit = canEditList || isCreator;
-  const canDrag = canEditList || isCreator;
+  const canDrag = !isOptimistic && (canEditList || isCreator);
 
   const openNewCardForm = (publicListId: PublicListId) => {
-    if (!canCreateCard) return;
+    if (!canCreateCard || isOptimistic) return;
     openModal("NEW_CARD");
     setSelectedPublicListId(publicListId);
   };
@@ -70,7 +72,7 @@ export default function List({
   });
 
   const onSubmit = (values: FormValues) => {
-    if (!canEdit) return;
+    if (!canEdit || isOptimistic) return;
     updateList.mutate({
       listPublicId: values.listPublicId,
       name: values.name,
@@ -108,7 +110,7 @@ export default function List({
                 aria-label={t`List name`}
                 {...register("name")}
                 onBlur={handleSubmit(onSubmit)}
-                readOnly={!canEdit}
+                readOnly={!canEdit || isOptimistic}
                 className="w-full border-0 bg-transparent px-4 pt-1 text-sm font-medium text-neutral-900 focus:ring-0 focus-visible:outline-none dark:text-dark-1000"
               />
             </form>
@@ -121,7 +123,7 @@ export default function List({
                 <button
                   className="mx-1 inline-flex h-fit items-center rounded-md p-1 px-1 text-sm font-semibold text-dark-50 hover:bg-light-400 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-dark-200"
                   onClick={() => openNewCardForm(list.publicId)}
-                  disabled={!canCreateCard}
+                  disabled={!canCreateCard || isOptimistic}
                   aria-label={t`Add card`}
                 >
                   <HiOutlinePlusSmall
@@ -132,7 +134,7 @@ export default function List({
               </Tooltip>
               {(() => {
                 const dropdownItems = [
-                  ...(canCreateCard
+                  ...(canCreateCard && !isOptimistic
                     ? [
                         {
                           label: t`Add a card`,
@@ -143,7 +145,7 @@ export default function List({
                         },
                       ]
                     : []),
-                  ...(canDeleteList || isCreator
+                  ...(!isOptimistic && (canDeleteList || isCreator)
                     ? [
                         {
                           label: t`Delete list`,

--- a/apps/web/src/views/board/components/NewListForm.tsx
+++ b/apps/web/src/views/board/components/NewListForm.tsx
@@ -52,7 +52,7 @@ export function NewListForm({
       await utils.board.byId.cancel();
 
       const currentState = utils.board.byId.getData(queryParams);
-      const optimisticPublicId = generateUID();
+      const optimisticPublicId = `PLACEHOLDER_${generateUID()}`;
 
       utils.board.byId.setData(queryParams, (oldBoard) => {
         if (!oldBoard) return oldBoard;

--- a/apps/web/src/views/board/index.tsx
+++ b/apps/web/src/views/board/index.tsx
@@ -35,7 +35,7 @@ import { useModal } from "~/providers/modal";
 import { usePopup } from "~/providers/popup";
 import { useWorkspace } from "~/providers/workspace";
 import { api } from "~/utils/api";
-import { formatToArray } from "~/utils/helpers";
+import { formatToArray, isPlaceholderPublicId } from "~/utils/helpers";
 import { DeleteCardConfirmation } from "~/views/card/components/DeleteCardConfirmation";
 import BoardDropdown from "./components/BoardDropdown";
 import Card from "./components/Card";
@@ -357,14 +357,22 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
       return;
     }
 
-    if (type === "LIST" && canEditList) {
+    if (
+      type === "LIST" &&
+      canEditList &&
+      !isPlaceholderPublicId(draggableId)
+    ) {
       updateListMutation.mutate({
         listPublicId: draggableId,
         index: destination.index,
       });
     }
 
-    if (type === "CARD" && canEditCard) {
+    if (
+      type === "CARD" &&
+      canEditCard &&
+      !isPlaceholderPublicId(destination.droppableId)
+    ) {
       updateCardMutation.mutate({
         cardPublicId: draggableId,
 
@@ -712,6 +720,9 @@ export default function BoardPage({ isTemplate }: { isTemplate?: boolean }) {
                             <Droppable
                               droppableId={`${list.publicId}`}
                               type="CARD"
+                              isDropDisabled={isPlaceholderPublicId(
+                                list.publicId,
+                              )}
                             >
                               {(provided) => (
                                 <div

--- a/packages/e2e/tests/self-hosted/optimistic-list.spec.ts
+++ b/packages/e2e/tests/self-hosted/optimistic-list.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+import { AuthPage } from "../support/pages/auth-page";
+import { BoardPage } from "../support/pages/board-page";
+import { DashboardPage } from "../support/pages/dashboard-page";
+import { SelfHostedOnboardingPage } from "../support/pages/self-hosted-onboarding-page";
+import { createTestUser } from "../support/test-user";
+import { waitForTrpcMutation } from "../support/wait-for-trpc";
+
+test(
+  "an optimistic list cannot be mutated before the server assigns its ID",
+  { tag: "@self-hosted" },
+  async ({ page }) => {
+    const user = createTestUser();
+    const auth = new AuthPage(page);
+    const onboarding = new SelfHostedOnboardingPage(page);
+    const dashboard = new DashboardPage(page);
+    const board = new BoardPage(page);
+
+    await auth.signUp(user);
+    await onboarding.createFirstWorkspace("E2E Test Workspace");
+    await dashboard.expectSignedInAs(user);
+    await board.createBoard("Optimistic list test");
+
+    let releaseListRequest: () => void = () => undefined;
+    const listRequestGate = new Promise<void>((resolve) => {
+      releaseListRequest = resolve;
+    });
+    await page.route(/\/api\/trpc\/list\.create/, async (route) => {
+      await listRequestGate;
+      await route.continue();
+    });
+
+    await page.getByRole("button", { name: "New list" }).click();
+    await page.getByPlaceholder("List name").fill("Delayed list");
+    const created = waitForTrpcMutation(page, "list.create");
+    await page.getByRole("button", { name: "Create list" }).click();
+
+    const listName = page.locator('input[aria-label="List name"][readonly]');
+    await expect(listName).toHaveValue("Delayed list");
+    await expect(listName).toHaveAttribute("readonly", "");
+    await expect(
+      page.getByRole("button", { name: "Add card", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "List options", exact: true }),
+    ).toHaveCount(0);
+
+    releaseListRequest();
+    await created;
+    await expect(
+      page.getByRole("button", { name: "Add card", exact: true }),
+    ).toBeEnabled();
+
+    await board.createCard("Created after list acknowledgement");
+    await expect(
+      page.getByText("Created after list acknowledgement"),
+    ).toBeVisible();
+  },
+);


### PR DESCRIPTION
## Description

Creating a list adds it to the board cache immediately, before `list.create`
returns. Until that request completes, the list has a client-generated public
ID that does not exist on the server. On a slow connection, the UI currently
treats it like a persisted list, so adding or moving a card, renaming the list,
or moving the list itself can send that temporary ID to the API and fail with a
not-found error.

Kan already prefixes client-only IDs with `PLACEHOLDER_` for optimistic cards,
checklists, and checklist items. The board UI also uses that prefix to prevent
actions on cards that have not been acknowledged by the server yet. This change
extends the same established convention to optimistic lists rather than
introducing a separate pending-state mechanism.

Actions that require a persisted list stay disabled until the server
acknowledges the creation. The temporary list cannot be renamed, dragged,
deleted, used to create a card, or used as a card drop target. Once
`list.create` returns, the optimistic ID is replaced with the server ID and the
controls become available normally.

The existing rollback and query invalidation behaviour is unchanged. This does
not change the API or database schema.

A Playwright test delays `list.create`, verifies that actions stay unavailable
while the list is optimistic, releases the request, and then creates a card in
the acknowledged list.

Tested with:

- focused helper tests — 9 tests passed
- `@kan/e2e` typecheck
- ESLint and Prettier checks for the new E2E test
- focused self-hosted Playwright test — 1 test passed
- `git diff --check`

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below — not required for this bug fix
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [ ] I have included screenshots for any UI changes — no persistent visual change

## Linked issue

Not required for this bug fix.
