### PR TITLE
fix(auth): explain how to fix the empty auth form when self hosting

### DIFF
--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -1,4 +1,5 @@
 import type { SocialProvider } from "better-auth/social-providers";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { t } from "@lingui/core/macro";
@@ -36,6 +37,9 @@ import Input from "~/components/Input";
 import { usePopup } from "~/providers/popup";
 
 type AuthProvider = SocialProvider | "oidc";
+
+// Kept out of the translated message so it is never localised.
+const CREDENTIALS_ENV_HINT = "NEXT_PUBLIC_ALLOW_CREDENTIALS=true";
 
 interface FormValues {
   name?: string;
@@ -368,12 +372,33 @@ export function Auth({
       )}
       {!(isCredentialsEnabled || isMagicLinkAvailable) &&
         socialProviders?.length === 0 && (
-          <div className="flex w-full items-center gap-4">
-            <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
-            <span className="text-center text-sm text-light-900 dark:text-dark-900">
-              {t`No authentication methods are currently available`}
-            </span>
-            <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
+          <div className="space-y-4">
+            <div className="flex w-full items-center gap-4">
+              <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
+              <span className="text-center text-sm text-light-900 dark:text-dark-900">
+                {t`No authentication methods are currently available`}
+              </span>
+              <div className="h-[1px] w-1/3 bg-light-600 dark:bg-dark-600" />
+            </div>
+            {!isCloudEnv && (
+              <p className="text-center text-xs text-light-900 dark:text-dark-900">
+                <Trans>
+                  Self-hosting? Set{" "}
+                  <code className="font-mono">{CREDENTIALS_ENV_HINT}</code> to
+                  enable email and password sign in, or configure an OAuth
+                  provider. See the{" "}
+                  <Link
+                    href="https://docs.kan.bn/guides/self-hosting/introduction"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 underline dark:text-blue-300"
+                  >
+                    self-hosting guide
+                  </Link>
+                  .
+                </Trans>
+              </p>
+            )}
           </div>
         )}
       {(isCredentialsEnabled || isMagicLinkAvailable) && (


### PR DESCRIPTION
## Problem

When a self-hosted instance has no OAuth/OIDC provider and `NEXT_PUBLIC_ALLOW_CREDENTIALS` is unset, `/signup` renders exactly one line:

> No authentication methods are currently available

Magic link is deliberately unavailable during sign up ([`AuthForm.tsx#L311-L313`](https://github.com/kanbn/kan/blob/main/apps/web/src/components/AuthForm.tsx#L311-L313)), so this is a dead end, and the message gives no indication of which variable to set. `/login` is worse in a way — it still shows an email box and a "Continue with magic link" button that silently cannot deliver without SMTP, so the instance looks functional.

In #551 the reporter worked around this by calling `/api/auth/sign-up/email` directly rather than finding the flag.

## Change

Adds a hint under the existing message naming `NEXT_PUBLIC_ALLOW_CREDENTIALS=true` and linking to the self-hosting guide.

- Hidden when `NEXT_PUBLIC_KAN_ENV=cloud`, where this state is unreachable anyway and the variable is meaningless to end users.
- The variable name is a module-level constant interpolated into the `<Trans>`, so it becomes a placeholder in the catalogs and cannot be localised.
- No catalog changes included — the `Translate` workflow extracts and translates on push to main.

Refs #551. Companion PR fixes the `.env.example` default that produces this state.
