### PR TITLE
fix: buffer avatar upload body before sending to S3

### DIFF
--- a/apps/web/src/pages/api/upload/avatar.ts
+++ b/apps/web/src/pages/api/upload/avatar.ts
@@ -1,10 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import type { Readable } from "node:stream";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 
 import { createNextApiContext } from "@kan/api/trpc-context";
 import { withApiLogging } from "@kan/api/utils/apiLogging";
 import { withRateLimit } from "@kan/api/utils/rateLimit";
 import * as userRepo from "@kan/db/repository/user.repo";
+import { createLogger } from "@kan/logger";
 import { createS3Client } from "@kan/shared/utils";
 
 import { env } from "~/env";
@@ -14,6 +16,20 @@ const MAX_SIZE_BYTES = parseInt(
   10,
 ); // Default 2MB
 const allowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
+
+const log = createLogger("api");
+
+async function buffer(readable: Readable, maxSizeBytes: number) {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of readable as AsyncIterable<Buffer | string>) {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    size += buf.length;
+    if (size > maxSizeBytes) return null;
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
 
 export const config = {
   api: {
@@ -80,6 +96,12 @@ export default withRateLimit(
 
       const s3Key = `${user.id}/${sanitizedFilename}`;
 
+      const body = await buffer(req, MAX_SIZE_BYTES);
+
+      if (!body) {
+        return res.status(400).json({ error: "File too large" });
+      }
+
       const client = createS3Client();
 
       // Upload the file to S3
@@ -87,9 +109,9 @@ export default withRateLimit(
         new PutObjectCommand({
           Bucket: bucket,
           Key: s3Key,
-          Body: req,
+          Body: body,
           ContentType: contentType,
-          ContentLength: contentLength,
+          ContentLength: body.length,
         }),
       );
 
@@ -102,10 +124,11 @@ export default withRateLimit(
         key: s3Key,
         filename: sanitizedFilename,
         contentType,
-        size: contentLength,
+        size: body.length,
         user: updatedUser,
       });
     } catch (error) {
+      log.error({ err: error }, "Avatar upload failed");
       return res.status(500).json({ error: "Internal server error" });
     }
   }),


### PR DESCRIPTION
## Description

Uploading an avatar fails with a `500` on self-hosted instances behind a reverse proxy.

This happens because S3 rejects request chunks smaller than 8 KB.

The fix is to buffer the request body before sending it to S3.

## Type of change

- [X] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] I have linked the related issue below
- [X] My code follows the existing style and conventions
- [ ] I have tested my changes locally
- [ ] I have included screenshots for any UI changes
