### PR TITLE
fix: stop checklist item editor remounting after creation

### DIFF
--- a/apps/web/src/views/card/components/ChecklistItemRow.tsx
+++ b/apps/web/src/views/card/components/ChecklistItemRow.tsx
@@ -15,6 +15,7 @@ interface ChecklistItemRowProps {
     publicId: string;
     title: string;
     completed: boolean;
+    clientId?: string;
   };
   cardPublicId: string;
   onCreateNewItem?: () => void;
@@ -163,7 +164,7 @@ export default function ChecklistItemRow({
 
       <div className="flex-1 pr-7">
         <PlainTextEditor
-          key={item.publicId}
+          key={item.clientId ?? item.publicId}
           content={item.title}
           readOnly={viewOnly}
           placeholder={t`Add details...`}

--- a/apps/web/src/views/card/components/Checklists.tsx
+++ b/apps/web/src/views/card/components/Checklists.tsx
@@ -16,6 +16,7 @@ interface ChecklistItem {
   publicId: string;
   title: string;
   completed: boolean;
+  clientId?: string;
 }
 
 interface Checklist {
@@ -191,7 +192,7 @@ export default function Checklists({
                     >
                       {checklist.items.map((item, index) => (
                         <Draggable
-                          key={item.publicId}
+                          key={item.clientId ?? item.publicId}
                           draggableId={item.publicId}
                           index={index}
                           isDragDisabled={viewOnly}
@@ -210,6 +211,7 @@ export default function Checklists({
                                   publicId: item.publicId,
                                   title: item.title,
                                   completed: item.completed,
+                                  clientId: item.clientId,
                                 }}
                                 cardPublicId={cardPublicId}
                                 onCreateNewItem={() =>

--- a/apps/web/src/views/card/components/NewChecklistItemForm.tsx
+++ b/apps/web/src/views/card/components/NewChecklistItemForm.tsx
@@ -7,7 +7,6 @@ import { generateUID } from "@kan/shared/utils";
 
 import { usePopup } from "~/providers/popup";
 import { api } from "~/utils/api";
-import { invalidateCard } from "~/utils/cardInvalidation";
 
 interface FormValues {
   title: string;
@@ -62,6 +61,7 @@ const NewChecklistItemForm = ({
         if (!old) return old as any;
         const placeholder = {
           publicId: optimisticPublicId,
+          clientId: optimisticPublicId,
           title: vars.title,
           completed: false,
         };
@@ -108,7 +108,7 @@ const NewChecklistItemForm = ({
       });
     },
     onSettled: async () => {
-      await invalidateCard(utils, cardPublicId);
+      await utils.card.getActivities.invalidate({ cardPublicId });
     },
   });
 

--- a/packages/e2e/tests/self-hosted/checklist-item-optimistic-edit.spec.ts
+++ b/packages/e2e/tests/self-hosted/checklist-item-optimistic-edit.spec.ts
@@ -64,7 +64,9 @@ test(
 
     await page.locator("#title").click();
     await expect(page.getByText("baz bar", { exact: true })).toBeVisible();
-    await expect(page.getByText("foo bar", { exact: true })).toHaveCount(0);
+    await expect(
+      page.locator(".plain-text-editor").filter({ hasText: "foo bar" }),
+    ).toHaveCount(0);
 
     await page.reload();
     await expect(page.getByText("baz bar", { exact: true })).toBeVisible();

--- a/packages/e2e/tests/self-hosted/checklist-item-optimistic-edit.spec.ts
+++ b/packages/e2e/tests/self-hosted/checklist-item-optimistic-edit.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+import { AuthPage } from "../support/pages/auth-page";
+import { BoardPage } from "../support/pages/board-page";
+import { CardPage } from "../support/pages/card-page";
+import { DashboardPage } from "../support/pages/dashboard-page";
+import { SelfHostedOnboardingPage } from "../support/pages/self-hosted-onboarding-page";
+import { createTestUser } from "../support/test-user";
+import { waitForTrpcMutation } from "../support/wait-for-trpc";
+
+test(
+  "editing a checklist item right after creating it keeps the cursor and the edit",
+  { tag: "@self-hosted" },
+  async ({ page }) => {
+    const user = createTestUser();
+    const auth = new AuthPage(page);
+    const onboarding = new SelfHostedOnboardingPage(page);
+    const dashboard = new DashboardPage(page);
+    const board = new BoardPage(page);
+    const card = new CardPage(page);
+
+    await auth.signUp(user);
+    await onboarding.createFirstWorkspace("E2E Test Workspace");
+    await dashboard.expectSignedInAs(user);
+
+    await board.createBoard("Checklist race test board");
+    await board.createList("To do");
+    await board.createCard("Checklist race test card");
+    await board.openCard("Checklist race test card");
+
+    await card.createChecklist("My checklist");
+
+    let releaseCreateItemRequest: () => void = () => undefined;
+    const createItemGate = new Promise<void>((resolve) => {
+      releaseCreateItemRequest = resolve;
+    });
+    await page.route(/\/api\/trpc\/checklist\.createItem/, async (route) => {
+      await createItemGate;
+      await route.continue();
+    });
+
+    await page
+      .getByRole("button", { name: "Add checklist item", exact: true })
+      .click();
+    const itemInput = page.locator('[id^="checklist-item-input-"]');
+    await itemInput.click();
+    await itemInput.pressSequentially("foo bar");
+    const created = waitForTrpcMutation(page, "checklist.createItem");
+    await page.keyboard.press("Enter");
+
+    await page.waitForTimeout(200);
+
+    const itemRow = page
+      .locator(".plain-text-editor")
+      .filter({ hasText: "foo bar" });
+    const itemEditor = itemRow.locator('[contenteditable="true"]');
+    await expect(itemRow).toBeVisible();
+    await itemEditor.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await itemEditor.pressSequentially("baz bar");
+
+    releaseCreateItemRequest();
+    await created;
+
+    await page.locator("#title").click();
+    await expect(page.getByText("baz bar", { exact: true })).toBeVisible();
+    await expect(page.getByText("foo bar", { exact: true })).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.getByText("baz bar", { exact: true })).toBeVisible();
+  },
+);


### PR DESCRIPTION
Resolves: https://github.com/kanbn/kan/issues/599