### PR TITLE
fix(api): return valid tRPC rate limit errors

### DIFF
--- a/apps/web/src/pages/api/trpc/[trpc].ts
+++ b/apps/web/src/pages/api/trpc/[trpc].ts
@@ -4,6 +4,7 @@ import { createNextApiHandler } from "@trpc/server/adapters/next";
 import { appRouter } from "@kan/api/root";
 import { createTRPCContext } from "@kan/api/trpc-context";
 import { withRateLimit } from "@kan/api/utils/rateLimit";
+import { createTRPCRateLimitResponder } from "@kan/api/utils/trpcRateLimit";
 
 import { env } from "~/env";
 
@@ -21,7 +22,11 @@ const nextApiHandler = createNextApiHandler({
 });
 
 export default withRateLimit(
-  { points: 100, duration: 60 },
+  {
+    points: 100,
+    duration: 60,
+    onRateLimit: createTRPCRateLimitResponder(appRouter._def._config),
+  },
   async (req: NextApiRequest, res: NextApiResponse) => {
     if (req.method === "OPTIONS") {
       res.writeHead(200);

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,10 @@
       "types": "./src/utils/rateLimit.ts",
       "default": "./src/utils/rateLimit.ts"
     },
+    "./utils/trpcRateLimit": {
+      "types": "./src/utils/trpcRateLimit.ts",
+      "default": "./src/utils/trpcRateLimit.ts"
+    },
     "./utils/apiLogging": {
       "types": "./src/utils/apiLogging.ts",
       "default": "./src/utils/apiLogging.ts"

--- a/packages/api/src/utils/rateLimit.test.ts
+++ b/packages/api/src/utils/rateLimit.test.ts
@@ -1,7 +1,15 @@
-import type { NextApiRequest } from "next";
-import { describe, expect, it } from "vitest";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { tokenOrIpIdentifier } from "./rateLimit.js";
+import { tokenOrIpIdentifier, withRateLimit } from "./rateLimit.js";
+
+vi.mock("@kan/db/redis", () => ({
+  getRedisClient: vi.fn(() => null),
+}));
+
+vi.mock("@kan/logger", () => ({
+  createLogger: vi.fn(() => ({ debug: vi.fn() })),
+}));
 
 function makeReq(headers: Record<string, string> = {}): NextApiRequest {
   return {
@@ -47,5 +55,35 @@ describe("tokenOrIpIdentifier", () => {
     const req = makeReq({ "x-api-key": "kan_test_token" });
 
     expect(tokenOrIpIdentifier(req)).toMatch(/^token_[0-9a-f]{64}$/);
+  });
+});
+
+describe("withRateLimit", () => {
+  beforeEach(() => {
+    vi.stubEnv("DISABLE_RATE_LIMIT", "false");
+  });
+
+  it("uses a route-specific response when the limit is exceeded", async () => {
+    const req = {
+      headers: {},
+      socket: { remoteAddress: "rate-limit-test" },
+    } as unknown as NextApiRequest;
+    const res = {} as NextApiResponse;
+    const handler = vi.fn();
+    const onRateLimit = vi.fn();
+    const limitedHandler = withRateLimit(
+      { points: 1, duration: 60, onRateLimit },
+      handler,
+    );
+
+    await limitedHandler(req, res);
+    await limitedHandler(req, res);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(onRateLimit).toHaveBeenCalledWith(
+      req,
+      res,
+      "Too many requests, please try again later.",
+    );
   });
 });

--- a/packages/api/src/utils/rateLimit.ts
+++ b/packages/api/src/utils/rateLimit.ts
@@ -14,6 +14,11 @@ export interface RateLimitOptions {
   duration?: number;
   identifier?: (req: NextApiRequest) => string | Promise<string>;
   errorMessage?: string;
+  onRateLimit?: (
+    req: NextApiRequest,
+    res: NextApiResponse,
+    errorMessage: string,
+  ) => unknown;
 }
 
 const defaultIdentifier = (req: NextApiRequest): string => {
@@ -102,6 +107,10 @@ export function withRateLimit(
         typeof error === "object" &&
         ("msBeforeNext" in error || "remainingPoints" in error)
       ) {
+        if (options.onRateLimit) {
+          return options.onRateLimit(req, res, errorMessage);
+        }
+
         return res.status(429).json({
           message: errorMessage,
         });

--- a/packages/api/src/utils/trpcRateLimit.test.ts
+++ b/packages/api/src/utils/trpcRateLimit.test.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { initTRPC } from "@trpc/server";
+import superjson from "superjson";
+import { describe, expect, it, vi } from "vitest";
+
+import { createTRPCRateLimitResponder } from "./trpcRateLimit";
+
+const t = initTRPC.create({ transformer: superjson });
+const router = t.router({});
+
+interface RateLimitErrorResponse {
+  error: {
+    json: {
+      message: string;
+      code: number;
+      data: {
+        code: string;
+        httpStatus: number;
+        path: string;
+      };
+    };
+  };
+}
+
+const createResponse = () => {
+  const json = vi.fn();
+  const status = vi.fn(() => ({
+    json,
+  })) as unknown as NextApiResponse["status"];
+
+  return {
+    response: { status } as unknown as NextApiResponse,
+    status,
+    json,
+  };
+};
+
+describe("createTRPCRateLimitResponder", () => {
+  it("returns a transformed tRPC error for a single request", () => {
+    const req = {
+      query: { trpc: "board.byId" },
+    } as unknown as NextApiRequest;
+    const { response, status, json } = createResponse();
+
+    createTRPCRateLimitResponder(router._def._config)(
+      req,
+      response,
+      "Slow down",
+    );
+
+    expect(status).toHaveBeenCalledWith(429);
+    const body = json.mock.calls[0]?.[0] as RateLimitErrorResponse;
+    expect(body.error.json.message).toBe("Slow down");
+    expect(body.error.json.code).toBe(-32029);
+    expect(body.error.json.data).toMatchObject({
+      code: "TOO_MANY_REQUESTS",
+      httpStatus: 429,
+      path: "board.byId",
+    });
+  });
+
+  it("returns one error per operation in a batch request", () => {
+    const req = {
+      query: { trpc: "board.byId,card.byId", batch: "1" },
+    } as unknown as NextApiRequest;
+    const { response, json } = createResponse();
+
+    createTRPCRateLimitResponder(router._def._config)(
+      req,
+      response,
+      "Slow down",
+    );
+
+    const body = json.mock.calls[0]?.[0] as RateLimitErrorResponse[];
+    expect(body).toHaveLength(2);
+    expect(body.map((item) => item.error.json.data.path)).toEqual([
+      "board.byId",
+      "card.byId",
+    ]);
+  });
+});

--- a/packages/api/src/utils/trpcRateLimit.ts
+++ b/packages/api/src/utils/trpcRateLimit.ts
@@ -1,0 +1,44 @@
+import type { TRPCDefaultErrorShape, TRPCRootConfig } from "@trpc/server";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getTRPCErrorShape, TRPCError } from "@trpc/server";
+
+const getRequestPaths = (req: NextApiRequest): (string | undefined)[] => {
+  const path = req.query.trpc;
+
+  if (Array.isArray(path)) return path;
+  if (typeof path === "string") return path.split(",");
+  return [undefined];
+};
+
+interface RateLimitRootTypes {
+  ctx: object;
+  meta: object;
+  errorShape: TRPCDefaultErrorShape;
+  transformer: boolean;
+}
+
+export const createTRPCRateLimitResponder =
+  <TRoot extends RateLimitRootTypes>(config: TRPCRootConfig<TRoot>) =>
+  (req: NextApiRequest, res: NextApiResponse, message: string) => {
+    const responses = getRequestPaths(req).map((path) => {
+      const error = new TRPCError({
+        code: "TOO_MANY_REQUESTS",
+        message,
+      });
+      const shape = getTRPCErrorShape({
+        config,
+        error,
+        type: "unknown",
+        path,
+        input: undefined,
+        ctx: undefined,
+      });
+
+      const serializedShape: unknown =
+        config.transformer.output.serialize(shape);
+      return { error: serializedShape };
+    });
+
+    const response = req.query.batch === "1" ? responses : responses[0];
+    return res.status(429).json(response);
+  };


### PR DESCRIPTION
## Description

Rate-limited tRPC requests currently return a plain JSON message, which the tRPC client cannot parse as an error response. Return a standard `TOO_MANY_REQUESTS` envelope for both single and batch requests while keeping the generic rate-limit middleware reusable.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes (not applicable: no UI changes)

## Linked issue

N/A — bug fix without an existing issue.

## Verification

- Focused tests: 3 passed
- API typecheck
- Single and batch HTTP requests against a locally running app