### PR TITLE
fix: enable credentials by default in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,10 @@ NEXT_PUBLIC_USE_VIRTUAL_HOSTED_URLS=
 
 
 # Auth config (optional)
-NEXT_PUBLIC_ALLOW_CREDENTIALS=
+# Enables email & password sign in/up. Only leave this unset if you configure an
+# OAuth/OIDC provider below, otherwise a fresh instance has no way to create the
+# first user.
+NEXT_PUBLIC_ALLOW_CREDENTIALS=true
 NEXT_PUBLIC_DISABLE_SIGN_UP=
 
 # API configuration (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       - NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY=${NEXT_PUBLIC_WHITE_LABEL_HIDE_POWERED_BY}
 
       # Auth config (optional)
+      # NEXT_PUBLIC_ALLOW_CREDENTIALS must be "true" for email & password auth.
+      # If it is blank and no OAuth/OIDC provider is configured, the sign up page
+      # has no available auth method and no user can be created.
       - NEXT_PUBLIC_ALLOW_CREDENTIALS=${NEXT_PUBLIC_ALLOW_CREDENTIALS}
       - NEXT_PUBLIC_DISABLE_SIGN_UP=${NEXT_PUBLIC_DISABLE_SIGN_UP}
 


### PR DESCRIPTION
## Problem

A fresh self-host that follows the repo's own instructions can end up with no way to create the first user.

`.env.example` ships `NEXT_PUBLIC_ALLOW_CREDENTIALS=` (blank), and `docker-compose.yml` forwards it verbatim. So `cp .env.example .env && docker compose up` produces an instance with email & password auth disabled on both sides:

- client: [`AuthForm.tsx`](https://github.com/kanbn/kan/blob/main/apps/web/src/components/AuthForm.tsx#L177-L184) never renders the password field
- server: [`auth.ts`](https://github.com/kanbn/kan/blob/main/packages/auth/src/auth.ts#L38) sets `emailAndPassword.enabled: false`

With no OAuth/OIDC provider configured, magic link is deliberately unavailable during sign up ([`AuthForm.tsx#L311-L313`](https://github.com/kanbn/kan/blob/main/apps/web/src/components/AuthForm.tsx#L311-L313)), so `/signup` falls through to "No authentication methods are currently available". There is no first-user bootstrap anywhere, so the instance is unusable.

`NEXT_PUBLIC_DISABLE_SIGN_UP` is not involved — it only hides sign up when the value is exactly `"true"`, so setting it to `false` is a no-op.

Note that the README quickstart and the self-hosting docs both hardcode `NEXT_PUBLIC_ALLOW_CREDENTIALS=true`, so only the `.env.example` + repo-compose path is broken. That inconsistency is what makes this easy to hit.

## Change

- `.env.example`: default `NEXT_PUBLIC_ALLOW_CREDENTIALS=true`, with a comment on when to leave it off.
- `docker-compose.yml`: comment explaining what a blank value does.

## Why not a compose-level default

`${NEXT_PUBLIC_ALLOW_CREDENTIALS:-true}` was the obvious alternative, but it would silently enable password auth on existing instances that deliberately left the variable blank (OIDC-only deployments, for example) — combined with an unset `NEXT_PUBLIC_DISABLE_SIGN_UP` that would open public registration on upgrade. Changing only `.env.example` affects new installs and leaves existing `.env` files alone.

Refs #551. Companion PR adds an actionable hint to the empty auth form itself.
