### PR TITLE
fix(s3): default empty region to us-east-1

### DIFF
--- a/packages/shared/src/utils/s3.test.ts
+++ b/packages/shared/src/utils/s3.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createS3Client } from "./s3";
+
+const originalS3Region = process.env.S3_REGION;
+
+afterEach(() => {
+  if (originalS3Region === undefined) {
+    delete process.env.S3_REGION;
+  } else {
+    process.env.S3_REGION = originalS3Region;
+  }
+});
+
+describe("createS3Client", () => {
+  it("defaults to us-east-1 when S3_REGION is unset", async () => {
+    delete process.env.S3_REGION;
+
+    const client = createS3Client();
+
+    await expect(client.config.region()).resolves.toBe("us-east-1");
+    client.destroy();
+  });
+
+  it("defaults to us-east-1 when S3_REGION is empty", async () => {
+    process.env.S3_REGION = "";
+
+    const client = createS3Client();
+
+    await expect(client.config.region()).resolves.toBe("us-east-1");
+    client.destroy();
+  });
+
+  it("uses S3_REGION when it is configured", async () => {
+    process.env.S3_REGION = "eu-west-1";
+
+    const client = createS3Client();
+
+    await expect(client.config.region()).resolves.toBe("eu-west-1");
+    client.destroy();
+  });
+});

--- a/packages/shared/src/utils/s3.ts
+++ b/packages/shared/src/utils/s3.ts
@@ -8,6 +8,8 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { env } from "next-runtime-env";
 
 export function createS3Client() {
+  const region =
+    process.env.S3_REGION === "" ? undefined : process.env.S3_REGION;
   const credentials =
     process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY
       ? {
@@ -23,7 +25,7 @@ export function createS3Client() {
   // set a meaningless value. Real AWS S3 users should still set
   // S3_REGION explicitly to their bucket's actual region.
   return new S3Client({
-    region: process.env.S3_REGION ?? "us-east-1",
+    region: region ?? "us-east-1",
     endpoint: process.env.S3_ENDPOINT ?? "",
     forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true",
     credentials,
@@ -130,4 +132,3 @@ export async function generateAttachmentUrl(
     return null;
   }
 }
-


### PR DESCRIPTION
## Description

While reviewing another PR, I noticed that the MinIO E2E setup uses a fixed `us-east-1` region. I checked whether self-hosted installations could override it and found that Kan already exposes `S3_REGION`, but its default still has a gap.

`S3_REGION` is optional and `.env.example` leaves it empty. The fallback added in #495 uses `??`, which handles an unset variable but not an empty string. Docker Compose can therefore pass `S3_REGION=""` to `S3Client`, which still throws `Region is missing`.

This normalizes an empty value before applying the existing `us-east-1` default. Explicitly configured regions remain unchanged. Regression tests cover unset, empty, and configured values.

## Type of change

- [x] Bug fix
- [ ] Feature (requires an approved issue — see below)
- [ ] Refactor / chore

## Checklist

- [ ] I have linked the relevant approved issue (required for features)
- [x] I have followed the project’s code style
- [x] I have tested my changes locally
- [ ] I have included screenshots for any UI changes

## Related issues

Follow-up to #495.
