### PR TITLE
fix(editor): restore monospace code font

### DIFF
--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -12,7 +12,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ["var(--font-geist-sans)", ...fontFamily.sans],
-        mono: ["var(--font-geist-mono)", ...fontFamily.mono],
+        mono: fontFamily.mono,
       },
     },
   },

--- a/packages/e2e/tests/self-hosted/markdown-code-font.spec.ts
+++ b/packages/e2e/tests/self-hosted/markdown-code-font.spec.ts
@@ -1,0 +1,70 @@
+import type { Locator } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { AuthPage } from "../support/pages/auth-page";
+import { BoardPage } from "../support/pages/board-page";
+import { DashboardPage } from "../support/pages/dashboard-page";
+import { SelfHostedOnboardingPage } from "../support/pages/self-hosted-onboarding-page";
+import { createTestUser } from "../support/test-user";
+
+async function pastePlainText(locator: Locator, value: string) {
+  await locator.click();
+  await locator.evaluate((element, text) => {
+    const clipboardData = new DataTransfer();
+    clipboardData.setData("text/plain", text);
+    element.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }),
+    );
+  }, value);
+}
+
+test(
+  "inline code and code blocks use a monospace font",
+  { tag: "@self-hosted" },
+  async ({ page }) => {
+    const user = createTestUser();
+    const auth = new AuthPage(page);
+    const onboarding = new SelfHostedOnboardingPage(page);
+    const dashboard = new DashboardPage(page);
+    const board = new BoardPage(page);
+
+    await auth.signUp(user);
+    await onboarding.createFirstWorkspace("E2E Test Workspace");
+    await dashboard.expectSignedInAs(user);
+
+    await board.createBoard("E2E Test Board");
+    await board.createList("To do");
+    await board.createCard("Markdown code font card");
+    await board.openCard("Markdown code font card");
+
+    const description = page.locator('.tiptap[contenteditable="true"]').first();
+    await pastePlainText(
+      description,
+      [
+        "Use `inline code` in a sentence.",
+        "",
+        "```ts",
+        "const answer = 42;",
+        "```",
+      ].join("\n"),
+    );
+
+    const inlineCode = description.locator("p code");
+    const codeBlock = description.locator("pre code");
+
+    await expect(inlineCode).toHaveText("inline code");
+    await expect(codeBlock).toContainText("const answer = 42;");
+
+    for (const code of [inlineCode, codeBlock]) {
+      await expect
+        .poll(() =>
+          code.evaluate((element) => getComputedStyle(element).fontFamily),
+        )
+        .toMatch(/mono|courier/i);
+    }
+  },
+);


### PR DESCRIPTION
## Description

Inline code and fenced code blocks were inheriting the application sans font because the configured `mono` stack starts with an undefined `--font-geist-mono` variable. That makes the declaration invalid, so the browser falls back to the inherited font.

This restores Tailwind's default monospace stack and adds a focused self-hosted Playwright regression test for both forms of rendered Markdown code.

This is also one of the concrete fixes proposed in #598.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Screenshots

### Before

![Code rendered with the inherited sans font](https://raw.githubusercontent.com/habralab/kan/pr-assets-markdown-code-font/screenshots/508-before-dark.png)

### After

![Code rendered with a monospace font](https://raw.githubusercontent.com/habralab/kan/pr-assets-markdown-code-font/screenshots/508-after-dark.png)

## Testing

- focused self-hosted Playwright test — passed
- `@kan/e2e` typecheck
- focused ESLint and Prettier checks
- `git diff --check`

## Checklist

- [x] I have linked the related issue below
- [x] My code follows the existing style and conventions
- [x] I have tested my changes locally
- [x] I have included screenshots for any UI changes

## Linked issue

Closes #508
